### PR TITLE
Fix: Remove duplicate additional_permissions in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,10 +67,6 @@ jobs:
           claude_env: |
             NODE_ENV: test
           
-          # Additional permissions for web access
-          additional_permissions: |
-            actions: read
-          
           # Allowed domains for reference documentation
           allowed_domains: |
             supabase.com


### PR DESCRIPTION
## Summary
This PR fixes a YAML parsing error in the Claude workflow that was causing workflow failures.

## Problem
The Claude workflow had duplicate `additional_permissions` keys, which is not valid YAML syntax. This caused the error:
```
This run likely failed because of a workflow file issue
```

## Solution
Removed the second duplicate `additional_permissions` entry (lines 71-72), keeping only the first occurrence at lines 40-41.

## Testing
The workflow should now parse correctly and trigger when comments contain `@claude`.

Fixes workflow failures seen in recent PR merges.