### PR TITLE
feat: enhance Clear All button to clear both filters and search

### DIFF
--- a/src/components/Filters/FilterSidebar.tsx
+++ b/src/components/Filters/FilterSidebar.tsx
@@ -4,6 +4,7 @@ import { SearchFilters } from '../../types';
 import { CORE_COMPETENCIES, LESSON_FORMATS } from '../../utils/filterConstants';
 import { CulturalHeritageFilter } from './CulturalHeritageFilter';
 import { getFacetCount } from '../../utils/facetHelpers';
+import { useSearchStore } from '../../stores/searchStore';
 
 interface FilterSidebarProps {
   filters: SearchFilters;
@@ -110,6 +111,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   onClose,
   facets = {},
 }) => {
+  const { clearFilters } = useSearchStore();
   const gradeOptions = [
     { value: '3K', label: '3K', count: getFacetCount(facets, 'gradeLevels', '3K') },
     { value: 'PK', label: 'Pre-K', count: getFacetCount(facets, 'gradeLevels', 'PK') },
@@ -336,6 +338,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   ];
 
   const activeFilterCount =
+    (filters.query?.trim() ? 1 : 0) + // Include search query in count
     filters.gradeLevels.length +
     filters.thematicCategories.length +
     filters.seasons.length +
@@ -348,22 +351,8 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
     filters.socialEmotionalLearning.length +
     (filters.cookingMethods ? 1 : 0);
 
-  const clearAllFilters = () => {
-    onFiltersChange({
-      ...filters,
-      gradeLevels: [],
-      thematicCategories: [],
-      seasons: [],
-      coreCompetencies: [],
-      activityType: [],
-      location: [],
-      culturalHeritage: [],
-      lessonFormat: [],
-      academicIntegration: [],
-      socialEmotionalLearning: [],
-      cookingMethods: '',
-      includeAllSeasons: false,
-    });
+  const handleClearAll = () => {
+    clearFilters(); // Use store's clearFilters function to clear both search and filters
   };
 
   return (
@@ -398,8 +387,9 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
             <div className="flex items-center space-x-2">
               {activeFilterCount > 0 && (
                 <button
-                  onClick={clearAllFilters}
+                  onClick={handleClearAll}
                   className="text-sm text-red-600 hover:text-red-700 font-medium"
+                  title="Clear all filters and search"
                 >
                   Clear All
                 </button>


### PR DESCRIPTION
Resolves #17

## Summary
This PR enhances the existing "Clear All" button in the FilterSidebar to clear both search query and all filters in a single action, improving user experience.

## Changes
- Modified FilterSidebar to use store's `clearFilters()` function directly
- Updated active filter count to include search queries
- Added tooltip for better UX clarity ("Clear all filters and search")
- Button now appears when either filters OR search query are active

## Implementation Details
- Uses the existing Zustand store's `clearFilters()` function which already clears both search and filters
- Follows **Option 1** from the issue description (enhanced existing button)
- No breaking changes to existing functionality
- Maintains all accessibility features

## Benefits
- Single action clears both search query AND all filters
- Reduced clicks needed to start fresh search
- Better UX when browsing full lesson library after complex searches
- Particularly helpful for search-only scenarios

## Testing
- [x] Button appears when only search is active (no filters)
- [x] Button appears when only filters are active (no search)  
- [x] Button appears when both search and filters are active
- [x] Clicking button clears both search and all filters
- [x] Filter count badge includes search query
- [x] Tooltip provides clear indication of functionality
- [x] Works on both desktop and mobile layouts

🤖 Implementation by Claude Code Action