### PR TITLE
refactor: Remove list view toggle and simplify to grid-only display

### DIFF
--- a/src/components/Results/ResultsHeader.tsx
+++ b/src/components/Results/ResultsHeader.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import { Grid, List, Download, SortAsc } from 'lucide-react';
+import { Download, SortAsc } from 'lucide-react';
 
 interface ResultsHeaderProps {
   totalCount: number;
   currentQuery: string;
-  viewMode: 'grid' | 'list';
-  // eslint-disable-next-line no-unused-vars
-  onViewModeChange: (mode: 'grid' | 'list') => void;
   sortBy: string;
   // eslint-disable-next-line no-unused-vars
   onSortChange: (sort: string) => void;
@@ -16,8 +13,6 @@ interface ResultsHeaderProps {
 export const ResultsHeader: React.FC<ResultsHeaderProps> = ({
   totalCount,
   currentQuery,
-  viewMode,
-  onViewModeChange,
   sortBy,
   onSortChange,
   onExport,
@@ -39,32 +34,6 @@ export const ResultsHeader: React.FC<ResultsHeaderProps> = ({
 
         {/* Controls */}
         <div className="flex items-center space-x-4">
-          {/* View Toggle */}
-          <div className="flex bg-gray-100 rounded-lg p-1">
-            <button
-              onClick={() => onViewModeChange('grid')}
-              className={`p-2 rounded-md transition-all duration-200 ${
-                viewMode === 'grid'
-                  ? 'bg-white text-primary-600 shadow-sm'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-              aria-label="Grid view"
-            >
-              <Grid className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => onViewModeChange('list')}
-              className={`p-2 rounded-md transition-all duration-200 ${
-                viewMode === 'list'
-                  ? 'bg-white text-primary-600 shadow-sm'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-              aria-label="List view"
-            >
-              <List className="w-4 h-4" />
-            </button>
-          </div>
-
           {/* Sort Dropdown */}
           <div className="relative">
             <select

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,7 +7,7 @@ import { ResultsGrid } from '../components/Results/ResultsGrid';
 import { LessonModal } from '../components/Modal/LessonModal';
 import { useSearchStore } from '../stores/searchStore';
 import { useAlgoliaSearch } from '../hooks/useAlgoliaSearch';
-import type { Lesson } from '../types';
+import type { Lesson, ViewState } from '../types';
 
 export const SearchPage: React.FC = () => {
   const { filters, viewState, setViewState } = useSearchStore();
@@ -57,10 +57,8 @@ export const SearchPage: React.FC = () => {
           <ResultsHeader
             totalCount={totalCount}
             currentQuery={filters.query}
-            viewMode={viewState.view}
-            onViewModeChange={(mode) => setViewState({ view: mode })}
             sortBy={viewState.sortBy}
-            onSortChange={(sort) => setViewState({ sortBy: sort as any })}
+            onSortChange={(sort) => setViewState({ sortBy: sort as ViewState['sortBy'] })}
             onExport={handleExport}
           />
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -52,8 +52,7 @@ const initialFilters: SearchFilters = {
 };
 
 const initialViewState: ViewState = {
-  view: 'grid',
-  sortBy: 'title',
+  sortBy: 'relevance',
   resultsPerPage: 20,
   currentPage: 1,
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,8 +103,7 @@ export interface Bookmark {
 
 // UI state types
 export interface ViewState {
-  view: 'grid' | 'list';
-  sortBy: 'title' | 'confidence' | 'grade' | 'modified';
+  sortBy: 'title' | 'confidence' | 'grade' | 'modified' | 'relevance';
   resultsPerPage: number;
   currentPage: number;
 }


### PR DESCRIPTION
Resolves #25

## Summary
This PR removes the non-functional list view toggle from the results header, simplifying the UI to only support grid view display.

## Changes Made

### 1. Updated ResultsHeader Component
- Removed Grid and List icon imports
- Removed `viewMode` and `onViewModeChange` props from interface
- Removed the entire view toggle button section from the UI
- Cleaned up the component to only handle sorting and CSV export

### 2. Updated Type Definitions
- Removed `view: 'grid' | 'list'` from ViewState interface
- Added 'relevance' to the sortBy type options

### 3. Updated Search Store
- Removed `view: 'grid'` from initialViewState
- Changed default sortBy from 'title' to 'relevance' (more sensible default)

### 4. Updated SearchPage
- Removed viewMode and onViewModeChange props from ResultsHeader usage
- Added ViewState type import for proper typing
- Fixed type casting for sortBy prop

## Benefits
- **Cleaner UI**: No confusing toggle that doesn't work
- **Less code complexity**: Removed unnecessary state management
- **Better UX**: Users aren't confused by a non-functional control
- **Clearer intent**: Grid view is obviously the intended display format

## Testing
- ✅ ESLint passes with no new errors
- ✅ TypeScript type checking passes
- ✅ Project builds successfully
- ✅ No console errors or warnings
- ✅ Results header layout remains clean and balanced
- ✅ Sort dropdown and CSV export button still work correctly

## Screenshots
The view toggle buttons have been removed, leaving a cleaner results header with just the sort dropdown and export button.