### PR TITLE
Fix: Update filter count from 16 to 11 to prevent Claude bot confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modern, responsive React/TypeScript application for searching and filtering 83
 
 ### Advanced Search & Filtering
 - **Full-text Search**: Searches across titles, summaries, ingredients, skills, and metadata
-- **Smart Filtering**: 16+ categories including grade levels, themes, seasons, cultural heritage
+- **Smart Filtering**: 11 filter categories including grade levels, themes, seasons, cultural heritage
 - **Hierarchical Cultural Search**: Select "Asian" to find all Asian cultures and subcultures
 - **Ingredient Grouping**: Search "butternut squash" to find "Winter squash" lessons
 - **Activity Type Detection**: Automatically categorizes lessons based on cooking/garden skills

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -7,7 +7,7 @@ interface HeaderProps {
   totalCategories?: number;
 }
 
-export const Header: React.FC<HeaderProps> = ({ totalLessons = 831, totalCategories = 16 }) => {
+export const Header: React.FC<HeaderProps> = ({ totalLessons = 831, totalCategories = 11 }) => {
   return (
     <header className="bg-gradient-to-r from-primary-600 to-primary-700 text-white shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Updated default `totalCategories` from 16 to 11 in Header component
- Changed README to say "11 filter categories" instead of "16+ categories"
- Aligns with CLAUDE.md which clearly states "EXACTLY 11 filter categories"

## Problem
The Claude bot in GitHub Actions has been consistently confused about the number of filters, thinking there should be 16 when there are actually 11. This was due to:
1. Header.tsx having a default value of `totalCategories = 16`
2. README.md saying "16+ categories"

## Solution
Both references have been updated to correctly state 11 filters, matching the authoritative CLAUDE.md documentation.

## Test Plan
- [x] Verified Header component renders correctly with updated default
- [x] README displays accurate filter count
- [ ] Future Claude bot reviews should correctly identify 11 filters

🤖 Generated with [Claude Code](https://claude.ai/code)