### PR TITLE
Add rollback instructions to database migrations

### DIFF
--- a/supabase/migrations/01_base_schema.sql
+++ b/supabase/migrations/01_base_schema.sql
@@ -255,6 +255,8 @@ ON lesson_submissions(status, teacher_id);
 -- DROP TABLE IF EXISTS lessons CASCADE;
 -- 
 -- -- Drop extensions
+-- WARNING: Dropping extensions can affect other parts of the database that may depend on them.
+--          Only drop these extensions if you are certain they are not used by other database objects.
 -- DROP EXTENSION IF EXISTS vector;
 -- DROP EXTENSION IF EXISTS unaccent;
 -- DROP EXTENSION IF EXISTS pg_trgm;

--- a/supabase/migrations/01_base_schema.sql
+++ b/supabase/migrations/01_base_schema.sql
@@ -231,3 +231,34 @@ CREATE TRIGGER update_lesson_submissions_updated_at BEFORE UPDATE ON lesson_subm
 -- Index for efficient submission queries by status and teacher
 CREATE INDEX IF NOT EXISTS idx_submissions_status_teacher 
 ON lesson_submissions(status, teacher_id);
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Drop indexes
+-- DROP INDEX IF EXISTS idx_submissions_status_teacher;
+-- 
+-- -- Drop triggers
+-- DROP TRIGGER IF EXISTS update_user_profiles_updated_at ON user_profiles;
+-- DROP TRIGGER IF EXISTS update_lesson_submissions_updated_at ON lesson_submissions;
+-- DROP TRIGGER IF EXISTS update_lessons_updated_at ON lessons;
+-- 
+-- -- Drop functions
+-- DROP FUNCTION IF EXISTS update_updated_at_column();
+-- 
+-- -- Drop tables (CASCADE will drop dependent objects)
+-- DROP TABLE IF EXISTS submission_reviews CASCADE;
+-- DROP TABLE IF EXISTS lesson_submissions CASCADE;
+-- DROP TABLE IF EXISTS user_profiles CASCADE;
+-- DROP TABLE IF EXISTS lessons CASCADE;
+-- 
+-- -- Drop extensions
+-- DROP EXTENSION IF EXISTS vector;
+-- DROP EXTENSION IF EXISTS unaccent;
+-- DROP EXTENSION IF EXISTS pg_trgm;
+-- DROP EXTENSION IF EXISTS pgcrypto;
+-- DROP EXTENSION IF EXISTS "uuid-ossp";
+-- 
+-- =====================================================

--- a/supabase/migrations/02_user_management.sql
+++ b/supabase/migrations/02_user_management.sql
@@ -181,3 +181,38 @@ LEFT JOIN auth.users au ON up.id = au.id;
 
 -- Grant access to authenticated users to view their own profile
 GRANT SELECT ON user_profiles_with_emails TO authenticated;
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Revoke grants
+-- REVOKE SELECT ON user_profiles_with_emails FROM authenticated;
+-- 
+-- -- Drop views
+-- DROP VIEW IF EXISTS user_profiles_with_emails CASCADE;
+-- 
+-- -- Drop policies
+-- DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON user_profiles;
+-- DROP POLICY IF EXISTS "Users can view their own full profile" ON user_profiles;
+-- DROP POLICY IF EXISTS "Admins can view all profiles" ON user_profiles;
+-- DROP POLICY IF EXISTS "Users can insert their own profile" ON user_profiles;
+-- DROP POLICY IF EXISTS "Users can update their own profile" ON user_profiles;
+-- DROP POLICY IF EXISTS "Admins can update any profile" ON user_profiles;
+-- DROP POLICY IF EXISTS "Admins can delete profiles" ON user_profiles;
+-- 
+-- -- Drop functions
+-- DROP FUNCTION IF EXISTS get_user_role(uuid);
+-- DROP FUNCTION IF EXISTS get_user_permissions(uuid);
+-- DROP FUNCTION IF EXISTS handle_new_user();
+-- DROP FUNCTION IF EXISTS check_user_permissions(uuid, text);
+-- DROP FUNCTION IF EXISTS check_is_admin(uuid);
+-- 
+-- -- Drop triggers
+-- DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+-- 
+-- -- Disable RLS (if you want to completely revert)
+-- ALTER TABLE user_profiles DISABLE ROW LEVEL SECURITY;
+-- 
+-- =====================================================

--- a/supabase/migrations/03_search_functionality.sql
+++ b/supabase/migrations/03_search_functionality.sql
@@ -307,3 +307,61 @@ BEGIN
     l.title ASC;
 END;
 $$;
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Drop functions
+-- DROP FUNCTION IF EXISTS search_lessons_with_filters(
+--   text, text[], text[], text[], text[], text[], 
+--   text[], text[], text[], text[], text[], text, text
+-- );
+-- DROP FUNCTION IF EXISTS search_lessons(text);
+-- 
+-- -- Drop indexes
+-- DROP INDEX IF EXISTS idx_lessons_season;
+-- DROP INDEX IF EXISTS idx_lessons_cultural_heritage_gin;
+-- DROP INDEX IF EXISTS idx_lessons_sel_gin;
+-- DROP INDEX IF EXISTS idx_lessons_academic_gin;
+-- DROP INDEX IF EXISTS idx_lessons_competencies_gin;
+-- DROP INDEX IF EXISTS idx_lessons_cooking_skills_gin;
+-- DROP INDEX IF EXISTS idx_lessons_garden_skills_gin;
+-- DROP INDEX IF EXISTS idx_lessons_ingredients_gin;
+-- DROP INDEX IF EXISTS idx_lessons_activity_gin;
+-- DROP INDEX IF EXISTS idx_lessons_themes_gin;
+-- DROP INDEX IF EXISTS idx_lessons_skills_gin;
+-- DROP INDEX IF EXISTS idx_lessons_grades_gin;
+-- DROP INDEX IF EXISTS idx_lessons_search_vector;
+-- 
+-- -- Drop triggers
+-- DROP TRIGGER IF EXISTS update_lessons_search_vector ON lessons;
+-- 
+-- -- Drop functions used by triggers
+-- DROP FUNCTION IF EXISTS lessons_search_vector_trigger();
+-- 
+-- -- Drop columns
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS search_vector;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS content_text;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS metadata;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS confidence;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS lesson_id;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS file_link;
+-- 
+-- -- Drop additional columns for enhanced search
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS sel_self_awareness;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS sel_self_management;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS sel_social_awareness;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS sel_relationship_skills;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS sel_responsible_decision_making;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_science;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_math;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_ela;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_social_studies;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_health;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS academic_arts;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS lesson_format;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS cooking_method;
+-- 
+-- =====================================================

--- a/supabase/migrations/04_duplicate_resolution.sql
+++ b/supabase/migrations/04_duplicate_resolution.sql
@@ -248,3 +248,32 @@ BEGIN
   LIMIT p_limit;
 END;
 $$ LANGUAGE plpgsql;
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Drop functions
+-- DROP FUNCTION IF EXISTS find_duplicate_lessons(numeric, integer);
+-- DROP FUNCTION IF EXISTS calculate_text_similarity(text, text);
+-- DROP FUNCTION IF EXISTS find_similar_lessons(uuid, numeric, integer);
+-- DROP FUNCTION IF EXISTS merge_duplicate_lessons(uuid, uuid[]);
+-- 
+-- -- Drop indexes
+-- DROP INDEX IF EXISTS idx_duplicate_resolutions_canonical;
+-- DROP INDEX IF EXISTS idx_duplicate_resolutions_duplicate;
+-- DROP INDEX IF EXISTS idx_submissions_lesson_id;
+-- DROP INDEX IF EXISTS idx_submission_similarities_submission;
+-- DROP INDEX IF EXISTS idx_lesson_similarities_lesson;
+-- 
+-- -- Drop tables
+-- DROP TABLE IF EXISTS duplicate_resolutions CASCADE;
+-- DROP TABLE IF EXISTS submission_similarities CASCADE;
+-- DROP TABLE IF EXISTS lesson_similarities CASCADE;
+-- 
+-- -- Drop columns added to existing tables
+-- ALTER TABLE lesson_submissions DROP COLUMN IF EXISTS existing_lesson_id;
+-- ALTER TABLE lesson_submissions DROP COLUMN IF EXISTS similarity_score;
+-- 
+-- =====================================================

--- a/supabase/migrations/05_rls_policies.sql
+++ b/supabase/migrations/05_rls_policies.sql
@@ -241,3 +241,61 @@ GRANT EXECUTE ON FUNCTION is_admin(UUID) TO authenticated;
 GRANT EXECUTE ON FUNCTION has_role(UUID, TEXT) TO authenticated;
 GRANT EXECUTE ON FUNCTION search_lessons TO authenticated;
 GRANT EXECUTE ON FUNCTION get_user_emails(UUID[]) TO authenticated;
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Revoke grants
+-- REVOKE EXECUTE ON FUNCTION get_user_emails(UUID[]) FROM authenticated;
+-- REVOKE EXECUTE ON FUNCTION search_lessons FROM authenticated;
+-- REVOKE EXECUTE ON FUNCTION has_role(UUID, TEXT) FROM authenticated;
+-- REVOKE EXECUTE ON FUNCTION is_admin(UUID) FROM authenticated;
+-- REVOKE USAGE ON SCHEMA auth FROM authenticated;
+-- REVOKE USAGE ON SCHEMA public FROM authenticated;
+-- 
+-- -- Drop policies for lesson_similarities
+-- DROP POLICY IF EXISTS "Anyone can view lesson similarities" ON lesson_similarities;
+-- DROP POLICY IF EXISTS "Admins can manage lesson similarities" ON lesson_similarities;
+-- 
+-- -- Drop policies for submission_similarities
+-- DROP POLICY IF EXISTS "Users can view similarities for their submissions" ON submission_similarities;
+-- DROP POLICY IF EXISTS "Reviewers can view all submission similarities" ON submission_similarities;
+-- DROP POLICY IF EXISTS "Users can create similarities for their submissions" ON submission_similarities;
+-- DROP POLICY IF EXISTS "Admins can manage submission similarities" ON submission_similarities;
+-- 
+-- -- Drop policies for submission_reviews
+-- DROP POLICY IF EXISTS "Teachers can view reviews of their submissions" ON submission_reviews;
+-- DROP POLICY IF EXISTS "Reviewers can view all reviews" ON submission_reviews;
+-- DROP POLICY IF EXISTS "Reviewers can create reviews" ON submission_reviews;
+-- DROP POLICY IF EXISTS "Reviewers can update their own reviews" ON submission_reviews;
+-- DROP POLICY IF EXISTS "Admins can manage all reviews" ON submission_reviews;
+-- 
+-- -- Drop policies for lesson_submissions
+-- DROP POLICY IF EXISTS "Users can view their own submissions" ON lesson_submissions;
+-- DROP POLICY IF EXISTS "Reviewers can view submitted lessons" ON lesson_submissions;
+-- DROP POLICY IF EXISTS "Users can create their own submissions" ON lesson_submissions;
+-- DROP POLICY IF EXISTS "Users can update their draft submissions" ON lesson_submissions;
+-- DROP POLICY IF EXISTS "Reviewers can update submission status" ON lesson_submissions;
+-- DROP POLICY IF EXISTS "Admins can manage all submissions" ON lesson_submissions;
+-- 
+-- -- Drop policies for lessons
+-- DROP POLICY IF EXISTS "Anyone can view lessons" ON lessons;
+-- DROP POLICY IF EXISTS "Reviewers can create lessons" ON lessons;
+-- DROP POLICY IF EXISTS "Reviewers can update lessons" ON lessons;
+-- DROP POLICY IF EXISTS "Admins can delete lessons" ON lessons;
+-- 
+-- -- Drop functions
+-- DROP FUNCTION IF EXISTS get_user_emails(UUID[]);
+-- DROP FUNCTION IF EXISTS is_admin(UUID);
+-- DROP FUNCTION IF EXISTS has_role(UUID, TEXT);
+-- 
+-- -- Disable RLS on tables
+-- ALTER TABLE lessons DISABLE ROW LEVEL SECURITY;
+-- ALTER TABLE lesson_submissions DISABLE ROW LEVEL SECURITY;
+-- ALTER TABLE submission_reviews DISABLE ROW LEVEL SECURITY;
+-- ALTER TABLE submission_similarities DISABLE ROW LEVEL SECURITY;
+-- ALTER TABLE lesson_similarities DISABLE ROW LEVEL SECURITY;
+-- 
+-- =====================================================

--- a/supabase/migrations/05_rls_policies.sql
+++ b/supabase/migrations/05_rls_policies.sql
@@ -292,6 +292,10 @@ GRANT EXECUTE ON FUNCTION get_user_emails(UUID[]) TO authenticated;
 -- DROP FUNCTION IF EXISTS has_role(UUID, TEXT);
 -- 
 -- -- Disable RLS on tables
+-- =====================================================
+-- WARNING: Disabling RLS removes all row-level access controls and may expose sensitive data.
+-- ONLY disable RLS if the tables are being completely removed immediately after.
+-- =====================================================
 -- ALTER TABLE lessons DISABLE ROW LEVEL SECURITY;
 -- ALTER TABLE lesson_submissions DISABLE ROW LEVEL SECURITY;
 -- ALTER TABLE submission_reviews DISABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/06_fix_login_tracking.sql
+++ b/supabase/migrations/06_fix_login_tracking.sql
@@ -154,8 +154,8 @@ COMMENT ON TABLE user_management_audit IS 'Audit table for user management actio
 -- --   FOR EACH ROW
 -- --   EXECUTE FUNCTION log_user_login();
 -- 
--- -- Note: The original trigger is commented out because it was causing 
--- -- authentication errors. Only restore it if you have a fix for the 
--- -- underlying auth.users access issue.
+-- Note: The original trigger is commented out because it was causing 
+-- authentication errors. Only restore it if you have a fix for the 
+-- underlying auth.users access issue.
 -- 
 -- =====================================================

--- a/supabase/migrations/06_fix_login_tracking.sql
+++ b/supabase/migrations/06_fix_login_tracking.sql
@@ -109,3 +109,53 @@ GRANT EXECUTE ON FUNCTION track_user_login(UUID) TO authenticated;
 
 -- Add comment explaining the fix
 COMMENT ON TABLE user_management_audit IS 'Audit table for user management actions. Login tracking is now done manually via track_user_login() function instead of auth.users trigger to avoid authentication errors.';
+
+-- =====================================================
+-- ROLLBACK INSTRUCTIONS (commented for safety)
+-- =====================================================
+-- To rollback this migration, run the following commands:
+-- 
+-- -- Remove comment
+-- COMMENT ON TABLE user_management_audit IS NULL;
+-- 
+-- -- Revoke grant
+-- REVOKE EXECUTE ON FUNCTION track_user_login(UUID) FROM authenticated;
+-- 
+-- -- Drop the manual tracking function
+-- DROP FUNCTION IF EXISTS track_user_login(UUID);
+-- 
+-- -- Drop the policy for profile creation
+-- DROP POLICY IF EXISTS "Users can create their own profile on first login" ON user_profiles;
+-- 
+-- -- Recreate the original trigger (ONLY if you have fixed the auth issue):
+-- -- CREATE OR REPLACE FUNCTION log_user_login()
+-- -- RETURNS trigger AS $$
+-- -- BEGIN
+-- --   IF NEW.last_sign_in_at IS DISTINCT FROM OLD.last_sign_in_at THEN
+-- --     INSERT INTO user_management_audit (
+-- --       action_type,
+-- --       user_id,
+-- --       details
+-- --     ) VALUES (
+-- --       'login',
+-- --       NEW.id,
+-- --       jsonb_build_object(
+-- --         'login_at', NEW.last_sign_in_at,
+-- --         'email', NEW.email
+-- --       )
+-- --     );
+-- --   END IF;
+-- --   RETURN NEW;
+-- -- END;
+-- -- $$ LANGUAGE plpgsql SECURITY DEFINER;
+-- -- 
+-- -- CREATE TRIGGER on_user_login
+-- --   AFTER UPDATE OF last_sign_in_at ON auth.users
+-- --   FOR EACH ROW
+-- --   EXECUTE FUNCTION log_user_login();
+-- 
+-- -- Note: The original trigger is commented out because it was causing 
+-- -- authentication errors. Only restore it if you have a fix for the 
+-- -- underlying auth.users access issue.
+-- 
+-- =====================================================


### PR DESCRIPTION
## Summary
- Added comprehensive rollback instructions to migrations 01-06
- Rollback instructions are safely commented to prevent accidental execution
- Improves database management practices for emergency situations

## What Changed
Added rollback instructions to:
1. `01_base_schema.sql` - Documents how to drop all base tables, functions, triggers, and extensions
2. `02_user_management.sql` - Documents how to remove user management features and RLS policies
3. `03_search_functionality.sql` - Documents how to remove search functions, indexes, and columns
4. `04_duplicate_resolution.sql` - Documents how to remove duplicate detection features
5. `05_rls_policies.sql` - Documents how to drop all RLS policies and related functions
6. `06_fix_login_tracking.sql` - Documents how to remove the manual tracking function (with warning about the original trigger)

## Format Used
Each migration now ends with:
```sql
-- =====================================================
-- ROLLBACK INSTRUCTIONS (commented for safety)
-- =====================================================
-- To rollback this migration, run the following commands:
-- 
-- -- Drop objects in reverse order of creation
-- DROP TABLE IF EXISTS...
-- DROP FUNCTION IF EXISTS...
-- etc.
-- =====================================================
```

## Important Notes
- All rollback commands are commented out for safety
- They serve as documentation for emergency rollbacks
- No database changes are needed - these are just SQL comments
- Special note in migration 06 about not restoring the problematic auth trigger

## Benefits
1. **Easier Rollbacks**: Clear instructions for reverting changes in emergencies
2. **Better Documentation**: Understanding of what each migration creates/modifies
3. **Safety**: Reduces risk of mistakes during rollbacks
4. **Best Practice**: Follows database management standards

Fixes #79