### PR TITLE
Enable Google Docs embedding by default

### DIFF
--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -3,7 +3,7 @@
  *
  * All feature flags should:
  * 1. Start with VITE_ to be accessible in the frontend
- * 2. Default to false for safety
+ * 2. Have a clear default behavior (can be true or false)
  * 3. Be documented with their purpose
  */
 
@@ -12,8 +12,9 @@ export const FEATURES = {
    * Enable Google Docs iframe embedding in the review page
    * When true: Shows live Google Doc editor
    * When false: Shows extracted text preview
+   * Default: true (enabled unless explicitly disabled)
    */
-  GOOGLE_DOC_EMBED: import.meta.env.VITE_ENABLE_DOC_EMBED === 'true',
+  GOOGLE_DOC_EMBED: import.meta.env.VITE_ENABLE_DOC_EMBED !== 'false',
 } as const;
 
 // Type for feature flag keys


### PR DESCRIPTION
## Summary
This PR changes the Google Docs embedding feature to be enabled by default, providing a better out-of-the-box experience for users.

## Changes
- Modified feature flag logic to enable Google Docs embedding unless explicitly disabled
- Updated documentation to reflect the new default behavior
- Feature can still be disabled by setting `VITE_ENABLE_DOC_EMBED=false`

## Rationale
Since the Google Docs embedding feature is working well and improves the reviewer workflow significantly, it makes sense to have it enabled by default rather than requiring manual activation.

🤖 Generated with [Claude Code](https://claude.ai/code)