### PR TITLE
fix: use placeholder env vars for Dependabot PRs in Lighthouse CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,10 +33,11 @@ jobs:
     - name: Build project
       run: npm run build
       env:
-        VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-        VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
+        # Use placeholder values for Dependabot PRs (secrets not available)
+        VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+        VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+        VITE_ALGOLIA_APP_ID: ${{ secrets.VITE_ALGOLIA_APP_ID || 'placeholder-app-id' }}
+        VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.VITE_ALGOLIA_SEARCH_API_KEY || 'placeholder-search-key' }}
         
     - name: Serve built app
       run: |


### PR DESCRIPTION
## Summary
- Fixes Lighthouse CI failures on all Dependabot PRs
- GitHub doesn't pass secrets to Dependabot PRs for security reasons
- Without env vars, the app fails to initialize and shows NO_FCP error

## Solution
Uses the bash `||` operator to provide placeholder values ONLY when secrets are empty (i.e., for Dependabot PRs). Regular PRs will continue to use real secrets.

## Testing
- Regular PRs: Will continue to use real secrets (no change)
- Dependabot PRs: Will use placeholder values, allowing the app to at least render for Lighthouse tests

This fix is needed to unblock all pending Dependabot dependency updates.