### PR TITLE
fix: Correct lesson ID query in ReviewDetail to prevent 400 errors

### DIFF
--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -189,14 +189,21 @@ export function ReviewDetail() {
       let similaritiesWithLessons = [];
       if (similarities && similarities.length > 0) {
         const lessonIds = similarities.map((s) => s.lesson_id);
-        const { data: lessons } = await supabase
+        const { data: lessons, error: lessonsError } = await supabase
           .from('lessons_with_metadata')
-          .select('id, title, grade_levels, thematic_categories')
-          .in('id', lessonIds);
+          .select('lesson_id, title, grade_levels, thematic_categories')
+          .in('lesson_id', lessonIds);
+
+        if (lessonsError) {
+          logger.error('Error fetching similar lessons:', lessonsError);
+        }
 
         if (lessons) {
           similaritiesWithLessons = similarities.map((sim) => {
-            const lesson = lessons.find((l) => l.id === sim.lesson_id);
+            const lesson = lessons.find((l) => l.lesson_id === sim.lesson_id);
+            if (!lesson) {
+              logger.debug(`Lesson not found for similarity: ${sim.lesson_id}`);
+            }
             return {
               ...sim,
               lesson: lesson || { title: 'Unknown', grade_levels: [], thematic_categories: [] },


### PR DESCRIPTION
## Problem
The ReviewDetail component was generating 400 errors in the browser console when trying to fetch lesson metadata for similarities.

Error message:
```
GET https://[supabase-url]/rest/v1/lessons_with_metadata?select=id%2Ctitle%2Cgrade_levels%2Cthematic_categories&id=in.%28lesson_1753316245157_flurdiez2%29 400 (Bad Request)
```

## Root Cause
The database has two ID fields:
- `id` (UUID) - Primary key
- `lesson_id` (TEXT) - Secondary identifier like "lesson_1753316245157_flurdiez2"

The `submission_similarities` table stores TEXT `lesson_id` values, but the ReviewDetail component was incorrectly querying by the UUID `id` field, causing a type mismatch.

## Solution
1. Changed the query to use `lesson_id` instead of `id`
2. Updated the mapping logic to match on `lesson_id`
3. Added error handling and debug logging

## Testing
- Verified TypeScript compilation passes
- Tested that the review page loads without errors
- Confirmed the 400 error no longer appears in console

## Files Changed
- `src/pages/ReviewDetail.tsx` - Fixed query and mapping logic