### PR TITLE
fix: Add write permissions for Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:

--- a/.github/workflows/claude-component-review.yml
+++ b/.github/workflows/claude-component-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
     

--- a/.github/workflows/claude-database-review.yml
+++ b/.github/workflows/claude-database-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:

--- a/.github/workflows/claude-feature-review.yml
+++ b/.github/workflows/claude-feature-review.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read
     


### PR DESCRIPTION
## Summary
- Fixes Claude workflow permission errors
- Changes `pull-requests` and `issues` from `read` to `write` permissions
- Resolves 'Resource not accessible by integration' errors

## Problem
Claude workflows were failing with:
```
HttpError: Resource not accessible by integration
```

This happened because Claude needs write permissions to post comments on PRs and issues.

## Solution
Updated permissions in 4 Claude workflow files:
- **claude-code-review.yml**
- **claude-component-review.yml**
- **claude-database-review.yml**
- **claude-feature-review.yml**

Changed:
```yaml
permissions:
  pull-requests: read  → write
  issues: read        → write
```

## Testing
Once merged, Claude will be able to post review comments on PR #201 and other PRs.

Related to #201 and #202