### PR TITLE
fix: Use default model and add Opus fallback for Claude workflows

### DIFF
--- a/.github/workflows/claude-auto-fix-ci.yml
+++ b/.github/workflows/claude-auto-fix-ci.yml
@@ -136,7 +136,7 @@ jobs:
           claude_args: |
             --max-turns 10
             --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(npm:*),Bash(npx:*)"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"
 
       - name: Push fix branch
         if: success()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,5 +70,5 @@ jobs:
           claude_args: |
             --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__add_issue_comment,mcp__github__get_pull_request,mcp__github__get_pull_request_files,Bash(npm run type-check),Bash(npm run lint),Bash(npm test),Bash(gh pr diff),Bash(gh pr view),Bash(gh pr checks)"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"
 

--- a/.github/workflows/claude-component-review.yml
+++ b/.github/workflows/claude-component-review.yml
@@ -92,4 +92,4 @@ jobs:
           claude_args: |
             --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_files,Bash(npm run type-check),Bash(npm run lint),Bash(npm test -- --run),Bash(npm run build),Bash(gh pr diff -- src/components),Read,Grep"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude-database-review.yml
+++ b/.github/workflows/claude-database-review.yml
@@ -93,4 +93,4 @@ jobs:
           claude_args: |
             --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_files,Bash(npm run test:rls),Bash(gh pr diff -- supabase/migrations),Read,Grep"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude-feature-review.yml
+++ b/.github/workflows/claude-feature-review.yml
@@ -109,4 +109,4 @@ jobs:
           claude_args: |
             --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_files,Bash(npm run type-check),Bash(npm run lint),Bash(npm test -- --run),Bash(gh pr diff),Read,Grep"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude-lesson-dedup.yml
+++ b/.github/workflows/claude-lesson-dedup.yml
@@ -130,4 +130,4 @@ jobs:
           claude_args: |
             --max-turns 8
             --allowedTools "mcp__github__get_issue,mcp__github__get_pull_request,mcp__github__get_pull_request_files,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__create_pull_request_review,mcp__github__update_issue,Read,Grep,Glob"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude-perf-review.yml
+++ b/.github/workflows/claude-perf-review.yml
@@ -154,4 +154,4 @@ jobs:
           claude_args: |
             --max-turns 5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_files,Bash(npm run build),Bash(npm ls),Bash(gh pr diff),Read,Grep,Glob"
-            --model claude-4-0-sonnet-20250805
+          fallback_model: "claude-opus-4-1-20250805"


### PR DESCRIPTION
## Summary
- Removes hardcoded model parameter to use action's default
- Adds `fallback_model: 'claude-opus-4-1-20250805'` to all workflows
- Fixes 404 model errors that were preventing Claude checks from running

## Problem
Claude workflows were failing with:
```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-4-0-sonnet-20250805"}}
```

The model identifier `claude-4-0-sonnet-20250805` doesn't exist.

## Solution
1. **Remove `--model` parameter** - Let the action use its default model (currently `claude-4-0-sonnet-20250219`)
2. **Add fallback model** - Use Opus 4.1 as fallback when the default model is overloaded

## Benefits
- ✅ Fixes immediate 404 errors
- ✅ Automatically uses latest model when action updates
- ✅ Provides fallback for reliability
- ✅ Cleaner configuration

## Files Changed
All 7 Claude workflow files:
- claude-code-review.yml
- claude-component-review.yml
- claude-database-review.yml
- claude-feature-review.yml
- claude-lesson-dedup.yml
- claude-perf-review.yml
- claude-auto-fix-ci.yml

Related to #201, #202, #203