### PR TITLE
fix: enable inline PR comments for Claude Code Action workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,7 @@ jobs:
                   "ghcr.io/github/github-mcp-server"
                 ],
                 "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}"
+                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}"
                 }
               }
             }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,29 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Create GitHub MCP Config
+        run: |
+          cat > /tmp/github-mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "github": {
+                "command": "docker",
+                "args": [
+                  "run",
+                  "-i",
+                  "--rm",
+                  "-e",
+                  "GITHUB_PERSONAL_ACCESS_TOKEN",
+                  "ghcr.io/github/github-mcp-server"
+                ],
+                "env": {
+                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}"
+                }
+              }
+            }
+          }
+          EOF
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -60,7 +83,10 @@ jobs:
             ## How to Provide Feedback
             
             ### For Line-Specific Issues (PREFERRED):
-            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code problems.
+            Create a pending PR review and add inline comments using:
+            1. `mcp__github__create_pending_pull_request_review` to start the review
+            2. `mcp__github__add_comment_to_pending_review` for each inline comment
+            3. `mcp__github__submit_pending_pull_request_review` to submit the review
             This is best for:
             - Bugs or errors in specific lines
             - Style/convention violations
@@ -87,5 +113,6 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: |
-            --allowed-tools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request,mcp__github__get_pull_request_files,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep"
+            --mcp-config /tmp/github-mcp-config.json
+            --allowed-tools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request,mcp__github__get_pull_request_files,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep"
 

--- a/.github/workflows/claude-component-review.yml
+++ b/.github/workflows/claude-component-review.yml
@@ -30,6 +30,29 @@ jobs:
         with:
           fetch-depth: 0
       
+      - name: Create GitHub MCP Config
+        run: |
+          cat > /tmp/github-mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "github": {
+                "command": "docker",
+                "args": [
+                  "run",
+                  "-i",
+                  "--rm",
+                  "-e",
+                  "GITHUB_PERSONAL_ACCESS_TOKEN",
+                  "ghcr.io/github/github-mcp-server"
+                ],
+                "env": {
+                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}"
+                }
+              }
+            }
+          }
+          EOF
+      
       - name: Claude React/TypeScript Review
         uses: anthropics/claude-code-action@v1
         with:
@@ -92,7 +115,12 @@ jobs:
             ## How to Provide Feedback
             
             ### Use Inline Comments (PREFERRED):
-            Use `mcp__github_inline_comment__create_inline_comment` for specific line feedback:
+            Create a pending PR review and add inline comments using:
+            1. `mcp__github__create_pending_pull_request_review` to start the review
+            2. `mcp__github__add_comment_to_pending_review` for each inline comment
+            3. `mcp__github__submit_pending_pull_request_review` to submit the review
+            
+            Focus inline comments on:
             - Hook dependency issues
             - Type errors or 'any' usage
             - Performance problems
@@ -114,4 +142,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: |
             --max-turns 5
-            --allowed-tools "mcp__github_inline_comment__create_inline_comment,mcp__github__get_pull_request_files,Bash(npm run type-check),Bash(npm run lint),Bash(npm test -- --run),Bash(npm run build),Bash(gh pr diff -- src/components),Bash(gh pr comment:*),Read,Grep"
+            --mcp-config /tmp/github-mcp-config.json
+            --allowed-tools "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request,mcp__github__get_pull_request_files,Bash(npm run type-check),Bash(npm run lint),Bash(npm test -- --run),Bash(npm run build),Bash(gh pr diff -- src/components),Bash(gh pr comment:*),Read,Grep"

--- a/.github/workflows/claude-component-review.yml
+++ b/.github/workflows/claude-component-review.yml
@@ -46,7 +46,7 @@ jobs:
                   "ghcr.io/github/github-mcp-server"
                 ],
                 "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}"
+                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}"
                 }
               }
             }


### PR DESCRIPTION
## 🔧 Fix Claude Code Action Inline Comments

This PR fixes the inline comment functionality for Claude Code Action workflows by properly configuring the GitHub MCP server.

## 🐛 Problem
- Claude workflows were trying to use `mcp__github_inline_comment__create_inline_comment` which doesn't exist
- No inline comments were appearing on PRs, only general comments

## ✅ Solution
1. **Added GitHub MCP Server Configuration**
   - Configures Docker-based GitHub MCP server in workflows
   - Uses `GH_PAT` secret (or falls back to `GITHUB_TOKEN`)
   
2. **Updated to Correct MCP Tools**
   - Replaced non-existent inline comment tool with proper GitHub API sequence:
     - `mcp__github__create_pending_pull_request_review`
     - `mcp__github__add_comment_to_pending_review`
     - `mcp__github__submit_pending_pull_request_review`

3. **Fixed Secret Naming**
   - Changed from `GITHUB_PAT` to `GH_PAT` (GitHub reserves `GITHUB_` prefix)

## 📝 Changes
- Updated `.github/workflows/claude-code-review.yml`
- Updated `.github/workflows/claude-component-review.yml`

## 🔑 Required Setup
Add a repository secret named `GH_PAT` with your GitHub Personal Access Token that has `repo` scope.

## 🧪 Testing
After merging, the inline comments should work on PR #211 (test PR).

---
Related to #211 (test PR for verification)