### PR TITLE
chore: add .mcp.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ debug-*/
 
 # Claude files
 .claude/
+.mcp.json
 
 # Data files
 *.csv


### PR DESCRIPTION
## Summary
Adds `.mcp.json` to the gitignore file to prevent committing local MCP (Model Context Protocol) configuration files.

## Why This Change?
The `.mcp.json` file contains local MCP server configurations which may include:
- API tokens and authentication credentials
- Personal server settings
- Local development paths

These should never be committed to version control as they are environment-specific and may contain sensitive information.

## What Changed
- Added `.mcp.json` to `.gitignore` under the Claude files section

This is a follow-up from our work on implementing the GitHub MCP server for Claude Code Action workflows (PR #212).