### PR TITLE
Fix: publish approved submissions + persist extracted title; update search mappings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Source: `src/` (React + TypeScript). Key areas: `components/`, `pages/`, `hooks/`, `stores/`, `utils/`, `types/`, `lib/`.
+- Tests: `src/__tests__/` (unit/integration) and `src/test/` (helpers). Mocks in `src/__mocks__/`.
+- Static assets: `public/`. Build output: `dist/`.
+- Platform/config: `supabase/`, `scripts/`, `.github/`, `docs/`.
+- Module alias: use `@` (e.g., `import { fetchX } from '@/utils/fetchX'`).
+
+## Build, Test, and Development Commands
+- `npm run dev`: Start Vite dev server.
+- `npm run build`: Type-check then build for production.
+- `npm run preview`: Serve the production build locally.
+- `npm run type-check`: Run TypeScript without emit.
+- `npm run test` | `test:ui` | `test:coverage`: Run Vitest (CLI, UI, with coverage). Reports in `coverage/`.
+- `npm run lint` | `lint:fix`: Lint code, optionally auto-fix.
+- `npm run format`: Apply Prettier to `src/**/*`.
+- Data/search ops: `npm run import-data`, `sync-algolia`, `configure-synonyms` (see `scripts/`).
+
+## Coding Style & Naming Conventions
+- Formatting: Prettier (2 spaces, single quotes, width 100, semicolons). Run `npm run format`.
+- Linting: ESLint with TS, React, hooks, a11y, Prettier integration. Fix with `npm run lint:fix`.
+- Components: PascalCase files in `src/components/...` (e.g., `LessonCard.tsx`).
+- Hooks: `useCamelCase` in `src/hooks` (e.g., `useSearch.ts`).
+- Utilities/types: camelCase functions in `src/utils`, PascalCase `Type`/`Interface` in `src/types`.
+
+## Testing Guidelines
+- Framework: Vitest + Testing Library (jsdom). Setup at `src/__tests__/setup.ts`.
+- Name tests `*.test.ts(x)` near source or under `src/__tests__/`.
+- Keep tests deterministic; mock Supabase/Algolia as needed (see setup mocks).
+- Generate coverage with `npm run test:coverage`.
+
+## Commit & Pull Request Guidelines
+- Commits: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`). Keep scope concise.
+- Branches: `feat/…`, `fix/…`, `chore/…` to match PRs.
+- PRs: clear description, link issues (`Closes #123`), include screenshots for UI changes, and notes on tests/migrations.
+- Ensure `lint`, `type-check`, and `test` pass before requesting review.
+
+## Security & Configuration Tips
+- Never commit secrets. Use `.env*` files locally; update `*.example` when adding a new var.
+- Required envs typically include Supabase, Algolia, and OpenAI keys (see `.env.example`).
+- For deployments, see `netlify.toml`/`vercel.json` and ensure `npm run build` succeeds.
+

--- a/docs/duplicate-detection-improvement-plan.md
+++ b/docs/duplicate-detection-improvement-plan.md
@@ -1,0 +1,181 @@
+# Duplicate Detection Improvement Plan
+
+Last updated: 2025-08-31
+
+## Summary & Goals
+
+Improve duplicate detection accuracy and reviewer signal-to-noise by:
+- Raising the bar for semantic matches and applying a combined-score floor
+- Using richer metadata overlap across existing array fields
+- Normalizing title similarity
+- Storing and surfacing only the strongest matches to reviewers
+- Tidying remaining exact-hash duplicates via the existing resolution RPC
+
+Success criteria:
+- Reduce “low” match noise in submission similarities
+- Shift combined-score distribution upward (p50 ≥ ~0.45) without losing real duplicates
+- Resolve/justify all remaining exact-hash duplicate groups
+
+## Current Architecture (High-Level)
+
+- Edge function `detect-duplicates`:
+  - Exact: `content_hash` (SHA-256 of normalized `content_text`)
+  - Semantic: `find_similar_lessons_by_embedding` (pgvector cosine)
+  - Fallback (no embedding): title Jaccard + rudimentary metadata overlap
+  - Persists to `submission_similarities`; returns top 10 to client
+- Submission pipeline `process-submission`:
+  - Extracts content, generates embeddings, calls `detect-duplicates`, stores hash + similarities
+- Offline analysis:
+  - `scripts/analyze-duplicates-v2.ts` (union-find, embeddings, Levenshtein); report in `public/reports`
+  - `scripts/analyze-duplicates-v3.ts` (human-centric categorization, canonical scoring, sub-groups)
+  - `scripts/auto-resolve-duplicates.ts` (optional exact-duplicate resolver using reports)
+- Admin UI:
+  - `AdminDuplicates` loads V3/V2 reports; flags resolved groups via `duplicate_resolutions`
+  - `AdminDuplicateDetailV3` executes `resolve_duplicate_group` (supports split/keep-all/title edits)
+- Database:
+  - Functions: `find_lessons_by_hash`, `find_similar_lessons_by_embedding`, `resolve_duplicate_group`, `is_duplicate_lesson`
+  - Indexes: ivfflat on `content_embedding`, BTREE on `content_hash` (+ composite)
+  - View: `lessons_with_metadata` (granular arrays + extracted JSON arrays; RLS-respecting)
+
+## Live DB Findings (Snapshot)
+
+- Totals: `lessons=815`, `submissions=95`, `submission_similarities=117`, `lesson_archive=13`, `duplicate_resolutions=10`, `canonical_lessons=3`
+- Hash health: `content_hash` present for all lessons; no `META_` hashes; `content_embedding` present for all lessons
+- Exact duplicates: 13 groups with >1 lesson sharing the same `content_hash`
+- Similarity distribution (from `submission_similarities`): `exact=2`, `high=2`, `medium=8`, `low=105`
+- Combined-score stats (persisted): `avg≈0.31`, `p50≈0.293`, `p90≈0.354`, `max=1.0`
+- Embedding threshold mismatch: DB function default is 0.5; edge `detect-duplicates` calls with 0.3 → floods low-value matches
+
+## Issues Identified
+
+1. Title similarity is simplistic (plain Jaccard, no normalization; weak on near-miss edits)
+2. Metadata overlap underuses available signals (only grade/skills; ignores `thematic_categories`, `activity_type`, `cultural_heritage`, `season_timing`, `main_ingredients`, `cooking_methods`)
+3. Semantic threshold too low in practice (0.3 via edge), producing many low matches
+4. Fallback path (no embedding) samples a small set and does basic scoring → potential misses/noise
+5. Reviewer UI surfaces many low matches; no default filtering
+6. Limited tests for similarity helpers and combined scoring
+
+## Plan
+
+### Immediate Fixes
+
+1. Raise semantic threshold and add a combined-score floor
+   - Call `find_similar_lessons_by_embedding` with `similarity_threshold = 0.5`
+   - Compute `combined_score` = weighted mix of `semantic`, `title`, `metadata`
+   - Apply `combined_score >= 0.45–0.50` floor before persisting to `submission_similarities`
+2. Store top-N only
+   - Sort by `combined_score` and insert at most the top 10 per submission
+3. Expand metadata overlap
+   - Consider and normalize (lowercase, trim) these array fields:
+     - `grade_levels`, `thematic_categories`, `activity_type`, `cultural_heritage`, `season_timing`, `main_ingredients`, `cooking_methods`
+   - Use per-field Jaccard; form a weighted average metadata score
+4. Title normalization & scoring
+   - Lowercase, strip punctuation, stopword removal
+   - Use a token-based similarity (still fast) for better resilience (e.g., token set ratio, or Jaro–Winkler alternative)
+
+### Reviewer & Admin UX
+
+5. Reviewer surfacing
+   - `ReviewDashboard`: fetch `submission_similarities` for each submission; show exact/high/medium by default; hide “low” behind an expander
+   - Sort by `combined_score`; show top 3 inline
+6. Exact-duplicate cleanup
+   - Use `resolve_duplicate_group` to clear remaining hash-identical groups
+   - Process:
+     - Generate a dry-run list of groups (see SQL below)
+     - Resolve automatically where safe (or review in `AdminDuplicateDetailV3`)
+
+### Reliability & Safety
+
+7. Tests
+   - Unit: title similarity normalization + scoring; metadata overlap across fields
+   - Integration: `detect-duplicates` combined scoring path with mocked RPC responses
+8. Observability
+   - Log match counts per tier (exact/high/medium/low), top-N persisted, and summary stats (p50/p90 combined-score) to tune thresholds over time
+9. Documentation
+   - Update README/ops notes with thresholds, field weights, and rollback guidance
+
+## Targets / Acceptance Criteria
+
+- Reduce “low” matches in `submission_similarities` (target: < 25% of persisted rows)
+- combined-score distribution improves: `p50 ≥ ~0.45`, `p90 ≥ ~0.60` (calibrated after baseline)
+- 0 unresolved exact-hash groups (either resolved or explicitly preserved with rationale)
+
+## Implementation Touchpoints
+
+- `supabase/functions/detect-duplicates/index.ts`
+  - Pass `similarity_threshold = 0.5`
+  - Expand `calculateMetadataOverlap` to include the arrays listed above (pull from `lessons_with_metadata`)
+  - Normalize title inputs; switch similarity function
+  - Add `combined_score` floor; cap to top 10
+- `src/pages/ReviewDashboard.tsx`
+  - Query `submission_similarities` (and join lesson titles as needed)
+  - Default-view exact/high/medium only; show “low” via expander
+- Admin exacts
+  - Use `resolve_duplicate_group` for remaining exact-hash groups; preserve titles via the `p_title_updates` parameter if needed
+- Optional (offline)
+  - Continue using `scripts/analyze-duplicates-v3.ts` for batch analytics and categorization reports
+
+## SQL Snippets (Reference)
+
+Top exact hash groups (live DB):
+
+```sql
+SELECT content_hash, COUNT(*) AS cnt
+FROM lessons
+WHERE content_hash IS NOT NULL
+GROUP BY content_hash
+HAVING COUNT(*) > 1
+ORDER BY cnt DESC
+LIMIT 25;
+```
+
+Similarity distribution (persisted):
+
+```sql
+SELECT 
+  COUNT(*) FILTER (WHERE match_type='exact') AS exact,
+  COUNT(*) FILTER (WHERE match_type='high')  AS high,
+  COUNT(*) FILTER (WHERE match_type='medium') AS medium,
+  COUNT(*) FILTER (WHERE match_type='low')   AS low
+FROM submission_similarities;
+```
+
+Combined-score distribution:
+
+```sql
+SELECT 
+  MIN(combined_score) AS min,
+  MAX(combined_score) AS max,
+  AVG(combined_score) AS avg,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY combined_score) AS p50,
+  PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY combined_score) AS p90
+FROM submission_similarities
+WHERE combined_score IS NOT NULL;
+```
+
+## Rollout & Validation
+
+1. Implement Immediate Fixes in a branch → deploy to staging
+2. Submit a few representative test docs; record:
+   - Match-type distribution
+   - Combined-score stats (min/max/avg/p50/p90)
+3. Adjust floor/weights (one iteration) to hit targets
+4. Roll out to production
+5. Resolve exact-hash groups (batched, with audit via `duplicate_resolutions`)
+6. Monitor over the next week; re-tune if reviewer noise reappears
+
+## Risks & Mitigations
+
+- Too-aggressive thresholds could miss real near-duplicates
+  - Mitigation: start with conservative floor (~0.45) and review metrics; tune incrementally
+- Metadata overlap weighting might overfit to certain fields
+  - Mitigation: cap individual field influence; favor diversity across signals
+- Reviewer workload spikes if many groups are surfaced simultaneously
+  - Mitigation: show high/medium by default; batch exact-hash cleanups first
+
+## Open Questions
+
+- Preferred field weights for metadata overlap (equal vs emphasis on `activity_type`/`thematic_categories`)?
+- Should we keep a small “gray” zone (e.g., 0.40–0.45) hidden by default but retrievable?
+- Any organizational constraints around auto-resolving exacts beyond content identity?
+

--- a/docs/migrations/2025-09-01-add-extracted-title-to-submissions.sql
+++ b/docs/migrations/2025-09-01-add-extracted-title-to-submissions.sql
@@ -1,0 +1,30 @@
+-- Add extracted_title to lesson_submissions to persist the document title
+
+ALTER TABLE public.lesson_submissions
+  ADD COLUMN IF NOT EXISTS extracted_title text;
+
+-- Optional: backfill from extracted_content for existing rows
+-- (picks first meaningful non-empty line, skipping separators and summary headers)
+WITH derived AS (
+  SELECT 
+    s.id,
+    (
+      SELECT ln
+      FROM (
+        SELECT btrim(x) AS ln
+        FROM regexp_split_to_table(s.extracted_content, E'\r?\n') AS x
+      ) t
+      WHERE ln <> ''
+        AND ln <> '---'
+        AND ln !~ '^\[.*\]'
+        AND ln !~* '^summary\s*:'
+      LIMIT 1
+    ) AS new_title
+  FROM public.lesson_submissions s
+  WHERE s.extracted_title IS NULL OR s.extracted_title = ''
+)
+UPDATE public.lesson_submissions s
+SET extracted_title = d.new_title
+FROM derived d
+WHERE s.id = d.id AND d.new_title IS NOT NULL AND d.new_title <> '';
+

--- a/docs/migrations/2025-09-01-backfill-lesson-titles-from-submissions.sql
+++ b/docs/migrations/2025-09-01-backfill-lesson-titles-from-submissions.sql
@@ -1,0 +1,32 @@
+-- One-time backfill: derive lesson titles from submission extracted_content
+-- Updates only rows with title='Untitled Lesson' and a linked submission.
+
+WITH derived AS (
+  SELECT 
+    l.lesson_id,
+    (
+      SELECT ln
+      FROM (
+        SELECT btrim(x) AS ln
+        FROM regexp_split_to_table(s.extracted_content, E'\r?\n') AS x
+      ) t
+      WHERE ln <> ''
+        AND ln <> '---'
+        AND ln !~ '^\[.*\]'
+        AND ln !~* '^summary\s*:'
+      LIMIT 1
+    ) AS new_title
+  FROM lessons l
+  JOIN lesson_submissions s ON s.id = l.original_submission_id
+  WHERE l.title = 'Untitled Lesson'
+)
+UPDATE lessons l
+SET title = d.new_title
+FROM derived d
+WHERE l.lesson_id = d.lesson_id
+  AND d.new_title IS NOT NULL
+  AND d.new_title <> '';
+
+-- Verify:
+--   SELECT lesson_id, title FROM lessons WHERE original_submission_id IS NOT NULL AND title='Untitled Lesson' LIMIT 20;
+

--- a/docs/migrations/2025-09-01-publish-approved-batch-v8.sql
+++ b/docs/migrations/2025-09-01-publish-approved-batch-v8.sql
@@ -1,0 +1,214 @@
+-- Publish approved submissions → lessons (title-first using submissions.extracted_title)
+-- Drops and recreates to prioritize extracted_title, then metadata title, then content-derived title.
+
+DROP FUNCTION IF EXISTS public.publish_approved_submissions(integer);
+
+CREATE OR REPLACE FUNCTION public.publish_approved_submissions(p_limit integer DEFAULT NULL)
+RETURNS TABLE(published_lesson_id text, published_submission_id uuid)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT 
+      a.id AS submission_id,
+      a.google_doc_url,
+      a.extracted_content,
+      a.extracted_title,
+      a.content_hash,
+      a.content_embedding,
+      (
+        SELECT sr.tagged_metadata
+        FROM submission_reviews sr
+        WHERE sr.submission_id = a.id
+        ORDER BY sr.created_at DESC
+        LIMIT 1
+      ) AS meta
+    FROM lesson_submissions a
+    LEFT JOIN lessons l ON l.original_submission_id = a.id
+    WHERE a.status='approved' AND l.lesson_id IS NULL
+    ORDER BY a.created_at DESC
+    LIMIT COALESCE(p_limit, 1000000)
+  ), title_fallback AS (
+    SELECT 
+      c.*,
+      COALESCE(
+        NULLIF(c.extracted_title, ''),
+        NULLIF(c.meta->>'title',''),
+        (
+          SELECT ln
+          FROM (
+            SELECT btrim(x) AS ln
+            FROM regexp_split_to_table(c.extracted_content, E'\r?\n') AS x
+          ) t
+          WHERE ln <> ''
+            AND ln <> '---'
+            AND ln !~ '^\[.*\]'
+            AND ln !~* '^summary\s*:'
+          LIMIT 1
+        )
+      ) AS derived_title,
+      COALESCE(c.meta->>'summary','') AS derived_summary
+    FROM candidates c
+  ), ins AS (
+    INSERT INTO lessons (
+      lesson_id,
+      title,
+      summary,
+      file_link,
+      grade_levels,
+      activity_type,
+      thematic_categories,
+      season_timing,
+      core_competencies,
+      cultural_heritage,
+      location_requirements,
+      lesson_format,
+      academic_integration,
+      social_emotional_learning,
+      cooking_methods,
+      main_ingredients,
+      garden_skills,
+      cooking_skills,
+      observances_holidays,
+      cultural_responsiveness_features,
+      metadata,
+      content_text,
+      content_hash,
+      original_submission_id,
+      content_embedding,
+      created_at,
+      updated_at
+    )
+    SELECT 
+      'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+      COALESCE(tf.derived_title, 'Untitled Lesson'),
+      tf.derived_summary,
+      tf.google_doc_url,
+      CASE 
+        WHEN tf.meta ? 'gradeLevels' AND jsonb_typeof(tf.meta->'gradeLevels') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'gradeLevels'))
+        WHEN tf.meta ? 'gradeLevels' THEN ARRAY[tf.meta->>'gradeLevels']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE WHEN tf.meta ? 'activityType' THEN ARRAY[tf.meta->>'activityType'] ELSE ARRAY[]::text[] END,
+      CASE 
+        WHEN tf.meta ? 'themes' AND jsonb_typeof(tf.meta->'themes') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'themes'))
+        WHEN tf.meta ? 'themes' THEN ARRAY[tf.meta->>'themes']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE
+        WHEN tf.meta ? 'season' AND jsonb_typeof(tf.meta->'season') = 'array' THEN
+          CASE
+            WHEN EXISTS (
+              SELECT 1 FROM jsonb_array_elements_text(tf.meta->'season') el
+              WHERE lower(trim(el)) IN ('year-round','all year','all-year')
+            ) THEN ARRAY['Fall','Winter','Spring','Summer']::text[]
+            ELSE ARRAY(
+              SELECT DISTINCT
+                CASE lower(trim(el2))
+                  WHEN 'autumn' THEN 'Fall'
+                  WHEN 'fall' THEN 'Fall'
+                  WHEN 'winter' THEN 'Winter'
+                  WHEN 'spring' THEN 'Spring'
+                  WHEN 'summer' THEN 'Summer'
+                END
+              FROM jsonb_array_elements_text(tf.meta->'season') el2
+              WHERE lower(trim(el2)) IN ('autumn','fall','winter','spring','summer')
+            )
+          END
+        WHEN tf.meta ? 'season' THEN
+          CASE lower(trim(tf.meta->>'season'))
+            WHEN 'year-round' THEN ARRAY['Fall','Winter','Spring','Summer']::text[]
+            WHEN 'all year'  THEN ARRAY['Fall','Winter','Spring','Summer']::text[]
+            WHEN 'all-year'  THEN ARRAY['Fall','Winter','Spring','Summer']::text[]
+            WHEN 'autumn'    THEN ARRAY['Fall']::text[]
+            WHEN 'fall'      THEN ARRAY['Fall']::text[]
+            WHEN 'winter'    THEN ARRAY['Winter']::text[]
+            WHEN 'spring'    THEN ARRAY['Spring']::text[]
+            WHEN 'summer'    THEN ARRAY['Summer']::text[]
+            ELSE ARRAY[]::text[]
+          END
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'coreCompetencies' AND jsonb_typeof(tf.meta->'coreCompetencies') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'coreCompetencies'))
+        WHEN tf.meta ? 'coreCompetencies' THEN ARRAY[tf.meta->>'coreCompetencies']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'culturalHeritage' AND jsonb_typeof(tf.meta->'culturalHeritage') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'culturalHeritage'))
+        WHEN tf.meta ? 'culturalHeritage' THEN ARRAY[tf.meta->>'culturalHeritage']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE WHEN tf.meta ? 'location' THEN ARRAY[tf.meta->>'location'] ELSE ARRAY[]::text[] END,
+      NULLIF(tf.meta->>'lessonFormat',''),
+      CASE 
+        WHEN tf.meta ? 'academicIntegration' AND jsonb_typeof(tf.meta->'academicIntegration') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'academicIntegration'))
+        WHEN tf.meta ? 'academicIntegration' THEN ARRAY[tf.meta->>'academicIntegration']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'socialEmotionalLearning' AND jsonb_typeof(tf.meta->'socialEmotionalLearning') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'socialEmotionalLearning'))
+        WHEN tf.meta ? 'socialEmotionalLearning' THEN ARRAY[tf.meta->>'socialEmotionalLearning']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'cookingMethods' AND jsonb_typeof(tf.meta->'cookingMethods') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'cookingMethods'))
+        WHEN tf.meta ? 'cookingMethods' THEN ARRAY[tf.meta->>'cookingMethods']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'mainIngredients' AND jsonb_typeof(tf.meta->'mainIngredients') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'mainIngredients'))
+        WHEN tf.meta ? 'mainIngredients' THEN ARRAY[tf.meta->>'mainIngredients']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'gardenSkills' AND jsonb_typeof(tf.meta->'gardenSkills') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'gardenSkills'))
+        WHEN tf.meta ? 'gardenSkills' THEN ARRAY[tf.meta->>'gardenSkills']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'cookingSkills' AND jsonb_typeof(tf.meta->'cookingSkills') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'cookingSkills'))
+        WHEN tf.meta ? 'cookingSkills' THEN ARRAY[tf.meta->>'cookingSkills']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'observancesHolidays' AND jsonb_typeof(tf.meta->'observancesHolidays') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'observancesHolidays'))
+        WHEN tf.meta ? 'observancesHolidays' THEN ARRAY[tf.meta->>'observancesHolidays']
+        ELSE ARRAY[]::text[]
+      END,
+      CASE 
+        WHEN tf.meta ? 'culturalResponsivenessFeatures' AND jsonb_typeof(tf.meta->'culturalResponsivenessFeatures') = 'array'
+          THEN ARRAY(SELECT jsonb_array_elements_text(tf.meta->'culturalResponsivenessFeatures'))
+        WHEN tf.meta ? 'culturalResponsivenessFeatures' THEN ARRAY[tf.meta->>'culturalResponsivenessFeatures']
+        ELSE ARRAY[]::text[]
+      END,
+      COALESCE(tf.meta, '{}'::jsonb),
+      COALESCE(tf.extracted_content, ''),
+      tf.content_hash,
+      tf.submission_id,
+      tf.content_embedding,
+      NOW(),
+      NOW()
+    FROM title_fallback tf
+    RETURNING lesson_id, original_submission_id
+  )
+  SELECT ins.lesson_id AS published_lesson_id, ins.original_submission_id::uuid AS published_submission_id
+  FROM ins;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.publish_approved_submissions(integer) TO anon, authenticated;
+

--- a/docs/migrations/2025-09-01-publish-approved-rls.sql
+++ b/docs/migrations/2025-09-01-publish-approved-rls.sql
@@ -1,0 +1,76 @@
+-- RLS fix for publishing approved submissions into lessons
+-- Apply in Supabase SQL editor (Dashboard) as an admin.
+
+-- 1) lessons: allow admins and reviewers to INSERT/UPDATE
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='lessons'
+      AND policyname='Only admins can insert lessons'
+  ) THEN
+    EXECUTE 'DROP POLICY "Only admins can insert lessons" ON public.lessons';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='lessons'
+      AND policyname='Only admins can update lessons'
+  ) THEN
+    EXECUTE 'DROP POLICY "Only admins can update lessons" ON public.lessons';
+  END IF;
+END $$;
+
+-- Recreate with correct role checks
+CREATE POLICY "Admins and reviewers can insert lessons"
+  ON public.lessons FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles up
+      WHERE up.user_id = auth.uid()
+      AND up.role IN ('admin','reviewer')
+    )
+  );
+
+CREATE POLICY "Admins and reviewers can update lessons"
+  ON public.lessons FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles up
+      WHERE up.user_id = auth.uid()
+      AND up.role IN ('admin','reviewer')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles up
+      WHERE up.user_id = auth.uid()
+      AND up.role IN ('admin','reviewer')
+    )
+  );
+
+-- 2) lesson_versions: allow reviewers to create versions when approving updates
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='lesson_versions'
+      AND policyname='Only admins can create versions'
+  ) THEN
+    EXECUTE 'DROP POLICY "Only admins can create versions" ON public.lesson_versions';
+  END IF;
+END $$;
+
+CREATE POLICY "Admins and reviewers can create versions"
+  ON public.lesson_versions FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_profiles up
+      WHERE up.user_id = auth.uid()
+      AND up.role IN ('admin','reviewer')
+    )
+  );
+
+-- Optional: keep existing SELECT policies as-is
+
+-- Validation (read-only):
+-- SELECT schemaname, tablename, policyname, cmd, roles FROM pg_policies
+--  WHERE schemaname='public' AND tablename IN ('lessons','lesson_versions');
+

--- a/scripts/backfill-publish-approved.ts
+++ b/scripts/backfill-publish-approved.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill: publish approved submissions that don’t have a lesson yet
+ *
+ * Usage:
+ *   VITE_SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npx tsx scripts/backfill-publish-approved.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL!;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const admin = createClient(supabaseUrl, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+type Submission = {
+  id: string;
+  google_doc_url: string;
+  extracted_content: string | null;
+  content_hash: string | null;
+  content_embedding: string | null; // stored as vector literal string like "[1,2,...]"
+};
+
+type Review = {
+  submission_id: string;
+  created_at: string;
+  tagged_metadata: any;
+};
+
+function ensureArray<T>(v: T | T[] | undefined | null): T[] {
+  if (!v) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+async function main() {
+  console.log('🔄 Backfill: publish approved submissions → lessons');
+
+  // Find approved submissions without lessons
+  const { data: subs, error: subsErr } = await admin
+    .from('lesson_submissions')
+    .select('id, google_doc_url, extracted_content, content_hash, content_embedding')
+    .eq('status', 'approved');
+
+  if (subsErr) throw subsErr;
+  if (!subs || subs.length === 0) {
+    console.log('No approved submissions found');
+    return;
+  }
+
+  // Filter to those not present in lessons
+  const ids = subs.map((s) => s.id);
+  const { data: existing, error: existErr } = await admin
+    .from('lessons')
+    .select('original_submission_id, lesson_id')
+    .in('original_submission_id', ids);
+  if (existErr) throw existErr;
+
+  const existingMap = new Map<string, string>();
+  (existing || []).forEach((r) => existingMap.set(r.original_submission_id, r.lesson_id));
+
+  const todo: Submission[] = subs.filter((s) => !existingMap.has(s.id)) as any;
+  console.log(`Found ${todo.length} approved submissions without lessons`);
+
+  // Load latest review per submission for metadata
+  for (const s of todo) {
+    const { data: reviews, error: revErr } = await admin
+      .from('submission_reviews')
+      .select('submission_id, created_at, tagged_metadata')
+      .eq('submission_id', s.id)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (revErr) throw revErr;
+
+    const meta = (reviews?.[0]?.tagged_metadata || {}) as any;
+
+    const newLesson: any = {
+      lesson_id: `lesson_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      title: meta.title || 'Untitled Lesson',
+      summary: meta.summary || '',
+      file_link: s.google_doc_url,
+      grade_levels: ensureArray<string>(meta.gradeLevels),
+      activity_type: ensureArray<string>(meta.activityType),
+      thematic_categories: ensureArray<string>(meta.themes),
+      season_timing: ensureArray<string>(meta.season),
+      core_competencies: ensureArray<string>(meta.coreCompetencies),
+      cultural_heritage: ensureArray<string>(meta.culturalHeritage),
+      location_requirements: ensureArray<string>(meta.location),
+      lesson_format: meta.lessonFormat || null,
+      academic_integration: ensureArray<string>(meta.academicIntegration),
+      social_emotional_learning: ensureArray<string>(meta.socialEmotionalLearning),
+      cooking_methods: ensureArray<string>(meta.cookingMethods),
+      main_ingredients: ensureArray<string>(meta.mainIngredients),
+      garden_skills: ensureArray<string>(meta.gardenSkills),
+      cooking_skills: ensureArray<string>(meta.cookingSkills),
+      observances_holidays: ensureArray<string>(meta.observancesHolidays),
+      cultural_responsiveness_features: ensureArray<string>(meta.culturalResponsivenessFeatures),
+      metadata: meta, // retain raw tagged metadata for compatibility
+      content_text: s.extracted_content || '',
+      content_hash: s.content_hash,
+      original_submission_id: s.id,
+      processing_notes: meta.processingNotes || '',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    if (s.content_embedding) newLesson.content_embedding = s.content_embedding;
+
+    const { error: insErr } = await admin.from('lessons').insert(newLesson);
+    if (insErr) {
+      console.error('❌ Insert failed for submission', s.id, insErr.message);
+      continue;
+    }
+    console.log('✅ Published submission → lesson:', s.id);
+  }
+
+  console.log('Done.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -107,7 +107,7 @@ const fallbackSearch = async ({
           coreCompetencies: row.core_competencies || metadata?.coreCompetencies || [],
           culturalHeritage: row.cultural_heritage || metadata?.culturalHeritage || [],
           locationRequirements: row.location_requirements || metadata?.locationRequirements || [],
-          activityType: metadata?.activityType || [],
+          activityType: row.activity_type || metadata?.activityType || [],
           lessonFormat: row.lesson_format || metadata?.lessonFormat || [],
           mainIngredients: row.main_ingredients || metadata?.mainIngredients || [],
           skills: metadata?.skills || [],

--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -28,6 +28,7 @@ interface SubmissionDetail {
   original_lesson_id?: string;
   status: string;
   extracted_content: string;
+  extracted_title?: string;
   content_hash: string;
   content_embedding?: string;
   teacher: {
@@ -328,15 +329,32 @@ export function ReviewDetail() {
       if (decision === 'approve_new') {
         // Parse the extracted content to get lesson details
         const lessonData = parseExtractedContent(submission.extracted_content);
+        const baseTitle = submission.extracted_title || lessonData.title;
 
-        // Create new lesson in the lessons table (including embedding if available)
+        // Create new lesson (write to base table to set all native columns)
         const newLesson: any = {
           lesson_id: `lesson_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-          title: lessonData.title || 'Untitled Lesson',
+          title: baseTitle || 'Untitled Lesson',
           summary: lessonData.summary || '',
           file_link: submission.google_doc_url,
           grade_levels: metadata.gradeLevels || [],
-          activity_type_meta: metadata.activityType || null,
+          // Base array columns (ensure arrays)
+          activity_type: metadata.activityType ? [metadata.activityType] : [],
+          thematic_categories: metadata.themes || [],
+          season_timing: metadata.season || [],
+          core_competencies: metadata.coreCompetencies || [],
+          cultural_heritage: metadata.culturalHeritage || [],
+          location_requirements: metadata.location ? [metadata.location] : [],
+          lesson_format: metadata.lessonFormat || null,
+          academic_integration: metadata.academicIntegration || [],
+          social_emotional_learning: metadata.socialEmotionalLearning || [],
+          cooking_methods: metadata.cookingMethods || [],
+          main_ingredients: metadata.mainIngredients || [],
+          garden_skills: metadata.gardenSkills || [],
+          cooking_skills: metadata.cookingSkills || [],
+          observances_holidays: metadata.observancesHolidays || [],
+          cultural_responsiveness_features: metadata.culturalResponsivenessFeatures || [],
+          // Keep metadata JSON as well for compatibility
           metadata: {
             thematicCategories: metadata.themes || [],
             seasonTiming: metadata.season || [],
@@ -383,7 +401,7 @@ export function ReviewDetail() {
         }
 
         const { error: lessonError } = await supabase
-          .from('lessons_with_metadata')
+          .from('lessons')
           .insert(newLesson);
 
         if (lessonError) throw lessonError;
@@ -423,6 +441,31 @@ export function ReviewDetail() {
           summary: lessonData.summary || existingLesson.summary,
           file_link: submission.google_doc_url,
           grade_levels: metadata.gradeLevels || existingLesson.grade_levels || [],
+          activity_type: metadata.activityType
+            ? [metadata.activityType]
+            : existingLesson.activity_type || [],
+          thematic_categories: metadata.themes || existingLesson.thematic_categories || [],
+          season_timing: metadata.season || existingLesson.season_timing || [],
+          core_competencies: metadata.core_competencies || existingLesson.core_competencies || [],
+          cultural_heritage: metadata.culturalHeritage || existingLesson.cultural_heritage || [],
+          location_requirements:
+            (metadata.location ? [metadata.location] : null) ||
+            existingLesson.location_requirements || [],
+          lesson_format: metadata.lessonFormat || existingLesson.lesson_format || null,
+          academic_integration:
+            metadata.academicIntegration || existingLesson.academic_integration || [],
+          social_emotional_learning:
+            metadata.socialEmotionalLearning || existingLesson.social_emotional_learning || [],
+          cooking_methods: metadata.cookingMethods || existingLesson.cooking_methods || [],
+          main_ingredients: metadata.mainIngredients || existingLesson.main_ingredients || [],
+          garden_skills: metadata.gardenSkills || existingLesson.garden_skills || [],
+          cooking_skills: metadata.cookingSkills || existingLesson.cooking_skills || [],
+          observances_holidays:
+            metadata.observancesHolidays || existingLesson.observances_holidays || [],
+          cultural_responsiveness_features:
+            metadata.culturalResponsivenessFeatures ||
+            existingLesson.cultural_responsiveness_features ||
+            [],
         };
 
         // Only set activity_type_meta if we have a value
@@ -432,7 +475,7 @@ export function ReviewDetail() {
         }
 
         const { error: updateLessonError } = await supabase
-          .from('lessons_with_metadata')
+          .from('lessons')
           .update({
             ...updateData,
             metadata: {

--- a/supabase/functions/process-submission/index.ts
+++ b/supabase/functions/process-submission/index.ts
@@ -204,11 +204,12 @@ serve(async (req) => {
       title = extractResult.data.title;
       content = extractResult.data.content;
 
-      // Step 3: Update submission with extracted content
+      // Step 3: Update submission with extracted content and title
       const { error: updateError } = await supabaseAdmin
         .from('lesson_submissions')
         .update({
           extracted_content: content,
+          extracted_title: title,
         })
         .eq('id', submission.id);
 

--- a/supabase/functions/smart-search/index.ts
+++ b/supabase/functions/smart-search/index.ts
@@ -263,7 +263,7 @@ serve(async (req) => {
         coreCompetencies: row.core_competencies || row.metadata?.coreCompetencies || [],
         culturalHeritage: row.cultural_heritage || row.metadata?.culturalHeritage || [],
         locationRequirements: row.location_requirements || row.metadata?.locationRequirements || [],
-        activityType: row.metadata?.activityType || [],
+        activityType: row.activity_type || row.metadata?.activityType || [],
         lessonFormat: row.lesson_format || row.metadata?.lessonFormat || [],
         mainIngredients: row.main_ingredients || row.metadata?.mainIngredients || [],
         skills: row.metadata?.skills || [],


### PR DESCRIPTION
Fix: publish approved submissions + persist extracted title; update search mappings

Summary
- Persist Google Doc title at submission time and use it when publishing approved lessons.
- Publish approved lessons to base table columns (not the view) and ensure arrays + metadata are correctly set.
- Fix search mappings so base columns (e.g., activity_type) surface reliably in results.
- Provide SQL docs for RLS fixes, a title‑first batch publisher, and a one‑time title backfill.

Changes
- Edge Functions
  - process-submission: stores extracted_title alongside extracted_content in lesson_submissions.
  - smart-search: maps activityType from row.activity_type first, then falls back to metadata.
- Frontend
  - ReviewDetail.tsx: approve_new prefers submission.extracted_title → parsed title → fallback; writes directly to lessons with array columns set; keeps metadata JSON for compatibility.
  - useSearch.ts: fallback search now maps activityType from row.activity_type first.
- Scripts
  - scripts/backfill-publish-approved.ts: service‑role backfill for approved submissions (optional alternative to SQL function).
- DB Docs (run in Supabase dashboard)
  - 2025-09-01-publish-approved-rls.sql: RLS fixes for lessons/lesson_versions.
  - 2025-09-01-add-extracted-title-to-submissions.sql: adds lesson_submissions.extracted_title (+ optional backfill).
  - 2025-09-01-publish-approved-batch-v8.sql: robust SECURITY DEFINER publisher (title‑first, defensive JSON handling, season normalization).
  - 2025-09-01-backfill-lesson-titles-from-submissions.sql: one‑time fix for existing “Untitled Lesson” rows.
- Docs
  - docs/duplicate-detection-improvement-plan.md: planned improvements for duplicate detection.

Rollout
1) Apply RLS and extracted_title migrations.
2) Replace publisher with v8 and (optionally) backfill titles for existing rows.
3) Deploy Edge functions: process-submission and smart-search.
4) Validate by approving a new submission and confirming title/metadata appear correctly in search.

Validation
- New submissions: lesson_submissions.extracted_title is populated.
- Approve as new: lessons.title matches the Doc title (e.g., “Varenyky”).
- Search shows correct title and activity type.

Notes
- Earlier draft publisher docs are omitted from this PR to keep it tidy. Duplicate detection plan included for visibility.
