### PR TITLE
Fix: Separate metadata fields from search filters to maintain 11-filter compliance

### DIFF
--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -11,7 +11,7 @@ import {
   Monitor,
   FileCode,
 } from 'lucide-react';
-import { FILTER_CONFIGS } from '../utils/filterDefinitions';
+import { ALL_FIELD_CONFIGS } from '../utils/filterDefinitions';
 import { logger } from '../utils/logger';
 import CreatableSelect from 'react-select/creatable';
 import type { ReviewMetadata } from '../types';
@@ -848,7 +848,7 @@ export function ReviewDetail() {
                     aria-invalid={validationErrors.includes('Activity Type') ? 'true' : 'false'}
                   >
                     <option value="">Select activity type</option>
-                    {FILTER_CONFIGS.activityType.options.map((opt) => (
+                    {ALL_FIELD_CONFIGS.activityType.options.map((opt) => (
                       <option key={opt.value} value={opt.value}>
                         {opt.label}
                       </option>
@@ -879,7 +879,7 @@ export function ReviewDetail() {
                     aria-invalid={validationErrors.includes('Location') ? 'true' : 'false'}
                   >
                     <option value="">Select location</option>
-                    {FILTER_CONFIGS.location.options.map((opt) => (
+                    {ALL_FIELD_CONFIGS.location.options.map((opt) => (
                       <option key={opt.value} value={opt.value}>
                         {opt.label}
                       </option>
@@ -896,7 +896,7 @@ export function ReviewDetail() {
                     className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2"
                     aria-label="Grade level selection"
                   >
-                    {FILTER_CONFIGS.gradeLevel.options.map((grade) => (
+                    {ALL_FIELD_CONFIGS.gradeLevel.options.map((grade) => (
                       <label key={grade.value} className="flex items-center">
                         <input
                           type="checkbox"
@@ -922,7 +922,7 @@ export function ReviewDetail() {
                     Thematic Categories *
                   </label>
                   <div className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2">
-                    {FILTER_CONFIGS.theme.options.map((theme) => (
+                    {ALL_FIELD_CONFIGS.theme.options.map((theme) => (
                       <label key={theme.value} className="flex items-center">
                         <input
                           type="checkbox"
@@ -948,7 +948,7 @@ export function ReviewDetail() {
                     Season & Timing *
                   </label>
                   <div className="border border-gray-300 rounded-md p-3 space-y-2">
-                    {FILTER_CONFIGS.seasonTiming.options.map((season) => (
+                    {ALL_FIELD_CONFIGS.seasonTiming.options.map((season) => (
                       <label key={season.value} className="flex items-center">
                         <input
                           type="checkbox"
@@ -974,7 +974,7 @@ export function ReviewDetail() {
                     Core Competencies *
                   </label>
                   <div className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2">
-                    {FILTER_CONFIGS.coreCompetencies.options.map((competency) => (
+                    {ALL_FIELD_CONFIGS.coreCompetencies.options.map((competency) => (
                       <label key={competency.value} className="flex items-center">
                         <input
                           type="checkbox"
@@ -1000,7 +1000,7 @@ export function ReviewDetail() {
                     Social-Emotional Learning *
                   </label>
                   <div className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2">
-                    {FILTER_CONFIGS.socialEmotionalLearning.options.map((sel) => (
+                    {ALL_FIELD_CONFIGS.socialEmotionalLearning.options.map((sel) => (
                       <label key={sel.value} className="flex items-center">
                         <input
                           type="checkbox"
@@ -1027,7 +1027,7 @@ export function ReviewDetail() {
                       Cooking Methods *
                     </label>
                     <div className="space-y-2 border border-gray-200 rounded-md p-2">
-                      {FILTER_CONFIGS.cookingMethods.options.map((method) => (
+                      {ALL_FIELD_CONFIGS.cookingMethods.options.map((method) => (
                         <label key={method.value} className="flex items-center">
                           <input
                             type="checkbox"
@@ -1062,7 +1062,7 @@ export function ReviewDetail() {
                             <div className="font-medium text-xs text-gray-600 mt-2 mb-1">
                               {category}
                             </div>
-                            {FILTER_CONFIGS.mainIngredients.options
+                            {ALL_FIELD_CONFIGS.mainIngredients.options
                               .filter((ingredient) => ingredient.category === category)
                               .map((ingredient) => (
                                 <label key={ingredient.value} className="flex items-center ml-2">
@@ -1097,7 +1097,7 @@ export function ReviewDetail() {
                       Garden Skills *
                     </label>
                     <div className="space-y-2 max-h-48 overflow-y-auto border border-gray-200 rounded-md p-2">
-                      {FILTER_CONFIGS.gardenSkills.options.map((skill) => (
+                      {ALL_FIELD_CONFIGS.gardenSkills.options.map((skill) => (
                         <label key={skill.value} className="flex items-center">
                           <input
                             type="checkbox"
@@ -1131,7 +1131,7 @@ export function ReviewDetail() {
                           <div className="font-medium text-xs text-gray-600 mt-2 mb-1">
                             {category}
                           </div>
-                          {FILTER_CONFIGS.cookingSkills.options
+                          {ALL_FIELD_CONFIGS.cookingSkills.options
                             .filter((skill) => skill.category === category)
                             .map((skill) => (
                               <label key={skill.value} className="flex items-center ml-2">
@@ -1169,7 +1169,7 @@ export function ReviewDetail() {
                       Cultural Heritage
                     </label>
                     <div className="space-y-2 max-h-48 overflow-y-auto border border-gray-200 rounded-md p-2">
-                      {FILTER_CONFIGS.culturalHeritage.options.map((heritage) => (
+                      {ALL_FIELD_CONFIGS.culturalHeritage.options.map((heritage) => (
                         <div key={heritage.value}>
                           <label className="flex items-center font-medium">
                             <input
@@ -1234,7 +1234,7 @@ export function ReviewDetail() {
                       className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
                     >
                       <option value="">Select lesson format</option>
-                      {FILTER_CONFIGS.lessonFormat.options.map((opt) => (
+                      {ALL_FIELD_CONFIGS.lessonFormat.options.map((opt) => (
                         <option key={opt.value} value={opt.value}>
                           {opt.label}
                         </option>
@@ -1248,7 +1248,7 @@ export function ReviewDetail() {
                       Academic Integration
                     </label>
                     <div className="space-y-2 max-h-32 overflow-y-auto border border-gray-200 rounded-md p-2">
-                      {FILTER_CONFIGS.academicIntegration.options.map((subject) => (
+                      {ALL_FIELD_CONFIGS.academicIntegration.options.map((subject) => (
                         <label key={subject.value} className="flex items-center">
                           <input
                             type="checkbox"
@@ -1285,7 +1285,7 @@ export function ReviewDetail() {
                       <CreatableSelect
                         isMulti
                         isClearable
-                        options={FILTER_CONFIGS.observancesHolidays.options}
+                        options={ALL_FIELD_CONFIGS.observancesHolidays.options}
                         value={(metadata.observancesHolidays || []).map((v: string) => ({
                           value: v,
                           label: v,
@@ -1323,7 +1323,7 @@ export function ReviewDetail() {
                       <CreatableSelect
                         isMulti
                         isClearable
-                        options={FILTER_CONFIGS.culturalResponsivenessFeatures.options}
+                        options={ALL_FIELD_CONFIGS.culturalResponsivenessFeatures.options}
                         value={(metadata.culturalResponsivenessFeatures || []).map((v: string) => ({
                           value: v,
                           label: v,

--- a/src/utils/filterDefinitions.test.ts
+++ b/src/utils/filterDefinitions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { FILTER_CONFIGS, FILTER_KEYS, METADATA_CONFIGS, METADATA_KEYS } from './filterDefinitions';
+
+describe('Filter Definitions Compliance', () => {
+  describe('ESYNYC 11-Filter Requirement', () => {
+    it('should have EXACTLY 11 filters in FILTER_CONFIGS', () => {
+      const filterCount = Object.keys(FILTER_CONFIGS).length;
+      expect(filterCount).toBe(11);
+    });
+
+    it('should have the correct 11 filters as specified in CLAUDE.md', () => {
+      const requiredFilters = [
+        'activityType',
+        'location',
+        'gradeLevel',
+        'theme',
+        'seasonTiming',
+        'coreCompetencies',
+        'culturalHeritage',
+        'lessonFormat',
+        'academicIntegration',
+        'socialEmotionalLearning',
+        'cookingMethods',
+      ];
+
+      const actualFilters = Object.keys(FILTER_CONFIGS);
+
+      // Check that we have exactly the required filters, no more, no less
+      expect(actualFilters.sort()).toEqual(requiredFilters.sort());
+    });
+
+    it('should have FILTER_KEYS match FILTER_CONFIGS keys', () => {
+      expect(FILTER_KEYS.length).toBe(11);
+      expect(FILTER_KEYS.sort()).toEqual(Object.keys(FILTER_CONFIGS).sort());
+    });
+  });
+
+  describe('Metadata Fields', () => {
+    it('should have metadata fields separated from filters', () => {
+      const expectedMetadataFields = [
+        'mainIngredients',
+        'gardenSkills',
+        'cookingSkills',
+        'observancesHolidays',
+        'culturalResponsivenessFeatures',
+      ];
+
+      const actualMetadataFields = Object.keys(METADATA_CONFIGS);
+      expect(actualMetadataFields.sort()).toEqual(expectedMetadataFields.sort());
+    });
+
+    it('should have METADATA_KEYS match METADATA_CONFIGS keys', () => {
+      expect(METADATA_KEYS.sort()).toEqual(Object.keys(METADATA_CONFIGS).sort());
+    });
+
+    it('should not have any overlap between filters and metadata', () => {
+      const filterKeys = Object.keys(FILTER_CONFIGS);
+      const metadataKeys = Object.keys(METADATA_CONFIGS);
+
+      const overlap = filterKeys.filter((key) => metadataKeys.includes(key));
+      expect(overlap).toEqual([]);
+    });
+  });
+
+  describe('Filter Types', () => {
+    it('should have correct filter types for each filter', () => {
+      // Single-select filters
+      expect(FILTER_CONFIGS.activityType.type).toBe('single');
+      expect(FILTER_CONFIGS.location.type).toBe('single');
+      expect(FILTER_CONFIGS.lessonFormat.type).toBe('single');
+
+      // Multiple-select filters
+      expect(FILTER_CONFIGS.gradeLevel.type).toBe('multiple');
+      expect(FILTER_CONFIGS.theme.type).toBe('multiple');
+      expect(FILTER_CONFIGS.seasonTiming.type).toBe('multiple');
+      expect(FILTER_CONFIGS.coreCompetencies.type).toBe('multiple');
+      expect(FILTER_CONFIGS.academicIntegration.type).toBe('multiple');
+      expect(FILTER_CONFIGS.socialEmotionalLearning.type).toBe('multiple');
+      expect(FILTER_CONFIGS.cookingMethods.type).toBe('multiple');
+
+      // Hierarchical filter
+      expect(FILTER_CONFIGS.culturalHeritage.type).toBe('hierarchical');
+    });
+  });
+
+  describe('Critical Filter Validation', () => {
+    it('should never exceed 11 filters (CRITICAL RULE)', () => {
+      // This test will fail if anyone adds a 12th filter
+      const filterCount = Object.keys(FILTER_CONFIGS).length;
+      expect(filterCount).toBeLessThanOrEqual(11);
+      expect(filterCount).toBeGreaterThanOrEqual(11);
+
+      // Double-check with explicit assertion
+      if (filterCount !== 11) {
+        throw new Error(
+          `CRITICAL VIOLATION: Filter count is ${filterCount}, must be EXACTLY 11. ` +
+            `This violates ESYNYC requirements specified in CLAUDE.md.`
+        );
+      }
+    });
+
+    it('should not include metadata fields in FILTER_CONFIGS', () => {
+      const filterKeys = Object.keys(FILTER_CONFIGS);
+      const metadataFieldNames = [
+        'mainIngredients',
+        'gardenSkills',
+        'cookingSkills',
+        'observancesHolidays',
+        'culturalResponsivenessFeatures',
+      ];
+
+      metadataFieldNames.forEach((field) => {
+        expect(filterKeys).not.toContain(field);
+      });
+    });
+  });
+});

--- a/src/utils/filterDefinitions.ts
+++ b/src/utils/filterDefinitions.ts
@@ -17,7 +17,8 @@ interface FilterConfig {
   }>;
 }
 
-// Filter configurations for the 11 filters
+// Filter configurations for EXACTLY 11 filters used in search
+// CRITICAL: Must maintain exactly 11 filters per ESYNYC requirements
 export const FILTER_CONFIGS: Record<string, FilterConfig> = {
   activityType: {
     label: 'Activity Type',
@@ -198,7 +199,11 @@ export const FILTER_CONFIGS: Record<string, FilterConfig> = {
       { value: 'oven', label: 'Oven' },
     ],
   },
+};
 
+// Metadata fields used in review/submission process (NOT search filters)
+// These are used for lesson data enrichment but not exposed as search filters
+export const METADATA_CONFIGS: Record<string, FilterConfig> = {
   // Additional metadata fields for review process
   mainIngredients: {
     label: 'Main Ingredients',
@@ -384,3 +389,13 @@ export const FILTER_CONFIGS: Record<string, FilterConfig> = {
 
 // Export filter keys for easy iteration
 export const FILTER_KEYS = Object.keys(FILTER_CONFIGS) as Array<keyof typeof FILTER_CONFIGS>;
+
+// Export metadata keys separately
+export const METADATA_KEYS = Object.keys(METADATA_CONFIGS) as Array<keyof typeof METADATA_CONFIGS>;
+
+// Combined configs for backward compatibility in review forms
+// WARNING: Do not use this for search filters!
+export const ALL_FIELD_CONFIGS = {
+  ...FILTER_CONFIGS,
+  ...METADATA_CONFIGS,
+};


### PR DESCRIPTION
## Fixes #218

## Summary
This PR resolves the filter count violation by properly separating search filters from metadata fields. The codebase now maintains EXACTLY 11 search filters as required by ESYNYC, with metadata fields stored separately.

## Problem
- FILTER_CONFIGS contained 16 entries instead of the required 11
- The extra 5 fields were metadata fields used in review/submission process, not search filters
- This violated the critical ESYNYC requirement documented in CLAUDE.md

## Solution
- Split FILTER_CONFIGS into two separate objects:
  - **FILTER_CONFIGS**: Contains EXACTLY 11 search filters
  - **METADATA_CONFIGS**: Contains 5 metadata fields for review process
- Created **ALL_FIELD_CONFIGS** for backward compatibility
- Updated ReviewDetail.tsx to use ALL_FIELD_CONFIGS (since it needs both filters and metadata)
- Added comprehensive test suite to enforce the 11-filter limit

## The 11 Required Filters
1. activityType
2. location  
3. gradeLevel
4. theme
5. seasonTiming
6. coreCompetencies
7. culturalHeritage
8. lessonFormat
9. academicIntegration
10. socialEmotionalLearning
11. cookingMethods

## The 5 Metadata Fields (NOT search filters)
- mainIngredients
- gardenSkills
- cookingSkills
- observancesHolidays
- culturalResponsivenessFeatures

## Testing
- ✅ Added comprehensive test suite with 9 tests
- ✅ All tests passing
- ✅ TypeScript compilation passing
- ✅ Critical validation test will fail if anyone adds a 12th filter

## Impact
- Search functionality unchanged (still uses only 11 filters)
- Review/submission forms still have access to all fields via ALL_FIELD_CONFIGS
- Clear separation between search filters and metadata fields
- Automated enforcement of 11-filter limit going forward