### PR TITLE
Phase 1B — Search Invalidation + Cache-Key Tests

### DIFF
--- a/docs/PRs/phase-1b-invalidation-tests.md
+++ b/docs/PRs/phase-1b-invalidation-tests.md
@@ -1,0 +1,36 @@
+Title: Phase 1B — Search Invalidation + Cache-Key Tests
+
+Summary
+- Add integration tests to ensure the unified `useLessonSearch` + `SearchPage` correctly:
+  - Resets pagination to page 0 and refetches when filters change.
+  - Uses distinct React Query cache keys when `resultsPerPage` changes (page size), refetching with `page_offset = 0`.
+
+Scope
+- Tests only; no production logic changes.
+- Files added:
+  - `src/__tests__/integration/lesson-search.invalidation.test.tsx`
+
+Test Plan
+- Filter-change invalidation:
+  1) Render `SearchPage` with `resultsPerPage = 2`, return 2 items.
+  2) Trigger load-more (moves to offset 2).
+  3) Call `useSearchStore.getState().setFilters({ gradeLevels: ['5'] })`.
+  4) Expect a new RPC call with `page_offset = 0` and `filter_grade_levels = ['5']`; verify new results render.
+
+- Cache-key isolation (page size):
+  1) Render `SearchPage` with `resultsPerPage = 2`, return 2 items.
+  2) Change view state to `resultsPerPage = 3`.
+  3) Expect a new RPC call with `page_size = 3` and `page_offset = 0`; verify 3 results render.
+
+How to Run
+- `npm run test` (or `pnpm test`) — uses Vitest + RTL.
+- Tests mock `supabase.rpc` via `@/lib/supabase`.
+
+Risks
+- None to production code; tests assume `getSearchRpcName()` returns `'search_lessons'`.
+
+Checklist
+- [x] Tests added and pass locally
+- [ ] CI green
+- [ ] PR reviewed and merged
+

--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -46,8 +46,10 @@ This section is a living checklist to track cleanup progress. Do not remove prio
   - [x] Move results ownership to React Query (store keeps filters/view only)
   - [ ] Add/adjust tests (paging, filters, suggestions)
     - [x] Paging (initial + load more) and error path
-    - [ ] Filter-change invalidation
-    - [ ] Suggestions integration (pending decision: unify or keep separate)
+    - [x] Filter-change invalidation (Phase 1B)
+    - [x] Cache-key isolation when page size changes (Phase 1B)
+    - [x] Suggestions: click applies query and refetches (Phase 1B)
+    - [ ] Suggestions path unification decision (Phase 1C)
 
 - [ ] Phase 2 — Filter Definitions & Type Cleanups
   - [ ] Consolidate filter options into `src/utils/filterDefinitions.ts`
@@ -89,9 +91,11 @@ This section is a living checklist to track cleanup progress. Do not remove prio
 
 Recent Notes
 - 2025‑09‑01: Phase 0 completed. Added RPC switch, env flags, baseline DB snapshot + plans.
+- 2025‑09‑01: Phase 1A merged; CI green after cache‑key + typing fixes.
+- 2025‑09‑01: Phase 1B in progress — added invalidation, cache‑key, and suggestions integration tests; preparing PR.
 
 Next Planned Actions
-- Begin Phase 1: Implement `useLessonSearch` with `useInfiniteQuery`, refactor `SearchPage`, and trim store ownership of results.
+- Phase 1B: Open PR including invalidation, cache-key, and suggestions tests; address CI.
 
 ======================================================================
 

--- a/src/__tests__/integration/lesson-search.invalidation.test.tsx
+++ b/src/__tests__/integration/lesson-search.invalidation.test.tsx
@@ -1,0 +1,296 @@
+import React, { act } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock Supabase client
+const rpcMock = vi.fn();
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: any[]) => rpcMock(...args),
+  },
+}));
+
+// Import after mocks
+import { SearchPage } from '@/pages/SearchPage';
+import { useSearchStore } from '@/stores/searchStore';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+describe('Search invalidation and cache-key isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset store to defaults
+    const store = useSearchStore.getState();
+    store.clearFilters();
+    store.setViewState({ resultsPerPage: 2 });
+  });
+
+  it('resets to first page and refetches when filters change', async () => {
+    // 1) Initial page (2 results)
+    rpcMock
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'L1',
+            title: 'Lesson One',
+            summary: 'Summary 1',
+            file_link: '#',
+            grade_levels: ['3'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.9 },
+            total_count: 4,
+          },
+          {
+            lesson_id: 'L2',
+            title: 'Lesson Two',
+            summary: 'Summary 2',
+            file_link: '#',
+            grade_levels: ['4'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.8 },
+            total_count: 4,
+          },
+        ],
+        error: null,
+      })
+      // 2) Load-more page (1 result)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'L3',
+            title: 'Lesson Three',
+            summary: 'Summary 3',
+            file_link: '#',
+            grade_levels: ['5'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.7 },
+            total_count: 4,
+          },
+        ],
+        error: null,
+      })
+      // 3) After filters change, reset to first page (new dataset)
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'LF1',
+            title: 'Filtered One',
+            summary: 'Filtered Summary 1',
+            file_link: '#',
+            grade_levels: ['5'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.95 },
+            total_count: 2,
+          },
+          {
+            lesson_id: 'LF2',
+            title: 'Filtered Two',
+            summary: 'Filtered Summary 2',
+            file_link: '#',
+            grade_levels: ['5'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.9 },
+            total_count: 2,
+          },
+        ],
+        error: null,
+      });
+
+    renderWithProviders(<SearchPage />);
+
+    // Initial results are shown
+    await waitFor(() => {
+      expect(screen.getByText('Lesson One')).toBeInTheDocument();
+      expect(screen.getByText('Lesson Two')).toBeInTheDocument();
+    });
+
+    // Load more to move to page 1 (offset 2)
+    const user = userEvent.setup();
+    const loadMoreBtn = await screen.findByRole('button', { name: /load more results/i });
+    await user.click(loadMoreBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson Three')).toBeInTheDocument();
+    });
+
+    // Now change filters via store – e.g., set gradeLevels to ['5']
+    const store = useSearchStore.getState();
+    await act(async () => {
+      store.setFilters({ gradeLevels: ['5'] });
+    });
+
+    // After filter change, the next RPC call should be for page 0 with new filters
+    await waitFor(() => {
+      // Three calls total: initial, load more, after filter change
+      expect(rpcMock).toHaveBeenCalledTimes(3);
+    });
+
+    const thirdCall = rpcMock.mock.calls[2];
+    // arg[0] is RPC name, arg[1] is params
+    expect(thirdCall[0]).toMatch(/search_lessons/);
+    expect(thirdCall[1].page_offset).toBe(0);
+    expect(thirdCall[1].filter_grade_levels).toEqual(['5']);
+
+    // UI should show the filtered dataset
+    await waitFor(() => {
+      expect(screen.getByText('Filtered One')).toBeInTheDocument();
+      expect(screen.getByText('Filtered Two')).toBeInTheDocument();
+    });
+  });
+
+  it('uses a separate cache key when page size changes (triggers refetch with new size)', async () => {
+    // First call with pageSize 2
+    rpcMock
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'L1',
+            title: 'Lesson One',
+            summary: 'Summary 1',
+            file_link: '#',
+            grade_levels: ['3'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.9 },
+            total_count: 5,
+          },
+          {
+            lesson_id: 'L2',
+            title: 'Lesson Two',
+            summary: 'Summary 2',
+            file_link: '#',
+            grade_levels: ['4'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.8 },
+            total_count: 5,
+          },
+        ],
+        error: null,
+      })
+      // Second call after page size change to 3
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'L3',
+            title: 'Lesson Three',
+            summary: 'Summary 3',
+            file_link: '#',
+            grade_levels: ['5'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.7 },
+            total_count: 5,
+          },
+          {
+            lesson_id: 'L4',
+            title: 'Lesson Four',
+            summary: 'Summary 4',
+            file_link: '#',
+            grade_levels: ['6'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.6 },
+            total_count: 5,
+          },
+          {
+            lesson_id: 'L5',
+            title: 'Lesson Five',
+            summary: 'Summary 5',
+            file_link: '#',
+            grade_levels: ['7'],
+            metadata: {
+              coreCompetencies: [],
+              culturalHeritage: [],
+              activityType: [],
+              lessonFormat: [],
+            },
+            confidence: { overall: 0.5 },
+            total_count: 5,
+          },
+        ],
+        error: null,
+      });
+
+    renderWithProviders(<SearchPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson One')).toBeInTheDocument();
+      expect(screen.getByText('Lesson Two')).toBeInTheDocument();
+    });
+
+    // Change resultsPerPage from 2 to 3
+    const store = useSearchStore.getState();
+    await act(async () => {
+      store.setViewState({ resultsPerPage: 3 });
+    });
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledTimes(2);
+    });
+
+    const secondCall = rpcMock.mock.calls[1];
+    expect(secondCall[0]).toMatch(/search_lessons/);
+    expect(secondCall[1].page_offset).toBe(0);
+    expect(secondCall[1].page_size).toBe(3);
+
+    await waitFor(() => {
+      expect(screen.getByText('Lesson Three')).toBeInTheDocument();
+      expect(screen.getByText('Lesson Four')).toBeInTheDocument();
+      expect(screen.getByText('Lesson Five')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/integration/lesson-search.suggestions.test.tsx
+++ b/src/__tests__/integration/lesson-search.suggestions.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock Supabase client
+const rpcMock = vi.fn();
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: any[]) => rpcMock(...args),
+  },
+}));
+
+// Mock suggestions hook to return suggestions
+vi.mock('@/hooks/useSearch', () => ({
+  useSearch: () => ({
+    data: { suggestions: ['garden planning'] },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+// Import after mocks
+import { SearchPage } from '@/pages/SearchPage';
+import { useSearchStore } from '@/stores/searchStore';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+describe('Search suggestions integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const store = useSearchStore.getState();
+    store.clearFilters();
+    store.setViewState({ resultsPerPage: 2 });
+  });
+
+  it('shows suggestions and applies one to trigger a new search', async () => {
+    // Initial call returns no results (simulate empty state)
+    rpcMock
+      .mockResolvedValueOnce({ data: [], error: null })
+      // After clicking suggestion, return a result
+      .mockResolvedValueOnce({
+        data: [
+          {
+            lesson_id: 'S1',
+            title: 'Garden Planning 101',
+            summary: 'Intro to garden planning',
+            file_link: '#',
+            grade_levels: ['5'],
+            metadata: { activityType: [], lessonFormat: [] },
+            confidence: { overall: 0.95 },
+            total_count: 1,
+          },
+        ],
+        error: null,
+      });
+
+    // Seed a query so suggestions are enabled
+    const store = useSearchStore.getState();
+    store.setFilters({ query: 'no-result' });
+
+    renderWithProviders(<SearchPage />);
+
+    // Ensure initial search executed with the original query
+    await waitFor(() => expect(rpcMock).toHaveBeenCalled());
+    const firstCall = rpcMock.mock.calls[0];
+    expect(firstCall[1].search_query).toBe('no-result');
+
+    // Suggestions are visible
+    expect(
+      screen.getByText(/no results found\. try these suggestions:/i)
+    ).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    const suggestionBtn = screen.getByRole('button', { name: 'garden planning' });
+    await user.click(suggestionBtn);
+
+    // After clicking suggestion, a new RPC call is made with updated query
+    await waitFor(() => expect(rpcMock).toHaveBeenCalledTimes(2));
+    const secondCall = rpcMock.mock.calls[1];
+    expect(secondCall[1].search_query).toBe('garden planning');
+    expect(secondCall[1].page_offset).toBe(0);
+
+    // UI shows the new result
+    await waitFor(() => {
+      expect(screen.getByText('Garden Planning 101')).toBeInTheDocument();
+    });
+  });
+});
+


### PR DESCRIPTION
Title: Phase 1B — Search Invalidation + Cache-Key Tests

Summary
- Add integration tests to ensure the unified `useLessonSearch` + `SearchPage` correctly:
  - Resets pagination to page 0 and refetches when filters change.
  - Uses distinct React Query cache keys when `resultsPerPage` changes (page size), refetching with `page_offset = 0`.

Scope
- Tests only; no production logic changes.
- Files added:
  - `src/__tests__/integration/lesson-search.invalidation.test.tsx`

Test Plan
- Filter-change invalidation:
  1) Render `SearchPage` with `resultsPerPage = 2`, return 2 items.
  2) Trigger load-more (moves to offset 2).
  3) Call `useSearchStore.getState().setFilters({ gradeLevels: ['5'] })`.
  4) Expect a new RPC call with `page_offset = 0` and `filter_grade_levels = ['5']`; verify new results render.

- Cache-key isolation (page size):
  1) Render `SearchPage` with `resultsPerPage = 2`, return 2 items.
  2) Change view state to `resultsPerPage = 3`.
  3) Expect a new RPC call with `page_size = 3` and `page_offset = 0`; verify 3 results render.

How to Run
- `npm run test` (or `pnpm test`) — uses Vitest + RTL.
- Tests mock `supabase.rpc` via `@/lib/supabase`.

Risks
- None to production code; tests assume `getSearchRpcName()` returns `'search_lessons'`.

Checklist
- [x] Tests added and pass locally
- [ ] CI green
- [ ] PR reviewed and merged

