### PR TITLE
Phase 1C — Suggestions Path Unification

### DIFF
--- a/docs/PRs/phase-1c-suggestions-unification.md
+++ b/docs/PRs/phase-1c-suggestions-unification.md
@@ -1,0 +1,33 @@
+Title: Phase 1C — Suggestions Path Unification
+
+Summary
+- Centralize suggestions into a dedicated React Query hook and render them from the results area when there are no results, reducing coupling and legacy code.
+
+Decision
+- Add `useLessonSuggestions` that calls the smart-search Edge Function and returns `{ suggestions, expandedQuery? }`.
+- Render suggestions in `SearchPage` only when `filters.query` is non-empty AND current `totalCount === 0`.
+- Deprecate `useSearch` (remove in Phase 3). Remove client-side fallback for suggestions.
+
+Scope
+- New: `src/hooks/useLessonSuggestions.ts`
+- Update: `src/pages/SearchPage.tsx` (results area renders suggestions panel)
+- Update: `src/components/Search/SearchBar.tsx` (remove dynamic suggestions block; keep quick searches)
+- Types: add a small response type for smart-search
+- Optional: env flag `VITE_ENABLE_SUGGESTIONS_V2`
+
+Acceptance Criteria
+- Suggestions appear only when no results for the current query; clicking a suggestion updates the query and refetches page 0.
+- Suggestions are not shown if results exist.
+- Edge Function error → suggestions hidden; no console noise.
+- React Query cache keys include sanitized query + filters; no cross-contamination with list cache.
+
+Test Plan
+- Update integration tests to validate suggestions in the results area:
+  - No results → suggestions shown; clicking refetches and renders new results.
+  - Results exist → suggestions not shown.
+  - Edge Function failure → no suggestions rendered (already covered by `lesson-search.suggestions.error.test.tsx`).
+- Adjust SearchBar tests to focus on quick searches (static chips) and input behavior.
+
+Risks
+- Minor UI shift (panel location). Behavior clearer and more reliable. No production DB changes.
+

--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -49,7 +49,7 @@ This section is a living checklist to track cleanup progress. Do not remove prio
     - [x] Filter-change invalidation (Phase 1B)
     - [x] Cache-key isolation when page size changes (Phase 1B)
     - [x] Suggestions: click applies query and refetches (Phase 1B)
-    - [ ] Suggestions path unification decision (Phase 1C)
+    - [ ] Suggestions path unification (Phase 1C)
 
 - [ ] Phase 2 — Filter Definitions & Type Cleanups
   - [ ] Consolidate filter options into `src/utils/filterDefinitions.ts`
@@ -98,9 +98,61 @@ Recent Notes
   - Follow-up branch: `feat/tests-consistency-phase-1b1` (tests-only consistency + suggestions error-path).
 
 Next Planned Actions
-- Open PR for Phase 1B.1 follow-up (tests consistency + error-path) and merge.
-- Phase 1C: Decide on suggestions path unification; scope small UI/logic changes accordingly.
+- Phase 1B.1: PR opened and merged — keep tests tidy going forward.
+- Phase 1C: Unify suggestions path and rendering. See plan below.
 
+--------------------------------------------------------------------
+
+Phase 1C — Suggestions Path Unification (Plan)
+
+Goals
+- One clear suggestions pathway powered by React Query.
+- Avoid fallback-heavy code in suggestions; keep UI logic simple and predictable.
+- Do not reintroduce server results into the Zustand store.
+
+Decision
+- Introduce a dedicated hook `useLessonSuggestions` that calls the smart-search Edge Function and returns `{ suggestions: string[], expandedQuery?: string }`.
+- Render suggestions from `SearchPage` (results area) only when `filters.query.trim()` is truthy AND `totalCount === 0` for the current results. This avoids coupling SearchBar to server results and prevents unnecessary state leakage back into the store.
+- Deprecate `useSearch` (keep temporarily; remove in Phase 3 alongside other legacy paths).
+- Remove the client-side `fallbackSearch` path for suggestions. On Edge Function error, show no suggestions (silent failure) and keep the UI clean.
+
+Implementation Outline
+- New: `src/hooks/useLessonSuggestions.ts`
+  - Inputs: `{ filters, enabled?: boolean }`
+  - Behavior: `enabled = !!filters.query?.trim()`; `staleTime = 5m`; `gcTime = 10m`
+  - RPC: `supabase.functions.invoke('smart-search', { body: { query, filters } })`
+  - Return: `{ suggestions, expandedQuery }`
+
+- Update `src/pages/SearchPage.tsx`
+  - Call `useLessonSuggestions({ filters, enabled: !!filters.query?.trim() })`.
+  - Render suggestions panel under ResultsHeader when `totalCount === 0 && suggestions.length > 0`.
+  - Keep Quick Searches UI unchanged in `SearchBar` (static chips).
+  - Remove dynamic suggestions UI from `SearchBar` to centralize logic near results.
+
+- Types & Flags
+  - Optional feature flag: `VITE_ENABLE_SUGGESTIONS_V2` (on by default) in `.env.*` to allow rollback if needed.
+  - Add a light TS type for Edge Function response to avoid `any`.
+
+Testing (acceptance criteria)
+- When no results are returned, suggestions appear with “No results found. Try these suggestions:”
+- Clicking a suggestion sets `filters.query` and triggers a new search from page 0.
+- When results exist, suggestions panel does not render.
+- If the Edge Function fails, suggestions panel does not render (no console noise).
+- Cache isolation: suggestions query key includes `filters.query` (sanitized) and filter selections.
+- No interference with pagination; suggestions do not alter React Query pages.
+
+Files to change
+- New: `src/hooks/useLessonSuggestions.ts`
+- Update: `src/pages/SearchPage.tsx` (render suggestions panel)
+- Update: `src/components/Search/SearchBar.tsx` (remove dynamic suggestions block)
+- Tests:
+  - Update/keep: `src/__tests__/integration/lesson-search.suggestions.test.tsx` (still valid; panel now in results area)
+  - Keep: `lesson-search.suggestions.error.test.tsx` (Edge Function failure covered)
+  - Adjust SearchBar tests to focus on static quick suggestions only.
+
+Rollout & Risks
+- Small UI movement (suggestions panel from SearchBar → Results area). Functional behavior remains identical or clearer.
+- Edge Function call remains; now isolated and typed; no heavy DB fallback.
 ======================================================================
 
 **Architecture Overview**

--- a/src/components/Search/SearchBar.test.tsx
+++ b/src/components/Search/SearchBar.test.tsx
@@ -4,11 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchBar } from './SearchBar';
 import { useSearchStore } from '@/stores/searchStore';
-import { useSearch } from '@/hooks/useSearch';
 
 // Mock the stores and hooks
 vi.mock('@/stores/searchStore');
-vi.mock('@/hooks/useSearch');
+// Suggestions moved to SearchPage; no dynamic suggestions from SearchBar
 vi.mock('@/utils/debounce', () => ({
   debounce: (fn: any) => fn,
 }));
@@ -32,11 +31,7 @@ describe('SearchBar', () => {
       setFilters: mockSetFilters,
     });
 
-    (useSearch as any).mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: null,
-    });
+    // No suggestions hook needed for SearchBar tests
   });
 
   const renderComponent = () => {
@@ -155,57 +150,7 @@ describe('SearchBar', () => {
     });
   });
 
-  describe('Search Suggestions', () => {
-    it('should display suggestions when no results found', () => {
-      (useSearch as any).mockReturnValue({
-        data: {
-          suggestions: ['tomatoes', 'tomato sauce', 'cherry tomatoes'],
-        },
-        isLoading: false,
-        error: null,
-      });
-
-      renderComponent();
-
-      expect(screen.getByText(/no results found/i)).toBeInTheDocument();
-      expect(screen.getByText('tomatoes')).toBeInTheDocument();
-      expect(screen.getByText('tomato sauce')).toBeInTheDocument();
-      expect(screen.getByText('cherry tomatoes')).toBeInTheDocument();
-    });
-
-    it('should apply suggestion when clicked', async () => {
-      const user = userEvent.setup();
-      (useSearch as any).mockReturnValue({
-        data: {
-          suggestions: ['garden planning'],
-        },
-        isLoading: false,
-        error: null,
-      });
-
-      renderComponent();
-
-      const suggestionButton = screen.getByRole('button', { name: 'garden planning' });
-      await user.click(suggestionButton);
-
-      expect(mockSetFilters).toHaveBeenCalledWith({ query: 'garden planning' });
-    });
-
-    it('should not display suggestions when results exist', () => {
-      (useSearch as any).mockReturnValue({
-        data: {
-          results: [{ id: 1, title: 'Test' }],
-          suggestions: [],
-        },
-        isLoading: false,
-        error: null,
-      });
-
-      renderComponent();
-
-      expect(screen.queryByText(/no results found/i)).not.toBeInTheDocument();
-    });
-  });
+  // No dynamic suggestions section in SearchBar anymore; covered in SearchPage integration tests
 
   describe('Accessibility', () => {
     it('should have accessible label for search input', () => {

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Search, X, Lightbulb } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 import { useSearchStore } from '../../stores/searchStore';
-import { useSearch } from '../../hooks/useSearch';
 import { debounce } from '../../utils/debounce';
 
 export const SearchBar: React.FC = () => {
@@ -13,12 +12,7 @@ export const SearchBar: React.FC = () => {
     setLocalQuery(filters.query);
   }, [filters.query]);
 
-  // Get search results to show suggestions when no results found
-  const { data: searchResults } = useSearch({
-    filters,
-    enabled: !!filters.query.trim(),
-    limit: 5, // Limit for testing
-  });
+  // Suggestions are now rendered in SearchPage when no results exist.
 
   // Debounced search to avoid too many API calls
   const debouncedSearch = useCallback(
@@ -77,33 +71,7 @@ export const SearchBar: React.FC = () => {
           </div>
         </form>
 
-        {/* Search Suggestions */}
-        {searchResults?.suggestions && searchResults.suggestions.length > 0 && (
-          <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <div className="flex items-start space-x-2">
-              <Lightbulb className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
-              <div>
-                <p className="text-sm font-medium text-blue-900 mb-2">
-                  No results found. Try these suggestions:
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {searchResults.suggestions.map((suggestion, index) => (
-                    <button
-                      key={index}
-                      onClick={() => {
-                        setLocalQuery(suggestion);
-                        setFilters({ query: suggestion });
-                      }}
-                      className="px-3 py-1 text-sm bg-blue-100 text-blue-800 rounded-full hover:bg-blue-200 transition-colors"
-                    >
-                      {suggestion}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        {/* Suggestions removed from SearchBar; shown in SearchPage when no results */}
 
         {/* Quick Search Suggestions */}
         <div className="mt-6 flex flex-wrap items-center gap-3">

--- a/src/hooks/useLessonSuggestions.ts
+++ b/src/hooks/useLessonSuggestions.ts
@@ -1,0 +1,75 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+import type { SearchFilters } from '@/types';
+
+interface SuggestionResponse {
+  suggestions: string[];
+  expandedQuery?: string;
+}
+
+interface UseLessonSuggestionsOptions {
+  filters: SearchFilters;
+  enabled?: boolean;
+}
+
+export function useLessonSuggestions({
+  filters,
+  enabled = true,
+}: UseLessonSuggestionsOptions) {
+  const query = (filters.query || '').trim();
+  const isEnabled = enabled && query.length > 0;
+
+  return useQuery<SuggestionResponse, Error>({
+    queryKey: [
+      'lesson-suggestions',
+      query,
+      // include relevant filters to avoid stale suggestions when filters impact suggestions later
+      filters.gradeLevels,
+      filters.thematicCategories,
+      filters.seasonTiming,
+      filters.coreCompetencies,
+      filters.culturalHeritage,
+      filters.location,
+      filters.activityType,
+      filters.lessonFormat,
+      filters.academicIntegration,
+      filters.socialEmotionalLearning,
+      filters.cookingMethods,
+    ],
+    enabled: isEnabled,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    queryFn: async () => {
+      const { data, error } = await supabase.functions.invoke('smart-search', {
+        body: {
+          query,
+          filters: {
+            gradeLevels: filters.gradeLevels,
+            thematicCategories: filters.thematicCategories,
+            seasonTiming: filters.seasonTiming,
+            coreCompetencies: filters.coreCompetencies,
+            culturalHeritage: filters.culturalHeritage,
+            location: filters.location,
+            activityType: filters.activityType,
+            lessonFormat: filters.lessonFormat,
+          },
+          // no need for paging here; we only need suggestions
+          limit: 0,
+        },
+      });
+
+      if (error) {
+        // Hide suggestions on error; keep UI quiet
+        return { suggestions: [] };
+      }
+
+      return {
+        suggestions: Array.isArray((data as any)?.suggestions)
+          ? ((data as any).suggestions as string[])
+          : [],
+        expandedQuery: (data as any)?.expandedQuery,
+      };
+    },
+  });
+}
+

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -11,6 +11,8 @@ import { SkipLink } from '../components/Common/SkipLink';
 import { InfiniteScrollTrigger } from '../components/Common/InfiniteScrollTrigger';
 import { useSearchStore } from '../stores/searchStore';
 import { useLessonSearch } from '@/hooks/useLessonSearch';
+import { useLessonSuggestions } from '@/hooks/useLessonSuggestions';
+import { Lightbulb } from 'lucide-react';
 import type { Lesson, ViewState } from '../types';
 
 export const SearchPage: React.FC = () => {
@@ -26,6 +28,13 @@ export const SearchPage: React.FC = () => {
 
   const lessons = (data?.pages || []).flatMap((p) => p.lessons);
   const totalCount = data?.pages?.[0]?.totalCount || 0;
+
+  // Suggestions when there are no results
+  const { data: suggestionsData } = useLessonSuggestions({
+    filters,
+    enabled: !!filters.query?.trim(),
+  });
+  const suggestions = suggestionsData?.suggestions || [];
 
   // Load more handler for infinite scroll
   const handleLoadMore = useCallback(async () => {
@@ -86,6 +95,31 @@ export const SearchPage: React.FC = () => {
           onLessonClick={handleLessonClick}
           isLoading={isLoading}
         />
+
+        {/* Suggestions Panel when no results */}
+        {totalCount === 0 && !!filters.query?.trim() && suggestions.length > 0 && (
+          <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <div className="flex items-start space-x-2">
+              <Lightbulb className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
+              <div>
+                <p className="text-sm font-medium text-blue-900 mb-2">
+                  No results found. Try these suggestions:
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {suggestions.map((s, index) => (
+                    <button
+                      key={`${s}-${index}`}
+                      onClick={() => setFilters({ query: s })}
+                      className="px-3 py-1 text-sm bg-blue-100 text-blue-800 rounded-full hover:bg-blue-200 transition-colors"
+                    >
+                      {s}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Infinite Scroll Trigger */}
         {lessons.length > 0 && (


### PR DESCRIPTION
Title: Phase 1C — Suggestions Path Unification

Summary
- Centralize suggestions into a dedicated React Query hook and render them from the results area when there are no results, reducing coupling and legacy code.

Decision
- Add `useLessonSuggestions` that calls the smart-search Edge Function and returns `{ suggestions, expandedQuery? }`.
- Render suggestions in `SearchPage` only when `filters.query` is non-empty AND current `totalCount === 0`.
- Deprecate `useSearch` (remove in Phase 3). Remove client-side fallback for suggestions.

Scope
- New: `src/hooks/useLessonSuggestions.ts`
- Update: `src/pages/SearchPage.tsx` (results area renders suggestions panel)
- Update: `src/components/Search/SearchBar.tsx` (remove dynamic suggestions block; keep quick searches)
- Types: add a small response type for smart-search
- Optional: env flag `VITE_ENABLE_SUGGESTIONS_V2`

Acceptance Criteria
- Suggestions appear only when no results for the current query; clicking a suggestion updates the query and refetches page 0.
- Suggestions are not shown if results exist.
- Edge Function error → suggestions hidden; no console noise.
- React Query cache keys include sanitized query + filters; no cross-contamination with list cache.

Test Plan
- Update integration tests to validate suggestions in the results area:
  - No results → suggestions shown; clicking refetches and renders new results.
  - Results exist → suggestions not shown.
  - Edge Function failure → no suggestions rendered (already covered by `lesson-search.suggestions.error.test.tsx`).
- Adjust SearchBar tests to focus on quick searches (static chips) and input behavior.

Risks
- Minor UI shift (panel location). Behavior clearer and more reliable. No production DB changes.

