### PR TITLE
Phase 2A — lessonFormat Normalization + Pill Fixes

### DIFF
--- a/src/components/Common/ScreenReaderAnnouncer.tsx
+++ b/src/components/Common/ScreenReaderAnnouncer.tsx
@@ -22,8 +22,8 @@ export const ScreenReaderAnnouncer: React.FC = () => {
       activeFilters.push(`${filters.culturalHeritage.length} cultural heritage selections`);
     if (filters.coreCompetencies.length)
       activeFilters.push(`${filters.coreCompetencies.length} core competencies`);
-    if (filters.lessonFormat.length)
-      activeFilters.push(`lesson format: ${filters.lessonFormat[0]}`);
+    if (filters.lessonFormat)
+      activeFilters.push(`lesson format: ${filters.lessonFormat}`);
     if (filters.cookingMethods) activeFilters.push(`cooking method: ${filters.cookingMethods}`);
     if (filters.academicIntegration.length)
       activeFilters.push(`${filters.academicIntegration.length} academic subjects`);

--- a/src/components/Filters/FilterModal.tsx
+++ b/src/components/Filters/FilterModal.tsx
@@ -318,9 +318,9 @@ export const FilterModal = React.memo<FilterModalProps>(
                                 <h3 className="flex items-center gap-2 text-lg font-semibold text-gray-900">
                                   <span>📋</span>
                                   <span>Lesson Format</span>
-                                  {filters.lessonFormat.length > 0 && (
+                                  {filters.lessonFormat && (
                                     <span className="ml-2 text-sm font-normal text-gray-600">
-                                      ({filters.lessonFormat[0]})
+                                      ({filters.lessonFormat})
                                     </span>
                                   )}
                                 </h3>

--- a/src/components/Filters/FilterPills.tsx
+++ b/src/components/Filters/FilterPills.tsx
@@ -25,7 +25,6 @@ export const FilterPills: React.FC<FilterPillsProps> = ({ onAddFilters }) => {
       'culturalHeritage',
       'location',
       'activityType',
-      'lessonFormat',
       'academicIntegration',
       'socialEmotionalLearning',
     ];
@@ -42,6 +41,9 @@ export const FilterPills: React.FC<FilterPillsProps> = ({ onAddFilters }) => {
     // Handle single-value filters
     if (filters.cookingMethods) {
       pills.push({ category: 'cookingMethods', value: filters.cookingMethods });
+    }
+    if (filters.lessonFormat) {
+      pills.push({ category: 'lessonFormat', value: filters.lessonFormat });
     }
 
     return pills;
@@ -81,12 +83,22 @@ export const FilterPills: React.FC<FilterPillsProps> = ({ onAddFilters }) => {
 
         if (values.length === 1) {
           // Single value - use regular FilterPill
+          const value = values[0];
+          const onRemove = () => {
+            if (categoryKey === 'lessonFormat') {
+              setFilters({ lessonFormat: '' });
+            } else if (categoryKey === 'cookingMethods') {
+              setFilters({ cookingMethods: '' });
+            } else {
+              removeFilter(categoryKey, value);
+            }
+          };
           return (
             <FilterPill
-              key={`${category}-${values[0]}`}
+              key={`${category}-${value}`}
               category={category}
-              value={values[0]}
-              onRemove={() => removeFilter(categoryKey, values[0])}
+              value={value}
+              onRemove={onRemove}
             />
           );
         } else {

--- a/src/components/Filters/FilterSidebar.tsx
+++ b/src/components/Filters/FilterSidebar.tsx
@@ -373,7 +373,7 @@ export const FilterSidebar = React.memo<FilterSidebarProps>(
       filters.activityType.length +
       filters.location.length +
       filters.culturalHeritage.length +
-      (filters.lessonFormat.length > 0 ? 1 : 0) +
+      (filters.lessonFormat ? 1 : 0) +
       filters.academicIntegration.length +
       filters.socialEmotionalLearning.length +
       (filters.cookingMethods ? 1 : 0);


### PR DESCRIPTION
Title: Phase 2 — Filter Definitions Consolidation + lessonFormat Normalization

Summary
- Begin consolidating filter options to a single source (`src/utils/filterDefinitions.ts`) and normalize `lessonFormat` as a string across UI/pills/announcer.

Scope (this PR)
- Normalize `lessonFormat` handling in UI:
  - `ScreenReaderAnnouncer`: treat `lessonFormat` as string
  - `FilterPills`: handle `lessonFormat` as single-value pill (proper removal)
  - `FilterModal`/`FilterSidebar`: fix header/count checks to use string semantics
- Leave metadata `lessonFormat` untouched (still string[] in LessonMetadata) — only the filters remain single-select string.
- Note: full consolidation of all filter options to `filterDefinitions.ts` will follow in 2B; this PR starts with correctness and UX fixes for `lessonFormat`.

Acceptance Criteria
- Removing the `lessonFormat` pill clears it correctly (no-op previously)
- Screen reader announcement uses the selected `lessonFormat` value (not array index)
- Active filter counts and headers reflect `lessonFormat` correctly
- Tests and builds stay green

Out of scope (to be done in Phase 2B)
- Replace ad hoc constants in `FilterModal`/`FilterSidebar` with values from `filterDefinitions.ts`
- Migrate all filter option sources and remove dead/duplicate constants where feasible

Why split into 2A/2B
- Minimize risk by landing the `lessonFormat` correctness fixes first
- Keep incremental diffs easy to review and revert if needed

