### PR TITLE
fix: Phase 1B.2 — season param names + announcer totals; tests; guide updates

### DIFF
--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -44,11 +44,17 @@ This section is a living checklist to track cleanup progress. Do not remove prio
   - [x] Implement unified `useLessonSearch` with `useInfiniteQuery`
   - [x] Update `SearchPage` to use the unified hook for initial + load‑more
   - [x] Move results ownership to React Query (store keeps filters/view only)
+  - [x] Follow‑ups (Phase 1B.2)
+    - [x] Fix RPC param naming drift: send `filter_seasons` (not `filter_seasonTiming`) from hooks
+    - [x] Fix suggestions season filter payload: send `seasons` to Edge Function (not `seasonTiming`)
+    - [x] ScreenReaderAnnouncer reads total count from React Query (prop)
+    - [ ] Remove legacy results fields from Zustand store (and any dependents)
   - [ ] Add/adjust tests (paging, filters, suggestions)
     - [x] Paging (initial + load more) and error path
     - [x] Filter-change invalidation (Phase 1B)
     - [x] Cache-key isolation when page size changes (Phase 1B)
     - [x] Suggestions: click applies query and refetches (Phase 1B)
+    - [x] Param naming asserts: RPC `filter_seasons` and suggestions `seasons` key
     - [ ] Suggestions path unification (Phase 1C)
 
 - [ ] Phase 2 — Filter Definitions & Type Cleanups

--- a/src/__tests__/integration/lesson-search.params.test.tsx
+++ b/src/__tests__/integration/lesson-search.params.test.tsx
@@ -41,7 +41,12 @@ describe('Season parameter naming (RPC and suggestions)', () => {
     // RPC returns one row
     rpcMock.mockResolvedValueOnce({
       data: [
-        makeRpcRow({ lesson_id: 'SZN1', title: 'Fall Planting', grade_levels: ['3'], total_count: 1 }),
+        makeRpcRow({
+          lesson_id: 'SZN1',
+          title: 'Fall Planting',
+          grade_levels: ['3'],
+          total_count: 1,
+        }),
       ],
       error: null,
     });

--- a/src/__tests__/integration/lesson-search.params.test.tsx
+++ b/src/__tests__/integration/lesson-search.params.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -81,4 +80,3 @@ describe('Season parameter naming (RPC and suggestions)', () => {
     expect(payload?.body?.filters?.seasonTiming).toBeUndefined();
   });
 });
-

--- a/src/__tests__/integration/lesson-search.params.test.tsx
+++ b/src/__tests__/integration/lesson-search.params.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mocks
+const rpcMock = vi.fn();
+const invokeMock = vi.fn();
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    rpc: (...args: any[]) => rpcMock(...args),
+    functions: { invoke: (...args: any[]) => invokeMock(...args) },
+  },
+}));
+
+import { SearchPage } from '@/pages/SearchPage';
+import { useSearchStore } from '@/stores/searchStore';
+import { makeRpcRow, makeSmartSearchPayload } from '@/__tests__/helpers/factories';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </BrowserRouter>
+  );
+}
+
+describe('Season parameter naming (RPC and suggestions)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const store = useSearchStore.getState();
+    store.clearFilters();
+    store.setViewState({ resultsPerPage: 2 });
+  });
+
+  it('sends `filter_seasons` to RPC when season filters are selected', async () => {
+    // RPC returns one row
+    rpcMock.mockResolvedValueOnce({
+      data: [
+        makeRpcRow({ lesson_id: 'SZN1', title: 'Fall Planting', grade_levels: ['3'], total_count: 1 }),
+      ],
+      error: null,
+    });
+
+    // Set season filters to ensure param is sent
+    const store = useSearchStore.getState();
+    store.setFilters({ seasonTiming: ['Fall', 'Winter'] });
+
+    renderWithProviders(<SearchPage />);
+
+    await waitFor(() => expect(rpcMock).toHaveBeenCalled());
+    const callArgs = rpcMock.mock.calls[0];
+    expect(callArgs[0]).toMatch(/search_lessons/);
+    expect(callArgs[1].filter_seasons).toEqual(['Fall', 'Winter']);
+  });
+
+  it('sends `seasons` in suggestions payload (not seasonTiming)', async () => {
+    // Suggestions available
+    invokeMock.mockResolvedValue({
+      data: makeSmartSearchPayload({ suggestions: ['winter gardening'] }),
+      error: null,
+    });
+    // No list results to force suggestions UI
+    rpcMock.mockResolvedValueOnce({ data: [], error: null });
+
+    const store = useSearchStore.getState();
+    store.setFilters({ query: 'no-result', seasonTiming: ['Winter'] });
+
+    renderWithProviders(<SearchPage />);
+
+    await waitFor(() => expect(invokeMock).toHaveBeenCalled());
+    const [fnName, payload] = invokeMock.mock.calls[0];
+    expect(fnName).toBe('smart-search');
+    expect(payload?.body?.filters?.seasons).toEqual(['Winter']);
+    // Ensure legacy key is not sent accidentally
+    expect(payload?.body?.filters?.seasonTiming).toBeUndefined();
+  });
+});
+

--- a/src/components/Common/ScreenReaderAnnouncer.tsx
+++ b/src/components/Common/ScreenReaderAnnouncer.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchStore } from '../../stores/searchStore';
 
-export const ScreenReaderAnnouncer: React.FC = () => {
+interface ScreenReaderAnnouncerProps {
+  totalCount?: number;
+}
+
+export const ScreenReaderAnnouncer: React.FC<ScreenReaderAnnouncerProps> = ({ totalCount }) => {
   const [announcement, setAnnouncement] = useState('');
-  const { filters, totalCount } = useSearchStore();
+  const { filters } = useSearchStore();
 
   // Announce filter changes
   useEffect(() => {
@@ -29,11 +33,12 @@ export const ScreenReaderAnnouncer: React.FC = () => {
     if (filters.socialEmotionalLearning.length)
       activeFilters.push(`${filters.socialEmotionalLearning.length} SEL competencies`);
 
+    const count = typeof totalCount === 'number' ? totalCount : 0;
     if (activeFilters.length > 0) {
       const filterText = activeFilters.join(', ');
-      setAnnouncement(`Filters updated: ${filterText}. Found ${totalCount} lessons.`);
+      setAnnouncement(`Filters updated: ${filterText}. Found ${count} lessons.`);
     } else {
-      setAnnouncement(`All filters cleared. Showing all ${totalCount} lessons.`);
+      setAnnouncement(`All filters cleared. Showing all ${count} lessons.`);
     }
   }, [filters, totalCount]);
 

--- a/src/hooks/useLessonSearch.ts
+++ b/src/hooks/useLessonSearch.ts
@@ -85,8 +85,8 @@ export function useLessonSearch({ filters, pageSize = 20 }: UseLessonSearchOptio
         search_query: filters.query || undefined,
         filter_grade_levels: filters.gradeLevels?.length ? filters.gradeLevels : undefined,
         filter_themes: filters.thematicCategories?.length ? filters.thematicCategories : undefined,
-        // Note: existing codebase passes `filter_seasonTiming`; preserve for compatibility
-        filter_seasonTiming: filters.seasonTiming?.length ? filters.seasonTiming : undefined,
+        // Season filter: RPC expects `filter_seasons`
+        filter_seasons: filters.seasonTiming?.length ? filters.seasonTiming : undefined,
         filter_competencies: filters.coreCompetencies?.length
           ? filters.coreCompetencies
           : undefined,

--- a/src/hooks/useLessonSuggestions.ts
+++ b/src/hooks/useLessonSuggestions.ts
@@ -48,7 +48,8 @@ export function useLessonSuggestions({ filters, enabled = true }: UseLessonSugge
           filters: {
             gradeLevels: filters.gradeLevels,
             thematicCategories: filters.thematicCategories,
-            seasonTiming: filters.seasonTiming,
+            // Edge Function expects `seasons`
+            seasons: filters.seasonTiming,
             coreCompetencies: filters.coreCompetencies,
             culturalHeritage: filters.culturalHeritage,
             location: filters.location,

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -38,7 +38,8 @@ const searchLessonsWithSmartSearch = async ({
       filters: {
         gradeLevels: filters.gradeLevels,
         thematicCategories: filters.thematicCategories,
-        seasonTiming: filters.seasonTiming,
+        // Edge Function expects `seasons`
+        seasons: filters.seasonTiming,
         coreCompetencies: filters.coreCompetencies,
         culturalHeritage: filters.culturalHeritage,
         location: filters.location,

--- a/src/hooks/useSupabaseSearch.ts
+++ b/src/hooks/useSupabaseSearch.ts
@@ -37,7 +37,8 @@ export function useSupabaseSearch(
           filter_themes: filters.thematicCategories?.length
             ? filters.thematicCategories
             : undefined,
-          filter_seasonTiming: filters.seasonTiming?.length ? filters.seasonTiming : undefined,
+          // Season filter: RPC expects `filter_seasons`
+          filter_seasons: filters.seasonTiming?.length ? filters.seasonTiming : undefined,
           filter_competencies: filters.coreCompetencies?.length
             ? filters.coreCompetencies
             : undefined,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -68,7 +68,7 @@ export const SearchPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <SkipLink />
-      <ScreenReaderAnnouncer />
+      <ScreenReaderAnnouncer totalCount={totalCount} />
       <SearchBar />
 
       {/* Filter Pills */}


### PR DESCRIPTION
This PR lands the Phase 1B.2 follow-ups.

Changes
- RPC seasons: send `filter_seasons` from `useLessonSearch` / `useSupabaseSearch`.
- Suggestions seasons: send `seasons` in Edge Function payload from `useLessonSuggestions` / `useSearch`.
- A11y: `ScreenReaderAnnouncer` now reads totalCount from React Query via prop; `SearchPage` passes total.
- Tests: add `lesson-search.params.test.tsx` asserting correct param keys (RPC + suggestions).
- Docs: update `docs/architecture-cleanup-guide.md` progress and plan to reflect these changes (Phase 1B.2 items checked).

Notes
- No UI behavior changes other than accurate season filtering and ARIA announcements.
- Leaves removal of legacy results fields from the store as a follow-up task.