### PR TITLE
chore: Phase 2B polish — Academic Integration normalization + remove deprecated constants

### DIFF
--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -63,7 +63,7 @@ This section is a living checklist to track cleanup progress. Do not remove prio
     - [x] FilterSidebar sources options from `filterDefinitions`
     - [ ] Cultural heritage remains on dedicated hierarchy config (OK to keep separate)
   - [x] Treat `lessonFormat` as string consistently (UI/types/pills/announcer)
-  - [ ] Normalize display labels ⇄ DB values
+  - [x] Normalize display labels ⇄ DB values (Academic Integration to Title Case)
 
 - [ ] Phase 3 — Remove Algolia/Legacy Code
   - [ ] Remove hooks/types/client (`useAlgoliaSearch`, `lib/algolia.ts`, `types/algolia.ts`)

--- a/src/utils/filterConstants.ts
+++ b/src/utils/filterConstants.ts
@@ -65,7 +65,6 @@ export const INGREDIENT_GROUPS: Record<string, string[]> = {
   Cruciferous: ['cauliflower', 'cabbage', 'broccoli', 'brussels sprouts'],
 };
 
-
 // Grade level groupings
 export const GRADE_GROUPS = {
   'early-childhood': {

--- a/src/utils/filterConstants.ts
+++ b/src/utils/filterConstants.ts
@@ -65,26 +65,6 @@ export const INGREDIENT_GROUPS: Record<string, string[]> = {
   Cruciferous: ['cauliflower', 'cabbage', 'broccoli', 'brussels sprouts'],
 };
 
-// Core competencies options
-export const CORE_COMPETENCIES = [
-  'Environmental and Community Stewardship',
-  'Social Justice',
-  'Social-Emotional Intelligence',
-  'Garden Skills and Related Academic Content',
-  'Kitchen Skills and Related Academic Content',
-  'Culturally Responsive Education',
-];
-
-// Lesson format options
-export const LESSON_FORMATS = [
-  'Standalone',
-  'Multi-session unit',
-  'Double period',
-  'Single period',
-  'Co-taught',
-  'Remote/virtual adapted',
-  'Mobile education format',
-];
 
 // Grade level groupings
 export const GRADE_GROUPS = {
@@ -106,24 +86,5 @@ export const GRADE_GROUPS = {
   },
 };
 
-// Academic subject options
-export const ACADEMIC_SUBJECTS = [
-  'Science',
-  'Social Studies',
-  'Literacy/ELA',
-  'Math',
-  'Health',
-  'Arts',
-];
-
-// SEL competency options
-export const SEL_COMPETENCIES = [
-  'Relationship skills',
-  'Self-awareness',
-  'Responsible decision-making',
-  'Self-management',
-  'Social awareness',
-];
-
-// Cooking method options
-export const COOKING_METHODS = ['No-cook', 'Stovetop', 'Oven', 'Basic prep only'];
+// Note: Option lists for filters have moved to `filterDefinitions.ts` (Phase 2B).
+// The remaining exports are still used by cultural heritage widgets and helpers.

--- a/src/utils/filterDefinitions.ts
+++ b/src/utils/filterDefinitions.ts
@@ -178,12 +178,12 @@ export const FILTER_CONFIGS: Record<string, FilterConfig> = {
     label: 'Academic Integration',
     type: 'multiple',
     options: [
-      { value: 'math', label: 'Math' },
-      { value: 'science', label: 'Science' },
-      { value: 'literacy-ela', label: 'Literacy/ELA' },
-      { value: 'social-studies', label: 'Social Studies' },
-      { value: 'health', label: 'Health' },
-      { value: 'arts', label: 'Arts' },
+      { value: 'Math', label: 'Math' },
+      { value: 'Science', label: 'Science' },
+      { value: 'Literacy/ELA', label: 'Literacy/ELA' },
+      { value: 'Social Studies', label: 'Social Studies' },
+      { value: 'Health', label: 'Health' },
+      { value: 'Arts', label: 'Arts' },
     ],
   },
 


### PR DESCRIPTION
Batched Phase 2B polish to reduce PR churn.

Changes
- Normalize Academic Integration values in `FILTER_CONFIGS` to Title Case (Math, Science, Literacy/ELA, Social Studies, Health, Arts) to match DB/facets.
- Remove deprecated filter option arrays from `src/utils/filterConstants.ts` (moved to `filterDefinitions.ts` in 2B). Cultural hierarchy and ingredient groups remain.
- Update architecture guide to mark label/value normalization as complete.

Notes
- No behavior changes expected beyond ensuring filter values align with DB.
- Keeps Cultural Heritage on the dedicated hierarchy config; can be reconciled later if we decide to move it.