### PR TITLE
chore: Phase 3 — deprecate store result fields (prep for removal); complete Algolia cleanup

### DIFF
--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -119,7 +119,10 @@ Next Planned Actions
   - Delete Algolia hooks/types/client and facet helpers; remove scripts/docs references.
     - [x] Remove hooks/types/client (`useAlgoliaSearch`, `lib/algolia.ts`, `types/algolia.ts`)
     - [x] Reword facet helpers to be generic (kept for future SQL counts)
-    - [ ] Remove scripts/docs referencing Algolia (scripts/sync-to-algolia.js; package.json scripts)
+    - [x] Remove scripts/docs referencing Algolia (scripts/sync-to-algolia.js; package.json scripts)
+  - [ ] Store cleanup: remove legacy results fields from Zustand store and update tests
+    - [x] Deprecate store results/loading/error methods with warnings (non-breaking)
+    - [ ] Remove results/loading/error fields and related tests (Phase 3B)
   - Remove legacy results fields from Zustand store (moved from Phase 1) and update any dependents.
   - Keep Cultural Heritage hierarchy config as-is unless a future consolidation is desired.
 

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -94,13 +94,18 @@ export const useSearchStore = create<SearchState>()(
           hasMore: true,
         }),
 
-      setResults: (results, totalCount) =>
+      setResults: (results, totalCount) => {
+        if (import.meta.env.DEV) {
+          // Deprecated: results are owned by React Query (Phase 1)
+          console.warn('[searchStore] setResults is deprecated; use React Query for server data');
+        }
         set({
           results,
           totalCount,
           error: null,
           hasMore: results.length < totalCount,
-        }),
+        });
+      },
 
       appendResults: (newResults) =>
         set((state) => ({
@@ -108,11 +113,26 @@ export const useSearchStore = create<SearchState>()(
           hasMore: state.results.length + newResults.length < state.totalCount,
         })),
 
-      setLoading: (isLoading) => set({ isLoading }),
+      setLoading: (isLoading) => {
+        if (import.meta.env.DEV) {
+          console.warn('[searchStore] setLoading is deprecated; use React Query statuses');
+        }
+        set({ isLoading });
+      },
 
-      setLoadingMore: (isLoadingMore) => set({ isLoadingMore }),
+      setLoadingMore: (isLoadingMore) => {
+        if (import.meta.env.DEV) {
+          console.warn('[searchStore] setLoadingMore is deprecated; use React Query statuses');
+        }
+        set({ isLoadingMore });
+      },
 
-      setError: (error) => set({ error, isLoading: false, isLoadingMore: false }),
+      setError: (error) => {
+        if (import.meta.env.DEV) {
+          console.warn('[searchStore] setError is deprecated; use React Query error states');
+        }
+        set({ error, isLoading: false, isLoadingMore: false });
+      },
 
       setViewState: (newViewState) =>
         set((state) => ({


### PR DESCRIPTION
Phase 3 continuation:

- Deprecate legacy results/loading/error fields in search store with dev-time warnings (non-breaking).
- Keep API temporarily for tests and backward compatibility.
- Outline Phase 3B in the guide to remove fields + update tests in a follow-up.
- Complete Algolia cleanup in guide (scripts/docs + generic facet helpers).

No functional changes to runtime behavior; this prepares safe removal without disrupting tests or consumers.