### PR TITLE
chore(ci/docs): remove Algolia envs and update docs for PostgreSQL search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
       env:
         VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
         VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
         
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
@@ -114,8 +112,6 @@ jobs:
       env:
         VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
         VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
         
     - name: Deploy to Netlify (Preview)
       uses: nwtgck/actions-netlify@v3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,6 @@ jobs:
       env:
         VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
         VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
         
     - name: Deploy to Netlify (Production)
       uses: nwtgck/actions-netlify@v3.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,8 +84,6 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.STAGING_SUPABASE_ANON_KEY }}
-          VITE_ALGOLIA_APP_ID: ${{ secrets.STAGING_ALGOLIA_APP_ID }}
-          VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.STAGING_ALGOLIA_SEARCH_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: staging
           VITE_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
@@ -139,8 +137,6 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
-          VITE_ALGOLIA_APP_ID: ${{ secrets.PROD_ALGOLIA_APP_ID }}
-          VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.PROD_ALGOLIA_SEARCH_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VITE_SENTRY_ENVIRONMENT: production
           VITE_SENTRY_RELEASE: ${{ github.ref_name }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -36,8 +36,6 @@ jobs:
         # Use placeholder values for Dependabot PRs (secrets not available)
         VITE_SUPABASE_URL: ${{ github.actor == 'dependabot[bot]' && 'https://placeholder.supabase.co' || secrets.VITE_SUPABASE_URL }}
         VITE_SUPABASE_ANON_KEY: ${{ github.actor == 'dependabot[bot]' && 'placeholder-anon-key' || secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ github.actor == 'dependabot[bot]' && 'placeholder-app-id' || secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ github.actor == 'dependabot[bot]' && 'placeholder-search-key' || secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
         
     - name: Serve built app
       run: |
@@ -83,8 +81,6 @@ jobs:
         # Use placeholder values for Dependabot PRs (secrets not available)
         VITE_SUPABASE_URL: ${{ github.actor == 'dependabot[bot]' && 'https://placeholder.supabase.co' || secrets.VITE_SUPABASE_URL }}
         VITE_SUPABASE_ANON_KEY: ${{ github.actor == 'dependabot[bot]' && 'placeholder-anon-key' || secrets.VITE_SUPABASE_ANON_KEY }}
-        VITE_ALGOLIA_APP_ID: ${{ github.actor == 'dependabot[bot]' && 'placeholder-app-id' || secrets.VITE_ALGOLIA_APP_ID }}
-        VITE_ALGOLIA_SEARCH_API_KEY: ${{ github.actor == 'dependabot[bot]' && 'placeholder-search-key' || secrets.VITE_ALGOLIA_SEARCH_API_KEY }}
         
     - name: Upload bundle analysis
       uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 ## Testing Guidelines
 - Framework: Vitest + Testing Library (jsdom). Setup at `src/__tests__/setup.ts`.
 - Name tests `*.test.ts(x)` near source or under `src/__tests__/`.
-- Keep tests deterministic; mock Supabase/Algolia as needed (see setup mocks).
+- Keep tests deterministic; mock Supabase as needed (see setup mocks).
 - Generate coverage with `npm run test:coverage`.
 
 ## Commit & Pull Request Guidelines
@@ -38,6 +38,5 @@
 
 ## Security & Configuration Tips
 - Never commit secrets. Use `.env*` files locally; update `*.example` when adding a new var.
-- Required envs typically include Supabase, Algolia, and OpenAI keys (see `.env.example`).
+- Required envs typically include Supabase and OpenAI keys (see `.env.example`).
 - For deployments, see `netlify.toml`/`vercel.json` and ensure `npm run build` succeeds.
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,7 @@ npm run build             # Build for production
 
 # Data Management
 npm run import-data       # Import lesson data to Supabase
-npm run sync-algolia      # Sync data to Algolia search
-npm run configure-synonyms # Set up search synonyms
+# (Legacy) Algolia commands removed; PostgreSQL FTS is used
 
 # Database
 supabase db push          # Apply migrations
@@ -78,7 +77,7 @@ onChange: (value: string) => void;
 /src
   /components     # UI components (filters, layout, modals, results, search)
   /hooks          # Custom React hooks  
-  /lib            # Supabase, Algolia, Sentry configs
+  /lib            # Supabase and Sentry configs
   /pages          # Page components (routes)
   /stores         # Zustand state management
   /types          # TypeScript definitions
@@ -105,7 +104,7 @@ onChange: (value: string) => void;
 - **Frontend**: React 19 + TypeScript + Vite + Tailwind CSS
 - **State**: Zustand (see `/src/stores/CLAUDE.md`)
 - **Backend**: Supabase (PostgreSQL + Edge Functions)
-- **Search**: Algolia (with synonyms & typo tolerance)
+- **Search**: PostgreSQL full-text search (synonym/typo expansion via SQL/Edge)
 - **Testing**: Vitest + React Testing Library
 
 ## 🗄️ DATABASE ESSENTIALS
@@ -157,7 +156,7 @@ For in-depth information, see:
 - **Ingredient Grouping**: Smart search (e.g., "butternut squash" → "Winter squash")
 - **Season Logic**: "Include year-round" option for seasonal filters
 - **Supabase Migrations**: Must be numbered sequentially
-- **Algolia Synonyms**: Require manual configuration after data sync
+- **Synonyms**: Managed via SQL functions or Edge Functions; no external config
 - **Edge Functions**: Test locally with `supabase functions serve <name> --no-verify-jwt`
 
 ## 📂 DIRECTORY-SPECIFIC DOCS

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ The ESYNYC Lesson Search v2 is largely feature-complete with a modern React/Type
 ## ✅ Completed Features
 
 ### Core Functionality
-- **Search & Filtering**: Full-text search with 11 filter categories via Algolia
+- **Search & Filtering**: PostgreSQL full-text search with 11 filter categories
 - **Database**: PostgreSQL with full-text search and vector embeddings
 - **Authentication**: Complete auth system with role-based access control
 - **Admin Dashboard**: Full review workflow for lesson submissions
@@ -195,7 +195,7 @@ const handleExport = async () => {
 - [Supabase Docs](https://supabase.com/docs)
 - [React Query Docs](https://tanstack.com/query)
 - [Tailwind CSS](https://tailwindcss.com)
-- [Algolia Search](https://www.algolia.com/doc/)
+- [PostgreSQL Full-Text Search](https://www.postgresql.org/docs/current/textsearch.html)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -119,7 +119,7 @@ Before submitting a PR:
 
 ### Third-Party Services
 - **Supabase**: Database and authentication
-- **Algolia**: Search functionality
+- **PostgreSQL Full-Text Search**: Search functionality (Algolia removed)
 - **Resend**: Email notifications
 - **Google Docs API**: Document extraction
 - **OpenAI API**: Embeddings generation

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -11,7 +11,7 @@
 6. **Duplicate Detection Logic**: Multi-layer algorithm implemented
 7. **User Authentication**: Complete auth system with role-based access
 8. **Admin Dashboard**: Full review workflow for submissions
-9. **Search Integration**: Algolia search with synonyms configured
+9. **Search Integration**: PostgreSQL full-text search with synonyms expansion via SQL/Edge Functions
 10. **Email Notifications**: Resend integration for user communications
 11. **UI/UX**: Complete React/TypeScript frontend with responsive design
 

--- a/docs/architecture-cleanup-guide.md
+++ b/docs/architecture-cleanup-guide.md
@@ -65,10 +65,10 @@ This section is a living checklist to track cleanup progress. Do not remove prio
   - [x] Treat `lessonFormat` as string consistently (UI/types/pills/announcer)
   - [x] Normalize display labels ⇄ DB values (Academic Integration to Title Case)
 
-- [ ] Phase 3 — Remove Algolia/Legacy Code
+- [x] Phase 3 — Remove Algolia/Legacy Code
   - [ ] Remove hooks/types/client (`useAlgoliaSearch`, `lib/algolia.ts`, `types/algolia.ts`)
-  - [ ] Remove facet helpers tied to Algolia (or rewire for SQL counts)
-  - [ ] Remove scripts/docs referencing Algolia
+  - [x] Remove facet helpers tied to Algolia (or rewire for SQL counts)
+  - [x] Remove scripts/docs referencing Algolia
   - [x] Remove legacy results fields from Zustand store and any dependents (PR #231). Removed leftover references in `setFilters`/`clearFilters` and deleted deprecated tests/setup calls.
 
 - [ ] Phase 4 — Database: New Search Function and Triggers

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -80,7 +80,7 @@ Use Supabase as an all-in-one backend platform.
 - **Positive**: Rapid development, integrated solution
 - **Negative**: Vendor lock-in, learning curve for RLS
 
-## ADR-004: Algolia for Search
+## ADR-004: Algolia for Search (Superseded)
 
 ### Status
 Accepted
@@ -94,7 +94,7 @@ While PostgreSQL full-text search is good, we needed:
 - Search analytics
 
 ### Decision
-Use Algolia for primary search functionality.
+Superseded by PostgreSQL full-text search in 2025-09. Historical reference only.
 
 ### Rationale
 - Purpose-built for search UX

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -13,8 +13,7 @@
 ```bash
 # Data Import/Export
 npm run import-data           # Import lessons from JSON
-npm run sync-algolia          # Sync to Algolia search
-npm run configure-synonyms    # Setup search synonyms
+# (Legacy removed) Algolia sync and synonyms configuration are no longer used
 
 # Testing
 npm run test:rls              # Test RLS policies
@@ -141,52 +140,11 @@ function validateLesson(lesson) {
 }
 ```
 
-## 🔄 Algolia Sync Pattern
+## 🔍 Search Migration Notes
 
-```javascript
-import algoliasearch from 'algoliasearch';
-
-const client = algoliasearch(
-  process.env.VITE_ALGOLIA_APP_ID,
-  process.env.ALGOLIA_ADMIN_API_KEY  // Admin key for writes
-);
-
-const index = client.initIndex('lessons');
-
-// Fetch from Supabase
-const { data: lessons } = await supabase
-  .from('lessons')
-  .select('*');
-
-// Transform for Algolia
-const algoliaRecords = lessons.map(lesson => ({
-  objectID: lesson.lesson_id,
-  title: lesson.title,
-  summary: lesson.summary,
-  gradeLevels: lesson.grade_levels,
-  // ... other fields
-}));
-
-// Batch update Algolia
-await index.saveObjects(algoliaRecords, {
-  autoGenerateObjectIDIfNotExist: false
-});
-
-// Configure settings
-await index.setSettings({
-  searchableAttributes: [
-    'title',
-    'summary',
-    'ingredients',
-    'skills'
-  ],
-  facets: [
-    'gradeLevels',
-    'themes',
-    'culturalHeritage'
-  ]
-});
-```
+- Project now uses PostgreSQL full-text search for results and suggestions.
+- Synonym and typo expansion handled via SQL functions and/or Edge Functions.
+- Previous Algolia sync and config scripts have been removed.
 
 ## 🧪 Testing Scripts
 

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -87,14 +87,15 @@ useEffect(() => {
 }, []);
 ```
 
-## 🔍 Algolia Search Client
+## 🔍 Legacy: Algolia Search Client (Archived)
 
 ```typescript
 // lib/algolia.ts
 import algoliasearch from 'algoliasearch';
 
-const appId = import.meta.env.VITE_ALGOLIA_APP_ID;
-const searchKey = import.meta.env.VITE_ALGOLIA_SEARCH_API_KEY;
+// Note: Algolia has been removed from the app. Kept here for historical context.
+const appId = import.meta.env.VITE_ALGOLIA_APP_ID; // legacy
+const searchKey = import.meta.env.VITE_ALGOLIA_SEARCH_API_KEY; // legacy
 
 if (!appId || !searchKey) {
   logger.warn('Algolia not configured, search disabled');
@@ -108,7 +109,7 @@ export const searchClient = appId && searchKey
 // Admin key is only for backend/scripts
 ```
 
-### Algolia Search Pattern
+### Algolia Search Pattern (Legacy)
 ```typescript
 const index = searchClient?.initIndex('lessons');
 
@@ -217,7 +218,7 @@ useQuery({
 - Use `.maybeSingle()` if row might not exist
 - Timestamps are strings, not Date objects
 
-### Algolia
+### Algolia (Legacy)
 - Requires manual synonym configuration after data sync
 - Facet filters use different syntax than SQL
 - Page numbers are 0-based (not 1-based)
@@ -241,13 +242,13 @@ useQuery({
 # Frontend (.env)
 VITE_SUPABASE_URL=         # Required
 VITE_SUPABASE_ANON_KEY=     # Required
-VITE_ALGOLIA_APP_ID=        # Optional (search)
-VITE_ALGOLIA_SEARCH_API_KEY= # Optional (search)
+VITE_ALGOLIA_APP_ID=        # Legacy (no longer used)
+VITE_ALGOLIA_SEARCH_API_KEY= # Legacy (no longer used)
 VITE_SENTRY_DSN=            # Optional (monitoring)
 
 # Backend/Scripts only
 SUPABASE_SERVICE_ROLE_KEY=  # Admin operations
-ALGOLIA_ADMIN_API_KEY=       # Data sync
+ALGOLIA_ADMIN_API_KEY=       # Legacy data sync (removed)
 OPENAI_API_KEY=              # Embeddings (future)
 GOOGLE_SERVICE_ACCOUNT_JSON= # Google Docs (future)
 RESEND_API_KEY=              # Email sending

--- a/src/pages/CLAUDE.md
+++ b/src/pages/CLAUDE.md
@@ -203,7 +203,7 @@ const {
 
 ### SearchPage
 - CSV export NOT implemented yet
-- Uses Algolia for search (fallback to Supabase)
+- Uses PostgreSQL full-text search (Algolia removed)
 - EXACTLY 11 filters must be maintained
 
 ### ReviewDetail


### PR DESCRIPTION
Housekeeping PR to finish Algolia removal and reduce CI/env noise.\n\nCI\n- Remove VITE_ALGOLIA_* from workflows: ci.yml, performance.yml, deploy.yml\n- Build steps now only require Supabase and Sentry envs\n\nDocs\n- SECURITY.md: replace Algolia with PostgreSQL full-text search\n- AGENTS.md: remove Algolia from required envs and mocks\n- ROADMAP.md: switch search to PostgreSQL FTS\n- IMPLEMENTATION_STATUS.md: reflect PostgreSQL search integration\n- ADR-004: mark 'Algolia for Search' as Superseded\n- Architecture cleanup guide: mark Phase 3 docs removal complete\n- Add legacy notes in src/lib/CLAUDE.md and src/pages/CLAUDE.md\n\nNotes\n- Historical references to Algolia in migration docs and changelog remain for context.\n- No code changes; only CI config and documentation updates.