### PR TITLE
ci: skip Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for dependabot (no access to secrets)
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Skip Claude Code Review workflow for Dependabot PRs since they don't have access to repository secrets.

## Problem

Dependabot PRs always fail the `claude-review` check because `CLAUDE_CODE_OAUTH_TOKEN` is unavailable (GitHub security restriction).

## Solution

Add `if: github.event.pull_request.user.login != 'dependabot[bot]'` condition, matching the pattern already used in:
- `claude-component-review.yml`
- `claude-database-review.yml`

## Test plan

- [ ] Verify existing Dependabot PRs no longer show `claude-review` as a failed check after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)