### PR TITLE
refactor: replace console.error with logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { VerifySetup } from './pages/VerifySetup';
 import { useLessonStats } from './hooks/useLessonStats';
 import { ProtectedRoute } from './components/Auth/ProtectedRoute';
 import { Permission } from './types/auth';
+import { logger } from './utils/logger';
 
 // Create a client
 const queryClient = new QueryClient({
@@ -164,8 +165,7 @@ function App() {
     <ErrorBoundary
       fallback={AppErrorFallback}
       onError={(error, errorInfo) => {
-        // In production, you could log to an error tracking service here
-        console.error('App Error:', error, errorInfo);
+        logger.error('App Error:', error, errorInfo);
       }}
     >
       <QueryClientProvider client={queryClient}>

--- a/src/components/Common/ReviewErrorBoundary.tsx
+++ b/src/components/Common/ReviewErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
+import { logger } from '@/utils/logger';
 
 interface Props {
   children: ReactNode;
@@ -21,7 +22,7 @@ export class ReviewErrorBoundary extends Component<Props, State> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Review component error:', error, errorInfo);
+    logger.error('Review component error:', error, errorInfo);
   }
 
   public render() {


### PR DESCRIPTION
## Summary

Replaces `console.error` calls with the project's `logger.error` utility in error boundary components for consistent error handling.

## Changes

- **src/components/Common/ReviewErrorBoundary.tsx**: Use `logger.error` instead of `console.error`
- **src/App.tsx**: Use `logger.error` in the root error boundary's `onError` handler

## Not Changed (Intentionally)

- **src/utils/logger.ts**: Uses `console.error` internally (this IS the logger implementation)
- **src/lib/sentry.ts**: Uses `console.error` for dev-only logging in error tracking code (changing this could risk circular dependencies)

## Benefits

- Consistent error logging across the application
- Errors are properly sanitized before logging
- In production, errors are sent to Sentry
- In development, errors are formatted nicely in console

## Test plan
- [x] `npm run type-check` passes
- [x] No other `console.error` calls in src/ that should be changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)