### PR TITLE
fix: use crypto.randomUUID() for lesson ID generation

### DIFF
--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -325,7 +325,7 @@ export function ReviewDetail() {
 
         // Create new lesson (write to base table to set all native columns)
         const newLesson: any = {
-          lesson_id: `lesson_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
+          lesson_id: `lesson_${crypto.randomUUID()}`,
           title: baseTitle || 'Untitled Lesson',
           summary: lessonData.summary || '',
           file_link: submission.google_doc_url,


### PR DESCRIPTION
## Summary

Replace the `Date.now() + Math.random()` pattern with `crypto.randomUUID()` for generating lesson IDs to prevent potential collisions.

## Problem

The current implementation:
```typescript
lesson_id: `lesson_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
```

Could theoretically lead to ID collisions under high load conditions, as multiple requests at the same millisecond could generate the same timestamp portion.

## Solution

Use `crypto.randomUUID()` which provides:
- Cryptographically secure random generation
- Guaranteed uniqueness (UUID v4)
- Industry standard approach
- No collision risk even under high load

New format: `lesson_550e8400-e29b-41d4-a716-446655440000`

## Test plan
- [x] `npm run type-check` passes
- [ ] Deploy preview works correctly
- [ ] Manual test: approve a new lesson and verify ID format

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)