### PR TITLE
feat(security): add RLS policy for teacher review access

### DIFF
--- a/supabase/migrations/20251129_teacher_review_access_policy.sql
+++ b/supabase/migrations/20251129_teacher_review_access_policy.sql
@@ -1,0 +1,19 @@
+-- Migration: 20251129_teacher_review_access_policy.sql
+-- Description: Add RLS policy for teachers to view reviews on their own submissions
+-- Issue: #122 - Security: Add RLS policies for review access control
+
+-- Teachers can view reviews for submissions they submitted
+-- This allows teachers to see feedback on their lesson submissions
+CREATE POLICY "Teachers can view own submission reviews" ON "public"."submission_reviews"
+  FOR SELECT
+  TO "authenticated"
+  USING (
+    EXISTS (
+      SELECT 1 FROM "public"."lesson_submissions"
+      WHERE "lesson_submissions"."id" = "submission_reviews"."submission_id"
+      AND "lesson_submissions"."teacher_id" = "auth"."uid"()
+    )
+  );
+
+-- Rollback:
+-- DROP POLICY IF EXISTS "Teachers can view own submission reviews" ON "public"."submission_reviews";


### PR DESCRIPTION
## Summary
- Adds RLS policy allowing teachers to view reviews on their own submissions
- Addresses security gap where teachers couldn't see feedback on lessons they submitted
- Maintains existing reviewer/admin full access

## Changes
- New migration: `20251129_teacher_review_access_policy.sql`
- Adds "Teachers can view own submission reviews" policy on `submission_reviews` table

## Policy Logic
```sql
CREATE POLICY "Teachers can view own submission reviews" ON "public"."submission_reviews"
  FOR SELECT
  TO "authenticated"
  USING (
    EXISTS (
      SELECT 1 FROM "public"."lesson_submissions"
      WHERE "lesson_submissions"."id" = "submission_reviews"."submission_id"
      AND "lesson_submissions"."teacher_id" = "auth"."uid"()
    )
  );
```

## Test plan
- [ ] Apply migration to staging database
- [ ] Verify reviewers can still create/view/update all reviews
- [ ] Verify teachers can view reviews on their own submissions
- [ ] Verify teachers cannot view reviews on other teachers' submissions
- [ ] Run `npm run test:rls` to verify RLS is enabled on all tables

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)