### PR TITLE
fix: handle academicIntegration object format in lesson modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,120 +80,122 @@ function AppContent() {
 
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50">
-        <Header totalLessons={totalLessons} totalCategories={totalCategories} />
+      <ErrorBoundary fallback={RouteErrorFallback}>
+        <div className="min-h-screen bg-gray-50">
+          <Header totalLessons={totalLessons} totalCategories={totalCategories} />
 
-        <main>
-          <Suspense fallback={<PageLoader />}>
-            <Routes>
-              <Route path="/" element={<SearchPage />} />
-              <Route path="/search" element={<SearchPage />} />
-              <Route path="/submit" element={<SubmissionPage />} />
-              <Route path="/accept-invitation" element={<AcceptInvitation />} />
-              <Route path="/reset-password" element={<ResetPassword />} />
-              <Route
-                path="/review"
-                element={
-                  <ProtectedRoute permissions={[Permission.REVIEW_LESSONS]}>
-                    <ReviewDashboard />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/review/:id"
-                element={
-                  <ProtectedRoute permissions={[Permission.REVIEW_LESSONS]}>
-                    <ReviewErrorBoundary>
-                      <ReviewDetail />
-                    </ReviewErrorBoundary>
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin"
-                element={
-                  <ProtectedRoute
-                    permissions={[
-                      Permission.VIEW_USERS,
-                      Permission.VIEW_ANALYTICS,
-                      Permission.MANAGE_DUPLICATES,
-                      Permission.REVIEW_LESSONS,
-                    ]}
-                  >
-                    <AdminDashboard />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/duplicates"
-                element={
-                  <ProtectedRoute permissions={[Permission.MANAGE_DUPLICATES]}>
-                    <AdminDuplicates />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/duplicates/:groupId"
-                element={
-                  <ProtectedRoute permissions={[Permission.MANAGE_DUPLICATES]}>
-                    <AdminDuplicateDetail />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/users"
-                element={
-                  <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
-                    <AdminUsers />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/users/invite"
-                element={
-                  <ProtectedRoute permissions={[Permission.INVITE_USERS]}>
-                    <AdminInviteUser />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/invitations"
-                element={
-                  <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
-                    <AdminInvitations />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/users/:userId"
-                element={
-                  <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
-                    <AdminUserDetail />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/admin/analytics"
-                element={
-                  <ProtectedRoute permissions={[Permission.VIEW_ANALYTICS]}>
-                    <AdminAnalytics />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  <ProtectedRoute>
-                    <UserProfile />
-                  </ProtectedRoute>
-                }
-              />
-              {/* Temporary route for testing - remove in production */}
-              <Route path="/verify-setup" element={<VerifySetup />} />
-            </Routes>
-          </Suspense>
-        </main>
-      </div>
+          <main>
+            <Suspense fallback={<PageLoader />}>
+              <Routes>
+                <Route path="/" element={<SearchPage />} />
+                <Route path="/search" element={<SearchPage />} />
+                <Route path="/submit" element={<SubmissionPage />} />
+                <Route path="/accept-invitation" element={<AcceptInvitation />} />
+                <Route path="/reset-password" element={<ResetPassword />} />
+                <Route
+                  path="/review"
+                  element={
+                    <ProtectedRoute permissions={[Permission.REVIEW_LESSONS]}>
+                      <ReviewDashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/review/:id"
+                  element={
+                    <ProtectedRoute permissions={[Permission.REVIEW_LESSONS]}>
+                      <ReviewErrorBoundary>
+                        <ReviewDetail />
+                      </ReviewErrorBoundary>
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin"
+                  element={
+                    <ProtectedRoute
+                      permissions={[
+                        Permission.VIEW_USERS,
+                        Permission.VIEW_ANALYTICS,
+                        Permission.MANAGE_DUPLICATES,
+                        Permission.REVIEW_LESSONS,
+                      ]}
+                    >
+                      <AdminDashboard />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/duplicates"
+                  element={
+                    <ProtectedRoute permissions={[Permission.MANAGE_DUPLICATES]}>
+                      <AdminDuplicates />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/duplicates/:groupId"
+                  element={
+                    <ProtectedRoute permissions={[Permission.MANAGE_DUPLICATES]}>
+                      <AdminDuplicateDetail />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/users"
+                  element={
+                    <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
+                      <AdminUsers />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/users/invite"
+                  element={
+                    <ProtectedRoute permissions={[Permission.INVITE_USERS]}>
+                      <AdminInviteUser />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/invitations"
+                  element={
+                    <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
+                      <AdminInvitations />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/users/:userId"
+                  element={
+                    <ProtectedRoute permissions={[Permission.VIEW_USERS]}>
+                      <AdminUserDetail />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/admin/analytics"
+                  element={
+                    <ProtectedRoute permissions={[Permission.VIEW_ANALYTICS]}>
+                      <AdminAnalytics />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
+                  path="/profile"
+                  element={
+                    <ProtectedRoute>
+                      <UserProfile />
+                    </ProtectedRoute>
+                  }
+                />
+                {/* Temporary route for testing - remove in production */}
+                <Route path="/verify-setup" element={<VerifySetup />} />
+              </Routes>
+            </Suspense>
+          </main>
+        </div>
+      </ErrorBoundary>
     </Router>
   );
 }
@@ -207,9 +209,7 @@ function App() {
       }}
     >
       <QueryClientProvider client={queryClient}>
-        <ErrorBoundary fallback={RouteErrorFallback}>
-          <AppContent />
-        </ErrorBoundary>
+        <AppContent />
         {/* React Query DevTools - only in development */}
         {import.meta.env.MODE === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>

--- a/src/components/Modal/LessonModal.tsx
+++ b/src/components/Modal/LessonModal.tsx
@@ -226,18 +226,28 @@ export const LessonModal: React.FC<LessonModalProps> = ({ lesson, isOpen, onClos
 
             {/* Academic Integration */}
             {lesson.metadata.academicIntegration &&
-              lesson.metadata.academicIntegration.length > 0 && (
-                <div>
-                  <h3 className="font-semibold text-gray-900 mb-3">Academic Integration</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {lesson.metadata.academicIntegration.map((subject) => (
-                      <span key={subject} className="lesson-tag bg-indigo-100 text-indigo-800">
-                        {subject}
-                      </span>
-                    ))}
+              (() => {
+                // Handle both array format and object with selected key
+                const ai = lesson.metadata.academicIntegration;
+                const subjects: string[] = Array.isArray(ai)
+                  ? ai.filter((item): item is string => typeof item === 'string')
+                  : ai && typeof ai === 'object' && 'selected' in ai && Array.isArray(ai.selected)
+                    ? ai.selected.filter((item): item is string => typeof item === 'string')
+                    : [];
+
+                return subjects.length > 0 ? (
+                  <div>
+                    <h3 className="font-semibold text-gray-900 mb-3">Academic Integration</h3>
+                    <div className="flex flex-wrap gap-2">
+                      {subjects.map((subject) => (
+                        <span key={subject} className="lesson-tag bg-indigo-100 text-indigo-800">
+                          {subject}
+                        </span>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              )}
+                ) : null;
+              })()}
 
             {/* Social-Emotional Learning */}
             {lesson.metadata.socialEmotionalLearning &&

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,10 @@
+// Academic Integration can be either a simple array or an object with concepts
+export interface AcademicIntegrationObject {
+  concepts: Record<string, string[]>;
+  selected: string[];
+}
+export type AcademicIntegration = string[] | AcademicIntegrationObject;
+
 // Core lesson data types
 export interface Lesson {
   lessonId: string;
@@ -36,7 +43,7 @@ export interface LessonMetadata {
   cookingSkills?: string[];
   cookingMethods?: string[];
   observancesHolidays?: string[];
-  academicIntegration?: string[];
+  academicIntegration?: AcademicIntegration;
   socialEmotionalLearning?: string[];
   culturalResponsivenessFeatures?: string[];
 }


### PR DESCRIPTION
## Summary

- Fix error when clicking on lesson cards: "Objects are not valid as a React child"
- Move ErrorBoundary inside Router so RouteErrorFallback can use `useNavigate()`
- Add `AcademicIntegration` union type to handle both array and object formats

## Problem

The `academicIntegration` field in the database has two formats:
- **Array format**: `["Social Studies", "Literacy/ELA"]`
- **Object format**: `{concepts: {...}, selected: ["Social Studies", ...]}`

The code was trying to `.map()` over the object format directly, causing the error.

## Changes

1. **`src/App.tsx`**: Moved `ErrorBoundary` with `RouteErrorFallback` inside the `<Router>` component so `useNavigate()` hook works properly
2. **`src/types/index.ts`**: Added `AcademicIntegration` union type
3. **`src/components/Modal/LessonModal.tsx`**: Made rendering defensive to handle both data formats, with explicit type filtering

## Test plan

- [x] Click on lesson cards with array format academicIntegration
- [x] Click on lesson cards with object format academicIntegration
- [x] Verify no console errors
- [x] TypeScript compiles without errors
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)