### PR TITLE
chore(ci): edge function deploy workflow with TEST + PROD targets

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -224,7 +224,11 @@ jobs:
   # (e.g. _shared/** changes). The gate runs once, then the matrix runs
   # without per-job approval.
   gate-prod:
-    name: Approve PROD Deploy
+    # The job display name shows up in the "Review pending deployments"
+    # approval prompt. Surfacing the trigger here so the approver can see
+    # at a glance whether this is a normal main-push deploy or a manual
+    # dispatch that bypassed the TEST stage.
+    name: ${{ github.event_name == 'workflow_dispatch' && 'Approve PROD Deploy ⚠️ manual dispatch — TEST bypassed' || 'Approve PROD Deploy' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'production'
     runs-on: ubuntu-latest
@@ -235,11 +239,16 @@ jobs:
       - name: Record approval
         env:
           FUNCTIONS: ${{ needs.detect-changes.outputs.functions }}
+          TRIGGER: ${{ github.event_name }}
         run: |
           {
             echo "## ✅ PROD Deploy Approved"
             echo ""
-            echo "Functions queued for deploy: \`$FUNCTIONS\`"
+            echo "- **Trigger:** \`$TRIGGER\`"
+            if [ "$TRIGGER" = "workflow_dispatch" ]; then
+              echo "- ⚠️ Manual dispatch — these functions did not auto-deploy to TEST first."
+            fi
+            echo "- **Functions:** \`$FUNCTIONS\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy-prod:

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -206,12 +206,17 @@ jobs:
         # on inbound requests; each function authenticates internally
         # (anon key context, service-role admin client, or webhook signature
         # as appropriate). Keep this aligned with the legacy deploy script.
+        #
+        # FUNCTION_NAME is passed via env (not template-substituted into the
+        # run script) per GitHub's published guidance for handling values
+        # that originate from workflow inputs / API outputs.
+        env:
+          FUNCTION_NAME: ${{ matrix.function }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          supabase functions deploy "${{ matrix.function }}" \
+          supabase functions deploy "$FUNCTION_NAME" \
             --project-ref rxgajgmphciuaqzvwmox \
             --no-verify-jwt
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
   # Single approval gate for the whole PROD deploy. Without this, every
   # matrix-expanded `deploy-prod` job would request its own approval —
@@ -258,13 +263,14 @@ jobs:
           version: latest
 
       - name: Deploy ${{ matrix.function }} to PROD
-        # --no-verify-jwt: see the deploy-test job above for rationale.
+        # See deploy-test for --no-verify-jwt + env-passing rationale.
+        env:
+          FUNCTION_NAME: ${{ matrix.function }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          supabase functions deploy "${{ matrix.function }}" \
+          supabase functions deploy "$FUNCTION_NAME" \
             --project-ref jxlxtzkmicfhchkhiojz \
             --no-verify-jwt
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
   report:
     name: Post Deploy Summary

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Target environment'
+        description: 'Target environment (production deploys skip TEST — manual approval still applies)'
         type: choice
         options: [test, production]
         default: test

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -254,7 +254,7 @@ jobs:
             echo "See the individual matrix job logs above for per-function output."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post PR comment
+      - name: Post or update PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
@@ -266,19 +266,41 @@ jobs:
           script: |
             const { ICON, STATUS, TARGET, FUNCTIONS } = process.env;
             const funcs = JSON.parse(FUNCTIONS);
-            const lines = [
+            const marker = '<!-- deploy-edge-functions-comment -->';
+            const body = [
+              marker,
               `### Edge Function Deploy — ${ICON} ${STATUS}`,
               ``,
               `- **Target:** \`${TARGET}\``,
               `- **Functions (${funcs.length}):**`,
               ...funcs.map(f => `  - \`${f}\``),
               ``,
-              `<sub>Deployed from ${context.payload.pull_request.head.sha.slice(0, 7)} via \`deploy-edge-functions.yml\`</sub>`,
+              `<sub>Last run: commit ${context.payload.pull_request.head.sha.slice(0, 7)} via \`deploy-edge-functions.yml\`</sub>`,
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: lines,
-            });
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const prior = existing.find(c => c.body && c.body.includes(marker));
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Initialize FUNCS up-front so the post-case length check is safe
+          # regardless of which event branch ran (defensive under set -u).
+          FUNCS=()
+
           # Discover deployable functions from the filesystem so adding a new
           # function under supabase/functions/<name>/ doesn't require editing
           # this workflow. The `_*` filter excludes `_shared` and any future
@@ -189,14 +193,35 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-  deploy-prod:
-    name: Deploy to PROD — ${{ matrix.function }}
+  # Single approval gate for the whole PROD deploy. Without this, every
+  # matrix-expanded `deploy-prod` job would request its own approval —
+  # up to one click per function, which is bad UX for full-suite deploys
+  # (e.g. _shared/** changes). The gate runs once, then the matrix runs
+  # without per-job approval.
+  gate-prod:
+    name: Approve PROD Deploy
     needs: detect-changes
     if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'production'
     runs-on: ubuntu-latest
     environment:
       name: production
       url: https://supabase.com/dashboard/project/jxlxtzkmicfhchkhiojz/functions
+    steps:
+      - name: Record approval
+        env:
+          FUNCTIONS: ${{ needs.detect-changes.outputs.functions }}
+        run: |
+          {
+            echo "## ✅ PROD Deploy Approved"
+            echo ""
+            echo "Functions queued for deploy: \`$FUNCTIONS\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-prod:
+    name: Deploy to PROD — ${{ matrix.function }}
+    needs: [detect-changes, gate-prod]
+    if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'production'
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,284 @@
+name: Deploy Edge Functions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'supabase/functions/**'
+      - '.github/workflows/deploy-edge-functions.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/functions/**'
+      - '.github/workflows/deploy-edge-functions.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        type: choice
+        options: [test, production]
+        default: test
+        required: true
+      function:
+        description: "Function name, or 'all' to deploy every function"
+        type: string
+        default: all
+        required: true
+
+concurrency:
+  group: deploy-edge-functions-${{ github.event_name == 'push' && 'production' || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('dispatch-{0}', inputs.environment) }}
+  cancel-in-progress: false
+
+jobs:
+  detect-changes:
+    name: Detect Deploy Target
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.plan.outputs.target }}
+      functions: ${{ steps.plan.outputs.functions }}
+      has_work: ${{ steps.plan.outputs.has_work }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Plan deployment
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_ENV: ${{ inputs.environment }}
+          DISPATCH_FUNC: ${{ inputs.function }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          ALL_FUNCTIONS=(
+            detect-duplicates
+            extract-google-doc
+            generate-embeddings
+            generate-gemini-embeddings
+            import-lessons
+            invitation-management
+            password-reset
+            process-submission
+            search-lessons
+            send-email
+            smart-search
+            user-management
+          )
+
+          is_valid_function() {
+            local name="$1"
+            for f in "${ALL_FUNCTIONS[@]}"; do
+              [ "$f" = "$name" ] && return 0
+            done
+            return 1
+          }
+
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              TARGET="$DISPATCH_ENV"
+              if [ "$DISPATCH_FUNC" = "all" ]; then
+                FUNCS=("${ALL_FUNCTIONS[@]}")
+              else
+                if ! is_valid_function "$DISPATCH_FUNC"; then
+                  echo "::error::Unknown function name: $DISPATCH_FUNC"
+                  echo "Valid: ${ALL_FUNCTIONS[*]}"
+                  exit 1
+                fi
+                FUNCS=("$DISPATCH_FUNC")
+              fi
+              ;;
+            pull_request)
+              TARGET="test"
+              git fetch origin "$BASE_REF" --depth=1
+              CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" -- supabase/functions/ || true)
+              ;;
+            push)
+              TARGET="production"
+              CHANGED=$(git diff --name-only HEAD~1 HEAD -- supabase/functions/ || true)
+              ;;
+            *)
+              echo "::error::Unsupported event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
+
+          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+            if echo "$CHANGED" | grep -q '^supabase/functions/_shared/'; then
+              echo "Shared code changed — deploying all functions."
+              FUNCS=("${ALL_FUNCTIONS[@]}")
+            else
+              mapfile -t FUNC_DIRS < <(
+                echo "$CHANGED" \
+                  | sed -n 's|^supabase/functions/\([^/]*\)/.*|\1|p' \
+                  | sort -u
+              )
+              FUNCS=()
+              for name in "${FUNC_DIRS[@]}"; do
+                if is_valid_function "$name"; then
+                  FUNCS+=("$name")
+                fi
+              done
+            fi
+          fi
+
+          if [ "${#FUNCS[@]}" -eq 0 ]; then
+            echo "No functions to deploy."
+            echo "has_work=false" >> "$GITHUB_OUTPUT"
+            echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+            echo 'functions=[]' >> "$GITHUB_OUTPUT"
+            {
+              echo "## Edge Function Deploy — no-op"
+              echo ""
+              echo "No functions changed, nothing to deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          JSON=$(printf '%s\n' "${FUNCS[@]}" | jq -R . | jq -cs .)
+          echo "has_work=true" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "functions=$JSON" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Edge Function Deploy Plan"
+            echo ""
+            echo "- **Event:** \`$EVENT_NAME\`"
+            echo "- **Target:** \`$TARGET\`"
+            echo "- **Functions (${#FUNCS[@]}):**"
+            for f in "${FUNCS[@]}"; do
+              echo "  - \`$f\`"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-test:
+    name: Deploy to TEST — ${{ matrix.function }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'test'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        function: ${{ fromJSON(needs.detect-changes.outputs.functions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy ${{ matrix.function }} to TEST
+        run: |
+          supabase functions deploy "${{ matrix.function }}" \
+            --project-ref rxgajgmphciuaqzvwmox \
+            --no-verify-jwt
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+  deploy-prod:
+    name: Deploy to PROD — ${{ matrix.function }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'production'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://supabase.com/dashboard/project/jxlxtzkmicfhchkhiojz/functions
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        function: ${{ fromJSON(needs.detect-changes.outputs.functions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy ${{ matrix.function }} to PROD
+        run: |
+          supabase functions deploy "${{ matrix.function }}" \
+            --project-ref jxlxtzkmicfhchkhiojz \
+            --no-verify-jwt
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+  report:
+    name: Post Deploy Summary
+    needs: [detect-changes, deploy-test, deploy-prod]
+    if: always() && needs.detect-changes.outputs.has_work == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Compute status
+        id: status
+        env:
+          TEST_RESULT: ${{ needs.deploy-test.result }}
+          PROD_RESULT: ${{ needs.deploy-prod.result }}
+          TARGET: ${{ needs.detect-changes.outputs.target }}
+        run: |
+          if [ "$TARGET" = "test" ]; then
+            RESULT="$TEST_RESULT"
+          else
+            RESULT="$PROD_RESULT"
+          fi
+          case "$RESULT" in
+            success) ICON="✅"; STATUS="succeeded" ;;
+            skipped) ICON="⏭️"; STATUS="skipped (awaiting approval?)" ;;
+            *)       ICON="❌"; STATUS="failed or cancelled" ;;
+          esac
+          echo "icon=$ICON" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        env:
+          ICON: ${{ steps.status.outputs.icon }}
+          STATUS: ${{ steps.status.outputs.status }}
+          TARGET: ${{ needs.detect-changes.outputs.target }}
+          FUNCTIONS: ${{ needs.detect-changes.outputs.functions }}
+        run: |
+          {
+            echo "## Edge Function Deploy — $ICON $STATUS"
+            echo ""
+            echo "- **Target:** \`$TARGET\`"
+            echo "- **Functions:** \`$FUNCTIONS\`"
+            echo ""
+            echo "See the individual matrix job logs above for per-function output."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          ICON: ${{ steps.status.outputs.icon }}
+          STATUS: ${{ steps.status.outputs.status }}
+          TARGET: ${{ needs.detect-changes.outputs.target }}
+          FUNCTIONS: ${{ needs.detect-changes.outputs.functions }}
+        with:
+          script: |
+            const { ICON, STATUS, TARGET, FUNCTIONS } = process.env;
+            const funcs = JSON.parse(FUNCTIONS);
+            const lines = [
+              `### Edge Function Deploy — ${ICON} ${STATUS}`,
+              ``,
+              `- **Target:** \`${TARGET}\``,
+              `- **Functions (${funcs.length}):**`,
+              ...funcs.map(f => `  - \`${f}\``),
+              ``,
+              `<sub>Deployed from ${context.payload.pull_request.head.sha.slice(0, 7)} via \`deploy-edge-functions.yml\`</sub>`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: lines,
+            });

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -171,6 +171,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'test'
     runs-on: ubuntu-latest
+    # Typical deploy is ~30s; cap at 10 min so a hung CLI / network stall
+    # surfaces quickly instead of consuming the GH Actions 360-min default.
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -186,6 +189,10 @@ jobs:
           version: latest
 
       - name: Deploy ${{ matrix.function }} to TEST
+        # --no-verify-jwt: the Supabase edge runtime doesn't enforce a JWT
+        # on inbound requests; each function authenticates internally
+        # (anon key context, service-role admin client, or webhook signature
+        # as appropriate). Keep this aligned with the legacy deploy script.
         run: |
           supabase functions deploy "${{ matrix.function }}" \
             --project-ref rxgajgmphciuaqzvwmox \
@@ -222,6 +229,7 @@ jobs:
     needs: [detect-changes, gate-prod]
     if: needs.detect-changes.outputs.has_work == 'true' && needs.detect-changes.outputs.target == 'production'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -237,6 +245,7 @@ jobs:
           version: latest
 
       - name: Deploy ${{ matrix.function }} to PROD
+        # --no-verify-jwt: see the deploy-test job above for rationale.
         run: |
           supabase functions deploy "${{ matrix.function }}" \
             --project-ref jxlxtzkmicfhchkhiojz \

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - 'supabase/functions/**'
       - '.github/workflows/deploy-edge-functions.yml'
+  # Manual dispatch is intentionally allowed to target `production` directly
+  # (e.g. emergency single-function redeploy). The `production` GitHub
+  # Environment still requires manual approval, but the TEST step does NOT
+  # run first when dispatching to production.
   workflow_dispatch:
     inputs:
       environment:
@@ -41,7 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          # Full history needed so the PR three-dot diff
+          # (origin/<base>...HEAD) can resolve its merge base on PRs
+          # with more than two commits since branching.
+          fetch-depth: 0
 
       - name: Plan deployment
         id: plan
@@ -53,20 +60,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          ALL_FUNCTIONS=(
-            detect-duplicates
-            extract-google-doc
-            generate-embeddings
-            generate-gemini-embeddings
-            import-lessons
-            invitation-management
-            password-reset
-            process-submission
-            search-lessons
-            send-email
-            smart-search
-            user-management
+          # Discover deployable functions from the filesystem so adding a new
+          # function under supabase/functions/<name>/ doesn't require editing
+          # this workflow. The `_*` filter excludes `_shared` and any future
+          # underscore-prefixed support directories.
+          mapfile -t ALL_FUNCTIONS < <(
+            find supabase/functions -mindepth 1 -maxdepth 1 -type d \
+              -not -name '_*' -printf '%f\n' | sort
           )
+
+          if [ "${#ALL_FUNCTIONS[@]}" -eq 0 ]; then
+            echo "::error::No edge functions discovered under supabase/functions/"
+            exit 1
+          fi
+          echo "Discovered functions: ${ALL_FUNCTIONS[*]}"
 
           is_valid_function() {
             local name="$1"
@@ -92,7 +99,9 @@ jobs:
               ;;
             pull_request)
               TARGET="test"
-              git fetch origin "$BASE_REF" --depth=1
+              # Unshallow fetch of base so the three-dot merge base resolves
+              # even if main has advanced since the PR branched.
+              git fetch origin "$BASE_REF"
               CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" -- supabase/functions/ || true)
               ;;
             push)

--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -57,6 +57,7 @@ jobs:
           DISPATCH_ENV: ${{ inputs.environment }}
           DISPATCH_FUNC: ${{ inputs.function }}
           BASE_REF: ${{ github.base_ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
 
@@ -110,7 +111,17 @@ jobs:
               ;;
             push)
               TARGET="production"
-              CHANGED=$(git diff --name-only HEAD~1 HEAD -- supabase/functions/ || true)
+              # github.event.before is the SHA before the push, so it covers
+              # the entire batch when multiple commits land at once. HEAD~1
+              # would only see the last commit's diff and miss earlier ones.
+              if [[ "$PUSH_BEFORE" =~ ^0+$ ]]; then
+                # Initial push or force-push that orphans history; history is
+                # unrecoverable, so deploy everything as the safe recovery.
+                echo "::warning::Push has no usable 'before' SHA (initial or force-push); deploying all functions."
+                FUNCS=("${ALL_FUNCTIONS[@]}")
+              else
+                CHANGED=$(git diff --name-only "$PUSH_BEFORE" HEAD -- supabase/functions/ || true)
+              fi
               ;;
             *)
               echo "::error::Unsupported event: $EVENT_NAME"
@@ -118,17 +129,19 @@ jobs:
               ;;
           esac
 
-          if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
-            if echo "$CHANGED" | grep -q '^supabase/functions/_shared/'; then
+          # Process CHANGED only when a branch above set it. Skip when FUNCS
+          # is already populated (workflow_dispatch, or the orphan-history
+          # full-suite recovery in the push branch).
+          if [ "${#FUNCS[@]}" -eq 0 ]; then
+            if echo "${CHANGED:-}" | grep -q '^supabase/functions/_shared/'; then
               echo "Shared code changed — deploying all functions."
               FUNCS=("${ALL_FUNCTIONS[@]}")
             else
               mapfile -t FUNC_DIRS < <(
-                echo "$CHANGED" \
+                echo "${CHANGED:-}" \
                   | sed -n 's|^supabase/functions/\([^/]*\)/.*|\1|p' \
                   | sort -u
               )
-              FUNCS=()
               for name in "${FUNC_DIRS[@]}"; do
                 if is_valid_function "$name"; then
                   FUNCS+=("$name")

--- a/docs/edge-functions-setup.md
+++ b/docs/edge-functions-setup.md
@@ -8,21 +8,36 @@ The 500 error when sending invitations occurs because the edge function is eithe
 
 ### 1. Deploy Edge Functions
 
-Run the deployment script:
+**Primary path: the `deploy-edge-functions.yml` GitHub workflow.**
+
+- PRs that touch `supabase/functions/**` auto-deploy the changed functions to the TEST project (`rxgajgmphciuaqzvwmox`) and leave a comment on the PR.
+- Pushes to `main` that touch `supabase/functions/**` deploy to PROD (`jxlxtzkmicfhchkhiojz`), gated by the `production` GitHub Environment for manual approval (same pattern as `migrate-production.yml`).
+- Manual runs (e.g. re-deploying a single function or backfilling TEST) use `workflow_dispatch`:
+
 ```bash
-./scripts/deploy-edge-functions.sh
+# Deploy every function to TEST
+gh workflow run deploy-edge-functions.yml \
+  --field environment=test \
+  --field function=all
+
+# Redeploy a single function to PROD (prompts approval in the Actions UI)
+gh workflow run deploy-edge-functions.yml \
+  --field environment=production \
+  --field function=send-email
 ```
 
-Or deploy manually using Supabase CLI:
+**Break-glass fallback: `./scripts/deploy-edge-functions.sh`.**
+
+The script still exists but prompts for confirmation and deploys straight to PROD from your laptop, skipping TEST. Only use it when CI is unavailable. For one-off manual work, this is equivalent:
+
 ```bash
 # Install Supabase CLI if not already installed
 brew install supabase/tap/supabase
 
-# Link your project (you'll need your project ID)
-supabase link --project-ref jxlxtzkmicfhchkhiojz
-
-# Deploy the send-email function
-supabase functions deploy send-email --no-verify-jwt
+# Deploy a single function (no `supabase link` needed)
+supabase functions deploy send-email \
+  --project-ref jxlxtzkmicfhchkhiojz \
+  --no-verify-jwt
 ```
 
 ### 2. Set Environment Variables

--- a/docs/edge-functions-setup.md
+++ b/docs/edge-functions-setup.md
@@ -26,6 +26,8 @@ gh workflow run deploy-edge-functions.yml \
   --field function=send-email
 ```
 
+**Workflow secret:** the workflow uses `SUPABASE_ACCESS_TOKEN` (a single repo secret) to deploy to both TEST and PROD. The token must be issued from a Supabase account that has access to both project refs (`rxgajgmphciuaqzvwmox` and `jxlxtzkmicfhchkhiojz`). Same token is already shared by `migrate-production.yml` and `e2e.yml`.
+
 **Break-glass fallback: `./scripts/deploy-edge-functions.sh`.**
 
 The script still exists but prompts for confirmation and deploys straight to PROD from your laptop, skipping TEST. Only use it when CI is unavailable. For one-off manual work, this is equivalent:

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -40,6 +40,9 @@ if [ ! -d "$FUNCTIONS_DIR" ]; then
 fi
 
 FUNCTIONS=()
+# nullglob so an empty directory expands to nothing instead of leaving the
+# literal `*/` pattern in the loop variable (which would add `*` to FUNCTIONS).
+shopt -s nullglob
 for dir in "$FUNCTIONS_DIR"/*/; do
     name="$(basename "$dir")"
     case "$name" in
@@ -47,6 +50,7 @@ for dir in "$FUNCTIONS_DIR"/*/; do
         *) FUNCTIONS+=("$name") ;;
     esac
 done
+shopt -u nullglob
 
 if [ "${#FUNCTIONS[@]}" -eq 0 ]; then
     echo "❌ No edge functions discovered under $FUNCTIONS_DIR"

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -29,21 +29,29 @@ if ! command -v supabase &> /dev/null; then
     exit 1
 fi
 
-# List of all edge functions to deploy
-FUNCTIONS=(
-    "detect-duplicates"
-    "extract-google-doc"
-    "generate-embeddings"
-    "generate-gemini-embeddings"
-    "import-lessons"
-    "invitation-management"
-    "password-reset"
-    "process-submission"
-    "search-lessons"
-    "send-email"
-    "smart-search"
-    "user-management"
-)
+# Discover deployable functions from the filesystem so this script can't drift
+# from the workflow's filesystem-based discovery. Pure-bash glob so it works on
+# macOS (bash 3.2) without depending on GNU find or `mapfile`.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTIONS_DIR="$SCRIPT_DIR/../supabase/functions"
+if [ ! -d "$FUNCTIONS_DIR" ]; then
+    echo "❌ Could not locate supabase/functions/ relative to this script."
+    exit 1
+fi
+
+FUNCTIONS=()
+for dir in "$FUNCTIONS_DIR"/*/; do
+    name="$(basename "$dir")"
+    case "$name" in
+        _*) ;;  # skip _shared and other underscore-prefixed support dirs
+        *) FUNCTIONS+=("$name") ;;
+    esac
+done
+
+if [ "${#FUNCTIONS[@]}" -eq 0 ]; then
+    echo "❌ No edge functions discovered under $FUNCTIONS_DIR"
+    exit 1
+fi
 
 # Deploy each function
 for func in "${FUNCTIONS[@]}"; do

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
-# Deploy Edge Functions to Supabase
-# This script deploys all edge functions to your Supabase project
+# Deploy Edge Functions to Supabase (manual / break-glass)
+#
+# Prefer the GitHub workflow for routine deploys — it deploys to TEST on PRs
+# and to PROD from main with manual approval, so code never skips the test
+# environment the way this script does.
 
 set -e
+
+echo "⚠️  This script bypasses CI and deploys directly to PROD from your laptop."
+echo "   Prefer the GitHub workflow for routine deploys:"
+echo "     gh workflow run deploy-edge-functions.yml --field environment=test"
+echo "     gh workflow run deploy-edge-functions.yml --field environment=production"
+echo ""
+read -r -p "Continue with manual deploy? (y/N) " reply
+echo
+case "$reply" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo "Aborted."; exit 1 ;;
+esac
 
 echo "🚀 Deploying Edge Functions to Supabase..."
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-edge-functions.yml`: auto-deploys changed functions to TEST on PR push, to PROD on main push (manual approval via the `production` GitHub Environment, same pattern as `migrate-production.yml`), plus `workflow_dispatch` for ad-hoc deploys of one function or the whole suite.
- Matrix-parallelizes function deploys (max 4 in flight) with `fail-fast: false`; `_shared/**` changes trigger a full-suite deploy since every function can import from there.
- Updates `./scripts/deploy-edge-functions.sh` to warn and require y/N confirmation — it's now a break-glass tool, not the default path.
- Rewrites the "Deploy Edge Functions" section of `docs/edge-functions-setup.md` to make the workflow the primary path and the script the fallback.

## Context

Closes the edge-function deployment gap surfaced in PR #437's Workstream B verification: previously, no CI path deployed edge functions, so code went laptop → PROD with no test environment. See `~/.claude/plans/path-b-edge-functions-and-cleanup.md` Step B1 for the full design rationale.

## Test plan

- [ ] CI lints the workflow file (implicit — GitHub will parse it once pushed)
- [ ] After merge, manually trigger `workflow_dispatch` with `environment=test, function=all` to backfill all 12 functions on the TEST project (`rxgajgmphciuaqzvwmox`)
- [ ] Verify via `mcp__supabase-test__list_edge_functions` that all 12 appear
- [ ] Smoke-curl `smart-search` on TEST with the test anon key → expect 200
- [ ] Confirm PR #437 branch is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)