### PR TITLE
fix(submission): replace inaccurate email promise with profile pointer

### DIFF
--- a/src/pages/SubmissionPage.tsx
+++ b/src/pages/SubmissionPage.tsx
@@ -393,7 +393,7 @@ export function SubmissionPage() {
             <li>· Include grade levels, objectives, and materials needed.</li>
             <li>· Add step-by-step instructions for activities.</li>
             <li>· Submissions are reviewed within 2–3 business days.</li>
-            <li>· You'll receive an email once your lesson is approved.</li>
+            <li>· Track your submission's status from your profile.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The submission success page promised teachers an email on approval, but **no submission emails are ever sent** today (no `send-email` template for it, no trigger from `process-submission` or the review save path).
- Teachers checking for the promised email currently get nothing. Until the notification pipeline ships, point them at `/profile` where they can actually see status today.

## Context
This is the calibration run for the lesson-submission Tier-1 work — the smallest, lowest-risk piece in the plan, used to verify the full PR/CI/merge workflow before higher-stakes data and schema changes ship.

The full plan lives at `~/.claude/plans/lesson-submission-tier1-implementation.md` (Phase 7a). The actual email infrastructure is Phase 7c, which depends on Phase 4's atomic `complete-review` edge function.

## Test plan
- [ ] CI green (type-check, lint, tests, E2E)
- [ ] Eyeball Netlify preview's `/submit` page after a successful submission — bullet list reads "Track your submission's status from your profile." instead of the email line
- [ ] Confirm no other copy in the page references emails (none expected; verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)