### PR TITLE
feat(submission): pass real metadata sketch to detect-duplicates

### DIFF
--- a/supabase/functions/_shared/google-docs-parser.test.ts
+++ b/supabase/functions/_shared/google-docs-parser.test.ts
@@ -135,6 +135,11 @@ describe('extractMetadataFromContent', () => {
       );
       expect(sketch.activityType).toBeUndefined();
     });
+
+    it('emits "academic-only" from labeled header', () => {
+      const sketch = extractMetadataFromContent('Activity Type: Academic Only');
+      expect(sketch.activityType).toBe('academic-only');
+    });
   });
 
   describe('cultural heritage', () => {

--- a/supabase/functions/_shared/google-docs-parser.test.ts
+++ b/supabase/functions/_shared/google-docs-parser.test.ts
@@ -29,6 +29,27 @@ describe('extractMetadataFromContent', () => {
       const sketch = extractMetadataFromContent('A lesson about apples.');
       expect(sketch.gradeLevels).toBeUndefined();
     });
+
+    it('emits only K for bare "Kindergarten" in prose', () => {
+      const sketch = extractMetadataFromContent(
+        'Designed for Kindergarten students.'
+      );
+      expect(sketch.gradeLevels).toEqual(['K']);
+    });
+
+    it('emits only PK for "Pre-Kindergarten" in prose (no K spillover)', () => {
+      const sketch = extractMetadataFromContent(
+        'Designed for Pre-Kindergarten students.'
+      );
+      expect(sketch.gradeLevels).toEqual(['PK']);
+    });
+
+    it('emits only PK for "prekindergarten" (no hyphen, no K spillover)', () => {
+      const sketch = extractMetadataFromContent(
+        'A prekindergarten lesson.'
+      );
+      expect(sketch.gradeLevels).toEqual(['PK']);
+    });
   });
 
   describe('seasons', () => {

--- a/supabase/functions/_shared/google-docs-parser.test.ts
+++ b/supabase/functions/_shared/google-docs-parser.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { extractMetadataFromContent } from './google-docs-parser';
+
+describe('extractMetadataFromContent', () => {
+  describe('grade levels', () => {
+    it('parses labeled list of bare digits', () => {
+      const sketch = extractMetadataFromContent('Grade Levels: 3, 4, 5');
+      expect(sketch.gradeLevels?.sort()).toEqual(['3', '4', '5']);
+    });
+
+    it('parses labeled list with K and ranges', () => {
+      const sketch = extractMetadataFromContent('Grades: K-2');
+      expect(sketch.gradeLevels?.sort()).toEqual(['1', '2', 'K']);
+    });
+
+    it('parses labeled list with PK', () => {
+      const sketch = extractMetadataFromContent('Grade: Pre-K, K, 1');
+      expect(sketch.gradeLevels?.sort()).toEqual(['1', 'K', 'PK']);
+    });
+
+    it('parses ordinal phrases in prose', () => {
+      const sketch = extractMetadataFromContent(
+        'This lesson is designed for 3rd grade and fourth grade students.'
+      );
+      expect(sketch.gradeLevels?.sort()).toEqual(['3', '4']);
+    });
+
+    it('omits gradeLevels when no signal', () => {
+      const sketch = extractMetadataFromContent('A lesson about apples.');
+      expect(sketch.gradeLevels).toBeUndefined();
+    });
+  });
+
+  describe('seasons', () => {
+    it('parses labeled season header', () => {
+      const sketch = extractMetadataFromContent('Season: Fall, Winter');
+      expect(sketch.seasonTiming?.sort()).toEqual(['Fall', 'Winter']);
+    });
+
+    it('parses "Season & Timing" header', () => {
+      const sketch = extractMetadataFromContent('Season & Timing: Spring');
+      expect(sketch.seasonTiming).toEqual(['Spring']);
+    });
+
+    it('emits Fall on autumn (unambiguous)', () => {
+      const sketch = extractMetadataFromContent(
+        'Students explore changes during the autumn season.'
+      );
+      expect(sketch.seasonTiming).toContain('Fall');
+    });
+
+    it('emits Fall on contextual phrase "in the fall"', () => {
+      const sketch = extractMetadataFromContent(
+        'This lesson works well in the fall when leaves change color.'
+      );
+      expect(sketch.seasonTiming).toContain('Fall');
+    });
+
+    it('does NOT emit Fall on bare "fall down" (false-positive guard)', () => {
+      const sketch = extractMetadataFromContent(
+        'Be careful not to fall down or drop the equipment.'
+      );
+      expect(sketch.seasonTiming).toBeUndefined();
+    });
+
+    it('does NOT emit Spring on "spring up" without seasonal context', () => {
+      const sketch = extractMetadataFromContent(
+        'Watch the seedlings spring up from the soil.'
+      );
+      expect(sketch.seasonTiming).toBeUndefined();
+    });
+  });
+
+  describe('thematic categories', () => {
+    it('matches multi-word phrases case-insensitively', () => {
+      const sketch = extractMetadataFromContent(
+        'A unit on plant growth and food justice.'
+      );
+      expect(sketch.thematicCategories?.sort()).toEqual([
+        'Food Justice',
+        'Plant Growth',
+      ]);
+    });
+
+    it('omits when no theme phrase appears', () => {
+      const sketch = extractMetadataFromContent(
+        'A lesson about ovens and recipes.'
+      );
+      expect(sketch.thematicCategories).toBeUndefined();
+    });
+  });
+
+  describe('activity type', () => {
+    it('emits "both" when labeled with cooking + garden', () => {
+      const sketch = extractMetadataFromContent('Activity Type: Cooking + Garden');
+      expect(sketch.activityType).toBe('both');
+    });
+
+    it('emits "cooking-only" from labeled header', () => {
+      const sketch = extractMetadataFromContent('Activity Type: Cooking Only');
+      expect(sketch.activityType).toBe('cooking-only');
+    });
+
+    it('emits "garden-only" from frequency when threshold met and no cooking', () => {
+      const content =
+        'Students will be planting seeds in the garden. They will harvest and observe seedlings. Add compost to the garden bed.';
+      const sketch = extractMetadataFromContent(content);
+      expect(sketch.activityType).toBe('garden-only');
+    });
+
+    it('does NOT emit when below frequency threshold', () => {
+      const sketch = extractMetadataFromContent(
+        'A short mention of garden once.'
+      );
+      expect(sketch.activityType).toBeUndefined();
+    });
+  });
+
+  describe('cultural heritage', () => {
+    it('emits child + parent for "East Asian"', () => {
+      const sketch = extractMetadataFromContent(
+        'Explore East Asian culinary traditions.'
+      );
+      expect(sketch.culturalHeritage?.sort()).toEqual(['asian', 'east-asian']);
+    });
+
+    it('emits "mediterranean" via word match', () => {
+      const sketch = extractMetadataFromContent(
+        'A lesson on Mediterranean herbs.'
+      );
+      expect(sketch.culturalHeritage).toContain('mediterranean');
+    });
+
+    it('omits when no cultural keyword', () => {
+      const sketch = extractMetadataFromContent('A lesson about composting.');
+      expect(sketch.culturalHeritage).toBeUndefined();
+    });
+  });
+
+  describe('cooking methods', () => {
+    it('matches Stovetop and Oven', () => {
+      const sketch = extractMetadataFromContent(
+        'Use the stovetop to simmer; finish in the oven.'
+      );
+      expect(sketch.cookingMethods?.sort()).toEqual(['Oven', 'Stovetop']);
+    });
+
+    it('matches "baking" → Oven', () => {
+      const sketch = extractMetadataFromContent('Students will be baking bread.');
+      expect(sketch.cookingMethods).toContain('Oven');
+    });
+
+    it('omits when no cooking-method keyword', () => {
+      const sketch = extractMetadataFromContent('A garden observation walk.');
+      expect(sketch.cookingMethods).toBeUndefined();
+    });
+  });
+
+  describe('robustness', () => {
+    it('returns empty object on empty input', () => {
+      expect(extractMetadataFromContent('')).toEqual({});
+    });
+
+    it('returns empty object on non-string input', () => {
+      // @ts-expect-error testing runtime guard
+      expect(extractMetadataFromContent(null)).toEqual({});
+      // @ts-expect-error testing runtime guard
+      expect(extractMetadataFromContent(undefined)).toEqual({});
+    });
+
+    it('handles a realistic mock lesson with multiple fields', () => {
+      const content = `
+Grade Levels: 3, 4, 5
+Theme: Plant Growth
+Season: Fall
+
+Overview: Students measure plant growth in the autumn garden.
+They will be planting and harvesting seeds. Compost is added.
+      `.trim();
+      const sketch = extractMetadataFromContent(content);
+      expect(sketch.gradeLevels?.sort()).toEqual(['3', '4', '5']);
+      expect(sketch.thematicCategories).toEqual(['Plant Growth']);
+      expect(sketch.seasonTiming).toEqual(['Fall']);
+      expect(sketch.activityType).toBe('garden-only');
+    });
+  });
+});

--- a/supabase/functions/_shared/google-docs-parser.test.ts
+++ b/supabase/functions/_shared/google-docs-parser.test.ts
@@ -50,6 +50,11 @@ describe('extractMetadataFromContent', () => {
       );
       expect(sketch.gradeLevels).toEqual(['PK']);
     });
+
+    it('parses 3K from labeled list', () => {
+      const sketch = extractMetadataFromContent('Grade Levels: 3K, PK');
+      expect(sketch.gradeLevels?.sort()).toEqual(['3K', 'PK']);
+    });
   });
 
   describe('seasons', () => {
@@ -140,6 +145,15 @@ describe('extractMetadataFromContent', () => {
       const sketch = extractMetadataFromContent('Activity Type: Academic Only');
       expect(sketch.activityType).toBe('academic-only');
     });
+
+    it('emits "both" from frequency inference when both signals are strong', () => {
+      const content =
+        'Students cook a recipe in the kitchen using a stovetop. ' +
+        'They harvest tomatoes from the garden after planting seedlings, ' +
+        'then add compost to the soil bed.';
+      const sketch = extractMetadataFromContent(content);
+      expect(sketch.activityType).toBe('both');
+    });
   });
 
   describe('cultural heritage', () => {
@@ -174,6 +188,13 @@ describe('extractMetadataFromContent', () => {
     it('matches "baking" → Oven', () => {
       const sketch = extractMetadataFromContent('Students will be baking bread.');
       expect(sketch.cookingMethods).toContain('Oven');
+    });
+
+    it('matches "Basic prep" → Basic prep only', () => {
+      const sketch = extractMetadataFromContent(
+        'No heat required — basic prep with knife skills.'
+      );
+      expect(sketch.cookingMethods).toContain('Basic prep only');
     });
 
     it('omits when no cooking-method keyword', () => {

--- a/supabase/functions/_shared/google-docs-parser.ts
+++ b/supabase/functions/_shared/google-docs-parser.ts
@@ -96,9 +96,12 @@ const THEMATIC_CATEGORIES = [
   'Food Justice',
 ];
 
-// Order matters: most specific (multi-word) first so a doc mentioning
-// "East Asian" emits both 'east-asian' and 'asian' (parent membership matches
-// the hierarchical filter semantics in filterDefinitions.ts).
+// Parent categories ('asian', 'african', 'european') fire on the same text
+// that matched a child ('east-asian', etc.) because the child phrase
+// contains the parent word as a substring — extractMatches tests every
+// pattern independently, so order is irrelevant. This double-emit is
+// intentional and matches the hierarchical filter semantics in
+// filterDefinitions.ts (parent selection includes children).
 const CULTURAL_PATTERNS: Array<[RegExp, string]> = [
   [/\beast\s+asian\b/i, 'east-asian'],
   [/\bsoutheast\s+asian\b/i, 'southeast-asian'],

--- a/supabase/functions/_shared/google-docs-parser.ts
+++ b/supabase/functions/_shared/google-docs-parser.ts
@@ -80,7 +80,9 @@ const ORDINAL_GRADE_PATTERNS: Array<[RegExp, string]> = [
   [/\b(?:6th|sixth)\s+grade\b/i, '6'],
   [/\b(?:7th|seventh)\s+grade\b/i, '7'],
   [/\b(?:8th|eighth)\s+grade\b/i, '8'],
-  [/\bkindergarten\b/i, 'K'],
+  // Negative lookbehind so "Pre-Kindergarten" / "prekindergarten" don't also
+  // emit 'K' alongside 'PK' from the next pattern.
+  [/\b(?<!pre-?)kindergarten\b/i, 'K'],
   [/\bpre-?kindergarten\b/i, 'PK'],
 ];
 

--- a/supabase/functions/_shared/google-docs-parser.ts
+++ b/supabase/functions/_shared/google-docs-parser.ts
@@ -46,12 +46,267 @@ export function extractTextFromGoogleDoc(doc: any): string {
   return text.trim();
 }
 
-// Extract basic metadata from content (simplified since reviewer will manually tag)
-export function extractMetadataFromContent(content: string): any {
-  // Just return basic content stats
-  // The reviewer will manually tag all the actual metadata
-  return {
-    // No need to extract grade levels, themes, or skills
-    // since the reviewer will enter these manually
-  };
+/**
+ * Metadata sketch produced by heuristic extraction over Google Doc content.
+ *
+ * Field names match the submission-side keys consumed by detect-duplicates'
+ * calculateMetadataOverlap (gradeLevels, thematicCategories, activityType,
+ * culturalHeritage, seasonTiming, cookingMethods). Values match the canonical
+ * filter values defined in src/utils/filterDefinitions.ts so that Jaccard
+ * comparison against lessons.metadata aligns case-insensitively.
+ *
+ * This is intentionally conservative: a missing field is preferable to a
+ * wrong one, since detect-duplicates skips fields that are missing on either
+ * side and weighted overlap defaults to zero — same as today's empty-object
+ * baseline.
+ */
+export interface MetadataSketch {
+  gradeLevels?: string[];
+  thematicCategories?: string[];
+  activityType?: string;
+  culturalHeritage?: string[];
+  seasonTiming?: string[];
+  cookingMethods?: string[];
+}
+
+// --- Vocabulary (mirrors src/utils/filterDefinitions.ts canonical values) ---
+
+const ORDINAL_GRADE_PATTERNS: Array<[RegExp, string]> = [
+  [/\b(?:1st|first)\s+grade\b/i, '1'],
+  [/\b(?:2nd|second)\s+grade\b/i, '2'],
+  [/\b(?:3rd|third)\s+grade\b/i, '3'],
+  [/\b(?:4th|fourth)\s+grade\b/i, '4'],
+  [/\b(?:5th|fifth)\s+grade\b/i, '5'],
+  [/\b(?:6th|sixth)\s+grade\b/i, '6'],
+  [/\b(?:7th|seventh)\s+grade\b/i, '7'],
+  [/\b(?:8th|eighth)\s+grade\b/i, '8'],
+  [/\bkindergarten\b/i, 'K'],
+  [/\bpre-?kindergarten\b/i, 'PK'],
+];
+
+const THEMATIC_CATEGORIES = [
+  'Garden Basics',
+  'Plant Growth',
+  'Garden Communities',
+  'Ecosystems',
+  'Seed to Table',
+  'Food Systems',
+  'Food Justice',
+];
+
+// Order matters: most specific (multi-word) first so a doc mentioning
+// "East Asian" emits both 'east-asian' and 'asian' (parent membership matches
+// the hierarchical filter semantics in filterDefinitions.ts).
+const CULTURAL_PATTERNS: Array<[RegExp, string]> = [
+  [/\beast\s+asian\b/i, 'east-asian'],
+  [/\bsoutheast\s+asian\b/i, 'southeast-asian'],
+  [/\bsouth\s+asian\b/i, 'south-asian'],
+  [/\bcentral\s+asian\b/i, 'central-asian'],
+  [/\blatin\s+american\b/i, 'latin-american'],
+  [/\bcaribbean\b/i, 'caribbean'],
+  [/\bnorth\s+american\b/i, 'north-american'],
+  [/\bwest\s+african\b/i, 'west-african'],
+  [/\bethiopian\b/i, 'ethiopian'],
+  [/\bnigerian\b/i, 'nigerian'],
+  [/\beastern\s+european\b/i, 'eastern-european'],
+  [/\bmediterranean\b/i, 'mediterranean'],
+  [/\blevantine\b/i, 'levantine'],
+  [/\bmiddle\s+eastern\b/i, 'middle-eastern'],
+  [/\basian\b/i, 'asian'],
+  [/\bafrican\b/i, 'african'],
+  [/\beuropean\b/i, 'european'],
+];
+
+const COOKING_METHOD_PATTERNS: Array<[RegExp, string]> = [
+  [/\bstovetop\b/i, 'Stovetop'],
+  [/\b(?:oven|baking|baked|bake)\b/i, 'Oven'],
+  [/\bbasic\s+prep\b/i, 'Basic prep only'],
+];
+
+// --- Extraction helpers ---
+
+function findLabeledLine(content: string, headerPattern: RegExp): string | null {
+  const m = content.match(headerPattern);
+  return m ? m[1] : null;
+}
+
+function extractGradeLevels(content: string): string[] {
+  const found = new Set<string>();
+
+  // Phase 1: labeled list — "Grade Levels: 3, 4, 5" / "Grades: K-2"
+  const list = findLabeledLine(
+    content,
+    /\bgrade(?:\s+levels?|s)?\s*[:=]\s*([^\n]+)/i
+  );
+  if (list) {
+    // Bare tokens
+    const tokens = list.match(/\b(?:3K|PK|Pre-?K|Kindergarten|[1-8]|K)\b/gi) || [];
+    for (const tok of tokens) {
+      const lower = tok.toLowerCase();
+      if (lower === '3k') found.add('3K');
+      else if (lower === 'pk' || lower === 'pre-k' || lower === 'prek') found.add('PK');
+      else if (lower === 'kindergarten' || lower === 'k') found.add('K');
+      else if (/^[1-8]$/.test(lower)) found.add(lower);
+    }
+    // Ranges: "K-2", "3-5"
+    const rangeMatches = list.matchAll(/\b([1-8K])\s*[-–]\s*([1-8])\b/gi);
+    for (const m of rangeMatches) {
+      const startToken = m[1].toUpperCase();
+      const start = startToken === 'K' ? 0 : parseInt(startToken, 10);
+      const end = parseInt(m[2], 10);
+      for (let i = start; i <= end; i++) {
+        if (i === 0) found.add('K');
+        else if (i >= 1 && i <= 8) found.add(String(i));
+      }
+    }
+  }
+
+  // Phase 2: ordinal phrases anywhere in content
+  for (const [pattern, value] of ORDINAL_GRADE_PATTERNS) {
+    if (pattern.test(content)) found.add(value);
+  }
+
+  return Array.from(found);
+}
+
+function extractSeasons(content: string): string[] {
+  const found = new Set<string>();
+
+  // Labeled list: "Season: Fall" / "Season & Timing: Fall, Winter"
+  const list = findLabeledLine(
+    content,
+    /\b(?:season(?:\s*(?:&|and)\s*timing)?|timing)\s*[:=]\s*([^\n]+)/i
+  );
+  if (list) {
+    const lower = list.toLowerCase();
+    if (/\bfall\b|\bautumn\b/.test(lower)) found.add('Fall');
+    if (/\bwinter\b/.test(lower)) found.add('Winter');
+    if (/\bspring\b/.test(lower)) found.add('Spring');
+    if (/\bsummer\b/.test(lower)) found.add('Summer');
+  }
+
+  // Phrase forms (strict — require seasonal context so "fall down" doesn't
+  // emit Fall). Autumn is unambiguous, so it's accepted bare.
+  if (/\bautumn\b/i.test(content)) found.add('Fall');
+  if (
+    /\bfall\s+(?:season|harvest|planting|garden|lesson|equinox|weather)\b/i.test(
+      content
+    ) ||
+    /\b(?:in|during)\s+(?:the\s+)?fall\b/i.test(content)
+  ) {
+    found.add('Fall');
+  }
+  if (
+    /\bwinter\s+(?:season|harvest|garden|lesson|solstice|weather)\b/i.test(
+      content
+    ) ||
+    /\b(?:in|during)\s+(?:the\s+)?winter\b/i.test(content)
+  ) {
+    found.add('Winter');
+  }
+  if (
+    /\bspring\s+(?:season|harvest|planting|garden|lesson|equinox|weather)\b/i.test(
+      content
+    ) ||
+    /\b(?:in|during)\s+(?:the\s+)?spring\b/i.test(content)
+  ) {
+    found.add('Spring');
+  }
+  if (
+    /\bsummer\s+(?:season|harvest|garden|lesson|solstice|weather)\b/i.test(
+      content
+    ) ||
+    /\b(?:in|during)\s+(?:the\s+)?summer\b/i.test(content)
+  ) {
+    found.add('Summer');
+  }
+
+  return Array.from(found);
+}
+
+function extractActivityType(content: string): string | undefined {
+  const list = findLabeledLine(content, /\bactivity\s+type\s*[:=]\s*([^\n]+)/i);
+  if (list) {
+    const lower = list.toLowerCase();
+    const cooking = /cooking|kitchen/.test(lower);
+    const garden = /garden/.test(lower);
+    const academic = /academic/.test(lower);
+    if (cooking && garden) return 'both';
+    if (cooking) return 'cooking-only';
+    if (garden) return 'garden-only';
+    if (academic) return 'academic-only';
+  }
+  // Frequency-based inference. Threshold ≥3 to require strong signal.
+  const cookingHits = (
+    content.match(
+      /\b(?:cooking|recipe|stovetop|oven|kitchen|knife\s+skills|chopping|sautéing|sauteing|simmer)\b/gi
+    ) || []
+  ).length;
+  const gardenHits = (
+    content.match(
+      /\b(?:garden|planting|harvest|soil|compost|seedling|seed-?starting|sowing|transplant)\b/gi
+    ) || []
+  ).length;
+  if (cookingHits >= 3 && gardenHits >= 3) return 'both';
+  if (cookingHits >= 3 && gardenHits === 0) return 'cooking-only';
+  if (gardenHits >= 3 && cookingHits === 0) return 'garden-only';
+  return undefined;
+}
+
+function extractMatches(
+  content: string,
+  patterns: Array<[RegExp, string]>
+): string[] {
+  const found = new Set<string>();
+  for (const [pattern, value] of patterns) {
+    if (pattern.test(content)) found.add(value);
+  }
+  return Array.from(found);
+}
+
+function extractThematicCategories(content: string): string[] {
+  const found = new Set<string>();
+  const lower = content.toLowerCase();
+  for (const val of THEMATIC_CATEGORIES) {
+    if (lower.includes(val.toLowerCase())) found.add(val);
+  }
+  return Array.from(found);
+}
+
+/**
+ * Heuristic metadata sketch from lesson content. Used to seed the metadata-
+ * overlap component of detect-duplicates' scoring formula at submission time.
+ *
+ * This is intentionally not LLM-quality: it only needs to be better than the
+ * empty-object baseline. Tier-3 #17 (AI-assisted metadata pre-fill) is the
+ * higher-quality successor for reviewer-facing pre-fill.
+ *
+ * Fields are omitted (not empty-array-set) when no signal is found, so that
+ * detect-duplicates' calculateMetadataOverlap skips them rather than treating
+ * them as authoritatively empty.
+ */
+export function extractMetadataFromContent(content: string): MetadataSketch {
+  if (!content || typeof content !== 'string') return {};
+
+  const sketch: MetadataSketch = {};
+
+  const grades = extractGradeLevels(content);
+  if (grades.length > 0) sketch.gradeLevels = grades;
+
+  const themes = extractThematicCategories(content);
+  if (themes.length > 0) sketch.thematicCategories = themes;
+
+  const activity = extractActivityType(content);
+  if (activity) sketch.activityType = activity;
+
+  const cultural = extractMatches(content, CULTURAL_PATTERNS);
+  if (cultural.length > 0) sketch.culturalHeritage = cultural;
+
+  const seasons = extractSeasons(content);
+  if (seasons.length > 0) sketch.seasonTiming = seasons;
+
+  const methods = extractMatches(content, COOKING_METHOD_PATTERNS);
+  if (methods.length > 0) sketch.cookingMethods = methods;
+
+  return sketch;
 }

--- a/supabase/functions/extract-google-doc/index.ts
+++ b/supabase/functions/extract-google-doc/index.ts
@@ -119,6 +119,7 @@ serve(async (req) => {
 
         const doc = await docResponse.json();
         const content = extractTextFromGoogleDoc(doc);
+        const metadataSketch = extractMetadataFromContent(content);
 
         return new Response(
           JSON.stringify({
@@ -132,6 +133,7 @@ serve(async (req) => {
                 extractionMethod: 'google-api',
                 hasImages: doc.inlineObjects ? Object.keys(doc.inlineObjects).length > 0 : false,
               },
+              metadataSketch,
               extractedAt: new Date().toISOString(),
             },
           }),
@@ -248,6 +250,7 @@ Always consult adults before using herbs medicinally. Some plants can cause alle
         hasImages: false,
         warning: 'Using mock data - Google service account not configured',
       },
+      metadataSketch: extractMetadataFromContent(mockLesson.content),
     };
 
     return new Response(

--- a/supabase/functions/process-submission/index.ts
+++ b/supabase/functions/process-submission/index.ts
@@ -1,6 +1,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import { getRestrictedCorsHeaders } from '../_shared/cors.ts';
+import type { MetadataSketch } from '../_shared/google-docs-parser.ts';
 
 interface ProcessSubmissionRequest {
   googleDocUrl?: string;
@@ -129,7 +130,7 @@ serve(async (req) => {
     let submission;
     let title: string;
     let content: string;
-    let metadataSketch: Record<string, unknown> = {};
+    let metadataSketch: MetadataSketch = {};
 
     // Handle regenerating embeddings for existing submissions
     if (regenerateEmbedding && submissionId) {

--- a/supabase/functions/process-submission/index.ts
+++ b/supabase/functions/process-submission/index.ts
@@ -129,6 +129,7 @@ serve(async (req) => {
     let submission;
     let title: string;
     let content: string;
+    let metadataSketch: Record<string, unknown> = {};
 
     // Handle regenerating embeddings for existing submissions
     if (regenerateEmbedding && submissionId) {
@@ -202,6 +203,7 @@ serve(async (req) => {
 
       title = extractResult.data.title;
       content = extractResult.data.content;
+      metadataSketch = extractResult.data.metadataSketch ?? {};
 
       // Step 3: Update submission with extracted content and title
       const { error: updateError } = await supabaseAdmin
@@ -295,7 +297,7 @@ serve(async (req) => {
           submissionId: submission.id,
           content,
           title,
-          metadata: {}, // Would extract from content in production
+          metadata: metadataSketch,
           embedding: contentEmbedding,
         }),
       });


### PR DESCRIPTION
## Summary
- `process-submission` was calling `detect-duplicates` with `metadata: {}`, zeroing out the metadata-overlap component of the duplicate-scoring formula (weighted 0.2 with embedding, 0.3 without). At submission time, dup detection was relying entirely on content hash + semantic embedding — reviewers saw fewer/lower-confidence candidates than the algorithm could surface.
- Replace the placeholder with a heuristic metadata sketch extracted inside `extract-google-doc` and threaded through to `detect-duplicates`. Covers the six fields the scorer actually consumes (`gradeLevels`, `thematicCategories`, `activityType`, `culturalHeritage`, `seasonTiming`, `cookingMethods`). `mainIngredients` is skipped — no canonical vocabulary exists in `filterDefinitions.ts`.
- This is part of the Tier-1 lesson-submission recovery work (Tier-1 #8 / Phase 7b in the implementation plan).

## Design notes

- **Bias is to under-emit.** A missing field is preferable to a wrong one — `calculateMetadataOverlap` skips fields absent on either side, so an omitted field contributes the same zero-weight as today's `{}`. Noise floods the reviewer queue; conservatism doesn't.
- **Vocabulary is inlined** in `_shared/google-docs-parser.ts` and mirrors canonical values from `src/utils/filterDefinitions.ts`. Edge functions are Deno; cross-runtime sharing isn't worth the lift for a heuristic that only needs to be better than zero.
- **Seasons are strict.** Bare "fall" requires nearby seasonal context (`fall season`, `fall harvest`, `in the fall`) so phrases like "fall down" don't emit Fall. Autumn is unambiguous and accepted bare.
- **Cultural heritage emits child + parent** when both match (e.g. "East Asian" → `['east-asian', 'asian']`), mirroring the hierarchical-filter semantics where parent selection includes children.
- **Heuristic, not LLM-quality.** Tier-3 #17 (AI-assisted metadata pre-fill) is the higher-quality successor for reviewer-facing pre-fill — different change with different latency/cost tradeoffs.

## Test plan
- [x] Unit tests: 26 cases covering grade levels (labeled list, ranges, ordinal phrases), seasons (header + contextual phrases + false-positive guards on "fall down"/"spring up"), thematic categories, activity-type frequency inference, cultural heritage child+parent, cooking methods, robustness on empty/non-string input
- [x] Full Vitest suite: 423/423 pass
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] Post-merge: re-submit a known Google Doc on the deploy preview, confirm `submission_similarities` rows now populate `metadata_overlap_score > 0` for matches that previously zeroed out (regression check via `mcp__supabase-test__execute_sql`)

## Rollback
Revert the edge-function changes; redeploy. No DB writes, no schema changes — purely in-memory metadata flow between edge functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)