### PR TITLE
chore(db): revoke EXECUTE on publish_approved_submissions (Tier-1 1b stage 1)

### DIFF
--- a/supabase/migrations/20260426000000_revoke_publish_approved_submissions.sql
+++ b/supabase/migrations/20260426000000_revoke_publish_approved_submissions.sql
@@ -1,0 +1,21 @@
+-- Phase 1b Stage 1 of the lesson-submission Tier-1 lock-down.
+--
+-- publish_approved_submissions() is SECURITY DEFINER and broadly granted to
+-- anon, authenticated, and service_role, but called by NOTHING in src/,
+-- supabase/functions/, or scripts/. Its semantics also publish prior
+-- approve_update submissions as fresh duplicates of the lessons they were
+-- meant to update, because its orphan-finder query does not filter
+-- submission_type != 'update'. Running it would create silent data damage.
+--
+-- This migration revokes EXECUTE from PUBLIC, anon, and authenticated to
+-- close the public-facing hazard surface. service_role retains EXECUTE so a
+-- privileged break-glass path remains if Stage 2 (DROP) turns out to be
+-- premature. If no permission-denied errors surface in production logs over
+-- a 1-2 week observation window, a follow-up migration will DROP the
+-- function entirely.
+--
+-- Reversal: GRANT EXECUTE ON FUNCTION public.publish_approved_submissions(integer)
+--   TO authenticated;  -- (and anon if needed)
+
+REVOKE EXECUTE ON FUNCTION public.publish_approved_submissions(integer)
+  FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Summary

Phase 1b Stage 1 of the lesson-submission Tier-1 lock-down. Revokes `EXECUTE` on `public.publish_approved_submissions(integer)` from `PUBLIC`, `anon`, and `authenticated`.

**Why now:** the function is `SECURITY DEFINER`, broadly granted, called by nothing in repo (verified across `src/`, `supabase/functions/`, `scripts/`), and its orphan-finder query lacks a `submission_type != 'update'` filter — so running it would publish prior `approve_update` submissions as fresh duplicates of the lessons they were meant to update. This is the smallest reversible step that neutralizes that hazard.

**Why two stages:**
- **Stage 1 (this PR)** — REVOKE from public-facing roles. Reversible with a `GRANT EXECUTE` migration if a hidden caller surfaces. `service_role` retains EXECUTE intentionally as a privileged break-glass path.
- **Stage 2 (deferred)** — `DROP FUNCTION` after 1–2 weeks of post-deploy log-watch with zero permission-denied errors.

## Code paths affected

None. The function still exists; it's just unreachable from `anon` and `authenticated` clients. No application code calls it.

## Test plan

- [x] Local: `supabase db reset` applies migration cleanly.
- [x] Local: `pg_proc.proacl` for the function is `{postgres=X/postgres,service_role=X/postgres}` after migration — anon/authenticated/PUBLIC stripped.
- [ ] CI applies migration to TEST DB.
- [ ] Verify on TEST DB via `mcp__supabase-test__execute_sql`:
  ```sql
  SELECT proname, proacl::text
  FROM pg_proc
  WHERE proname = 'publish_approved_submissions';
  ```
  Expect `proacl` to omit anon/authenticated/PUBLIC.
- [ ] Negative test on TEST DB as authenticated role: `SELECT publish_approved_submissions(1);` should error `permission denied`.
- [ ] Post-prod-deploy: same `pg_proc` query against PROD; begin 1–2 week log watch for `permission denied for function publish_approved_submissions` errors. Zero such errors → green-light Stage 2.

## Plan reference

`/Users/danfeder/.claude/plans/lesson-submission-tier1-implementation.md` §3 Phase 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)