### PR TITLE
fix(ci): add pipefail to migration workflows so apply failures fail loudly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Show pending migrations (dry-run)
         if: steps.migration-check.outputs.migrations == 'true'
         run: |
+          # pipefail: a failing `supabase db push --dry-run` must NOT be
+          # masked by `tee` returning 0 (see migrate-production.yml for
+          # the incident this prevents).
+          set -o pipefail
           mkdir -p /tmp/migration-report
           echo "## 🔍 Pending Migrations for TEST Database" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -167,6 +167,10 @@ jobs:
       - name: Show pending migrations (dry-run)
         id: dry-run
         run: |
+          # pipefail: a failing `supabase db push --dry-run` must NOT be
+          # masked by `tee` returning 0 — otherwise the workflow paints
+          # itself green while the underlying command failed.
+          set -o pipefail
           mkdir -p /tmp/migration-report
           echo "## 🔍 Pending Migrations for PRODUCTION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -298,6 +302,12 @@ jobs:
 
       - name: Apply migrations to PRODUCTION
         run: |
+          # pipefail: a failing `supabase db push` must NOT be masked by
+          # `tee` returning 0. Without this, an auth/connection failure
+          # paints the workflow green while no migration actually applied
+          # (incident on 2026-04-27 — orphan-recovery migration was
+          # silently skipped on first attempt).
+          set -o pipefail
           echo "## ✅ Applying Migrations to PRODUCTION" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -308,6 +318,10 @@ jobs:
 
       - name: Verify migration success
         run: |
+          # pipefail: same reasoning as the Apply step. A failing
+          # `supabase migration list` is diagnostic-worthy; don't let
+          # tee swallow its exit code.
+          set -o pipefail
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## 📋 Current Migration Status" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Adds \`set -o pipefail\` to the 4 \`run:\` blocks across \`migrate-production.yml\` and \`e2e.yml\` that pipe a \`supabase\` command through \`tee\`. Without it, the pipeline's exit code is \`tee\`'s (always 0 on a successful write), so a failed \`supabase db push\` is masked and the workflow falsely reports success.
- Scoped to exactly the 4 piped supabase commands. \`backup-production.yml\` has no piped supabase commands; \`reset-test-db.yml\`'s pipes use \`|| true\` deliberately for failure-tolerance — both correctly excluded.
- Comments explain the WHY in-line so future readers don't reinvent the same gotcha.

## Why this exists

Real incident on 2026-04-27 (a few hours ago). Workflow run [\`24970415465\`](https://github.com/danfeder/esnyc-lesson-search-react/actions/runs/24970415465) of \`migrate-production.yml\` had its Apply step fail with \`failed SASL auth (invalid SCRAM server-final-message received from server)\`. The pipeline:

\`\`\`bash
supabase db push 2>&1 | tee -a \$GITHUB_STEP_SUMMARY
\`\`\`

…exited 0 anyway, because \`tee\` writes successfully even when the upstream fails. GitHub painted the run green, the "✅ Production migrations complete!" summary line printed, but no migration actually applied to PROD. The orphan-recovery migration was caught only by the post-apply MCP verification step (\`mcp__supabase-remote__execute_sql\` showed orphan count was unchanged). A second workflow attempt (\`gh run rerun\`) succeeded with no other variables changing, confirming the underlying SASL error was transient.

This PR can't prevent the transient pooler hiccup, but it ensures the next one fails the workflow loudly instead of silently.

## What's in scope

| File | Run blocks edited |
|------|-------------------|
| \`migrate-production.yml\` | dry-run (line ~167), apply (line ~303), verify (line ~313) |
| \`e2e.yml\` | dry-run (line ~46) |

\`e2e.yml\`'s actual TEST apply at line 121 is **not** piped (\`supabase db push --db-url ...\`) and already correctly propagates exit codes — no change needed there.

## What's NOT in scope

- \`set -u\` (nounset) — could break unrelated env-var lookups; minimal fix only.
- The \`reset-test-db.yml\` pipes — they use \`|| true\` deliberately for failure-tolerance.
- Pinning the supabase CLI version (\`version: latest\` everywhere) — separate hygiene item, larger blast radius, deferred.

## Test plan

- [ ] CI passes (the workflow files only execute on push-with-migration-changes, so the plumbing is exercised lazily; this PR has no migration files).
- [ ] After merge, the next prod migration with any failure mode (auth, network, SQL error) will fail the workflow visibly instead of silently — verifiable via the next regular migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)