### PR TITLE
feat(review): Phase 4 — atomic complete_review RPC + edge function wrap

### DIFF
--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -346,6 +346,10 @@ export function ReviewDetail() {
   const handleMetadataChange = useCallback(
     <K extends keyof ReviewMetadata>(filterKey: K, value: ReviewMetadata[K]) => {
       setMetadata((prev) => ({ ...prev, [filterKey]: value }));
+      // Stale "save failed" banner becomes confusing the moment the
+      // reviewer changes anything — they're clearly preparing a fresh
+      // attempt. Clear on any meaningful state change.
+      setSaveError(null);
     },
     []
   );
@@ -893,11 +897,12 @@ export function ReviewDetail() {
                           matchType: normalizeMatchType(d.match_type),
                         }}
                         selected={selectedDuplicate === d.lesson_id}
-                        onSelect={() =>
+                        onSelect={() => {
                           setSelectedDuplicate(
                             selectedDuplicate === d.lesson_id ? null : d.lesson_id
-                          )
-                        }
+                          );
+                          setSaveError(null);
+                        }}
                       />
                     );
                   })}
@@ -915,7 +920,10 @@ export function ReviewDetail() {
                     name="decision"
                     value="approve_new"
                     checked={decision === 'approve_new'}
-                    onChange={() => setDecision('approve_new')}
+                    onChange={() => {
+                      setDecision('approve_new');
+                      setSaveError(null);
+                    }}
                   />
                   Approve &amp; publish
                 </label>
@@ -929,7 +937,10 @@ export function ReviewDetail() {
                     value="approve_update"
                     disabled={!selectedDuplicate}
                     checked={decision === 'approve_update'}
-                    onChange={() => setDecision('approve_update')}
+                    onChange={() => {
+                      setDecision('approve_update');
+                      setSaveError(null);
+                    }}
                   />
                   Merge into existing
                   {!selectedDuplicate && ' (select a duplicate first)'}
@@ -940,7 +951,10 @@ export function ReviewDetail() {
                     name="decision"
                     value="needs_revision"
                     checked={decision === 'needs_revision'}
-                    onChange={() => setDecision('needs_revision')}
+                    onChange={() => {
+                      setDecision('needs_revision');
+                      setSaveError(null);
+                    }}
                   />
                   Request revisions
                 </label>
@@ -955,7 +969,10 @@ export function ReviewDetail() {
                 className="adm-textarea"
                 rows={4}
                 value={notes}
-                onChange={(e) => setNotes(e.target.value)}
+                onChange={(e) => {
+                  setNotes(e.target.value);
+                  setSaveError(null);
+                }}
                 placeholder="Optional. Will be emailed to the teacher along with the decision."
               />
             </div>

--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -8,7 +8,6 @@ import { logger } from '@/utils/logger';
 import { sanitizeContent } from '@/utils/sanitize';
 import { FEATURES } from '@/utils/featureFlags';
 import type { ReviewMetadata } from '@/types';
-import type { Json, Database } from '@/types/database.types';
 import { ALL_FIELD_CONFIGS, type FilterConfig } from '@/utils/filterDefinitions';
 import { STATUS_LABEL, STATUS_TO_BADGE, type SubmissionStatus } from '@/utils/submissionStatus';
 import { GoogleDocEmbed } from '@/components/Review/GoogleDocEmbed';
@@ -25,16 +24,10 @@ import {
   type IntDuplicateMatchType,
 } from '@/components/Internal';
 
-type LessonInsert = Database['public']['Tables']['lessons']['Insert'];
-type LessonUpdate = Database['public']['Tables']['lessons']['Update'];
-
-/**
- * The DB CHECK constraint on lesson_submissions.status only allows
- * 'submitted' | 'in_review' | 'needs_revision' | 'approved' — see
- * `utils/submissionStatus.ts`. This slice deliberately drops the Reject
- * decision because the legacy 'reject' path silently failed at the status
- * update step.
- */
+// As of Phase 4 (complete-review edge function + complete_review_atomic
+// RPC), the DB-side CHECK on lesson_submissions.status accepts 'rejected'
+// too. The UI here still only renders three decisions — Phase 8a will add
+// the reject radio. The four-decision union is reserved for that flip.
 type ReviewDecision = 'approve_new' | 'approve_update' | 'needs_revision';
 
 interface SimilarityWithLesson {
@@ -48,24 +41,6 @@ interface SimilarityWithLesson {
     grade_levels: string[] | null;
     thematic_categories: string[] | null;
   };
-}
-
-interface LessonMetadataJson {
-  activityType?: string | string[];
-  thematicCategories?: string[];
-  seasonTiming?: string[];
-  coreCompetencies?: string[];
-  culturalHeritage?: string[];
-  locationRequirements?: string[];
-  lessonFormat?: string[];
-  academicIntegration?: string[];
-  socialEmotionalLearning?: string[];
-  cookingMethods?: string[];
-  mainIngredients?: string[];
-  gardenSkills?: string[];
-  cookingSkills?: string[];
-  observancesHolidays?: string[];
-  culturalResponsivenessFeatures?: string[];
 }
 
 interface SubmissionDetail {
@@ -147,6 +122,7 @@ export function ReviewDetail() {
   const [selectedDuplicate, setSelectedDuplicate] = useState<string | null>(null);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [legacyDecisionWarning, setLegacyDecisionWarning] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const errorBannerRef = useRef<HTMLDivElement | null>(null);
 
@@ -384,201 +360,45 @@ export function ReviewDetail() {
       return;
     }
     setValidationErrors([]);
+    setSaveError(null);
     setSaving(true);
 
     try {
-      const currentUser = (await supabase.auth.getUser()).data.user;
-      if (!currentUser) throw new Error('Not authenticated');
-
-      const { error: reviewError } = await supabase
-        .from('submission_reviews')
-        .insert({
-          submission_id: submission.id,
-          reviewer_id: currentUser.id,
+      // Phase 4: the entire save flow goes through the complete-review edge
+      // function, which auths the JWT, ensures the submission embedding is
+      // fresh enough for the decision, and calls complete_review_atomic.
+      // The RPC wraps submission_reviews + lesson_submissions + lessons +
+      // lesson_versions writes in one transaction, closing the orphan-
+      // creation pathway that the Tier-1 work is recovering from.
+      const { data, error: invokeError } = await supabase.functions.invoke('complete-review', {
+        body: {
+          submissionId: submission.id,
           decision,
+          metadata,
           notes,
-          tagged_metadata: metadata as Json,
-        })
-        .select()
-        .single();
-      if (reviewError) throw reviewError;
+          selectedLessonId: decision === 'approve_update' ? selectedDuplicate : null,
+        },
+      });
 
-      const newStatus: SubmissionStatus =
-        decision === 'approve_new' || decision === 'approve_update' ? 'approved' : 'needs_revision';
-
-      const { error: updateError } = await supabase
-        .from('lesson_submissions')
-        .update({
-          status: newStatus,
-          reviewed_at: new Date().toISOString(),
-          reviewed_by: currentUser.id,
-        })
-        .eq('id', submission.id);
-      if (updateError) throw updateError;
-
-      if (decision === 'approve_new') {
-        const lessonData = parsedContent;
-        const baseTitle = submission.extracted_title || lessonData.title;
-
-        const newLesson: LessonInsert = {
-          lesson_id: `lesson_${crypto.randomUUID()}`,
-          title: baseTitle || 'Untitled Lesson',
-          summary: lessonData.summary || '',
-          file_link: submission.google_doc_url,
-          grade_levels: metadata.gradeLevels || [],
-          activity_type: metadata.activityType ? [metadata.activityType] : [],
-          thematic_categories: metadata.themes || [],
-          season_timing: metadata.season || [],
-          core_competencies: metadata.coreCompetencies || [],
-          cultural_heritage: metadata.culturalHeritage || [],
-          location_requirements: metadata.location ? [metadata.location] : [],
-          lesson_format: metadata.lessonFormat || null,
-          academic_integration: metadata.academicIntegration || [],
-          social_emotional_learning: metadata.socialEmotionalLearning || [],
-          cooking_methods: metadata.cookingMethods || [],
-          main_ingredients: metadata.mainIngredients || [],
-          garden_skills: metadata.gardenSkills || [],
-          cooking_skills: metadata.cookingSkills || [],
-          observances_holidays: metadata.observancesHolidays || [],
-          cultural_responsiveness_features: metadata.culturalResponsivenessFeatures || [],
-          metadata: {
-            thematicCategories: metadata.themes || [],
-            seasonTiming: metadata.season || [],
-            coreCompetencies: metadata.coreCompetencies || [],
-            culturalHeritage: metadata.culturalHeritage || [],
-            locationRequirements: metadata.location ? [metadata.location] : [],
-            lessonFormat: metadata.lessonFormat ? [metadata.lessonFormat] : [],
-            academicIntegration: metadata.academicIntegration || [],
-            socialEmotionalLearning: metadata.socialEmotionalLearning || [],
-            cookingMethods: metadata.cookingMethods || [],
-            mainIngredients: metadata.mainIngredients || [],
-            gardenSkills: metadata.gardenSkills || [],
-            cookingSkills: metadata.cookingSkills || [],
-            observancesHolidays: metadata.observancesHolidays || [],
-            culturalResponsivenessFeatures: metadata.culturalResponsivenessFeatures || [],
-          },
-          content_text: submission.extracted_content,
-          content_hash: submission.content_hash,
-          original_submission_id: submission.id,
-          processing_notes: metadata.processingNotes || '',
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        };
-
-        if (submission.content_embedding && typeof submission.content_embedding === 'string') {
-          try {
-            const parsed = JSON.parse(submission.content_embedding);
-            if (Array.isArray(parsed) && parsed.length > 0) {
-              newLesson.content_embedding = submission.content_embedding;
-            }
-          } catch (error) {
-            logger.warn('Failed to validate embedding for submission:', submission.id, error);
-          }
-        }
-
-        const { error: lessonError } = await supabase.from('lessons').insert(newLesson);
-        if (lessonError) throw lessonError;
-      } else if (decision === 'approve_update' && selectedDuplicate) {
-        const { data: existingLesson, error: fetchError } = await supabase
-          .from('lessons_with_metadata')
-          .select('*')
-          .eq('lesson_id', selectedDuplicate)
-          .single();
-        if (fetchError) throw fetchError;
-
-        const { error: archiveError } = await supabase.from('lesson_versions').insert({
-          lesson_id: selectedDuplicate,
-          version_number: existingLesson.version_number || 1,
-          title: existingLesson.title || '',
-          summary: existingLesson.summary || '',
-          file_link: existingLesson.file_link || '',
-          grade_levels: existingLesson.grade_levels || [],
-          metadata: existingLesson.metadata,
-          content_text: existingLesson.content_text,
-          archived_from_submission_id: submission.id,
-          archived_by: currentUser.id,
-          archive_reason: 'Content update from new submission',
-        });
-        if (archiveError) throw archiveError;
-
-        const lessonData = parsedContent;
-        const metadataObj = existingLesson.metadata as LessonMetadataJson | null;
-        const existingActivityType =
-          metadataObj && typeof metadataObj === 'object' && !Array.isArray(metadataObj)
-            ? metadataObj.activityType
-            : undefined;
-
-        const updateData: LessonUpdate = {
-          title: lessonData.title || existingLesson.title || undefined,
-          summary: lessonData.summary || existingLesson.summary || undefined,
-          file_link: submission.google_doc_url,
-          grade_levels: metadata.gradeLevels || existingLesson.grade_levels || [],
-          activity_type: metadata.activityType
-            ? [metadata.activityType]
-            : Array.isArray(existingActivityType)
-              ? existingActivityType
-              : existingActivityType
-                ? [existingActivityType]
-                : [],
-          thematic_categories: metadata.themes || existingLesson.thematic_categories || [],
-          season_timing: metadata.season || existingLesson.season_timing || [],
-          core_competencies: metadata.coreCompetencies || existingLesson.core_competencies || [],
-          cultural_heritage: metadata.culturalHeritage || existingLesson.cultural_heritage || [],
-          location_requirements:
-            (metadata.location ? [metadata.location] : null) ||
-            existingLesson.location_requirements ||
-            [],
-          lesson_format: metadata.lessonFormat || existingLesson.lesson_format || null,
-          academic_integration:
-            metadata.academicIntegration || existingLesson.academic_integration || [],
-          social_emotional_learning:
-            metadata.socialEmotionalLearning || existingLesson.social_emotional_learning || [],
-          cooking_methods: metadata.cookingMethods || existingLesson.cooking_methods || [],
-          main_ingredients: metadata.mainIngredients || existingLesson.main_ingredients || [],
-          garden_skills: metadata.gardenSkills || existingLesson.garden_skills || [],
-          cooking_skills: metadata.cookingSkills || existingLesson.cooking_skills || [],
-          observances_holidays:
-            metadata.observancesHolidays || existingLesson.observances_holidays || [],
-          cultural_responsiveness_features:
-            metadata.culturalResponsivenessFeatures ||
-            existingLesson.cultural_responsiveness_features ||
-            [],
-        };
-
-        const { error: updateLessonError } = await supabase
-          .from('lessons')
-          .update({
-            ...updateData,
-            metadata: {
-              thematicCategories: metadata.themes || [],
-              seasonTiming: metadata.season || [],
-              coreCompetencies: metadata.coreCompetencies || [],
-              culturalHeritage: metadata.culturalHeritage || [],
-              locationRequirements: metadata.location ? [metadata.location] : [],
-              lessonFormat: metadata.lessonFormat ? [metadata.lessonFormat] : [],
-              academicIntegration: metadata.academicIntegration || [],
-              socialEmotionalLearning: metadata.socialEmotionalLearning || [],
-              cookingMethods: metadata.cookingMethods || [],
-              mainIngredients: metadata.mainIngredients || [],
-              gardenSkills: metadata.gardenSkills || [],
-              cookingSkills: metadata.cookingSkills || [],
-              observancesHolidays: metadata.observancesHolidays || [],
-              culturalResponsivenessFeatures: metadata.culturalResponsivenessFeatures || [],
-            },
-            content_text: submission.extracted_content,
-            content_hash: submission.content_hash,
-            version_number: (existingLesson.version_number || 1) + 1,
-            has_versions: true,
-            processing_notes: metadata.processingNotes || '',
-            updated_at: new Date().toISOString(),
-          })
-          .eq('lesson_id', selectedDuplicate);
-        if (updateLessonError) throw updateLessonError;
+      if (invokeError) throw invokeError;
+      if (data && typeof data === 'object' && 'error' in data && data.error) {
+        throw new Error(typeof data.error === 'string' ? data.error : 'complete-review failed');
       }
 
       navigate('/review');
     } catch (error) {
-      logger.error('Error saving review:', parseDbError(error));
+      const parsed = parseDbError(error);
+      logger.error('Error saving review:', parsed);
+      // Atomicity is the whole point of Phase 4 — when the RPC rolls back,
+      // the reviewer must SEE that nothing happened. The pre-existing
+      // silent-catch left them clicking again with no feedback.
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : typeof parsed === 'string'
+            ? parsed
+            : 'Save failed. Please try again or check the console for details.';
+      setSaveError(message);
     } finally {
       setSaving(false);
     }
@@ -1139,6 +959,12 @@ export function ReviewDetail() {
                 placeholder="Optional. Will be emailed to the teacher along with the decision."
               />
             </div>
+
+            {saveError && (
+              <div role="alert" className="adm-hint adm-hint--error adm-alert--error">
+                Save failed — nothing was written. {saveError}
+              </div>
+            )}
 
             <IntDecisionBar
               eyebrow="Metadata"

--- a/supabase/functions/complete-review/index.ts
+++ b/supabase/functions/complete-review/index.ts
@@ -1,0 +1,246 @@
+// Phase 4 of the lesson-submission Tier-1 work. This edge function is the
+// single auth boundary (Pattern A in the plan): it validates the JWT,
+// checks the caller's role, ensures the submission embedding is fresh
+// enough for an approve_* decision, and then calls the
+// complete_review_atomic RPC with the service-role key. The RPC trusts
+// p_reviewer_id because EXECUTE is granted only to service_role.
+//
+// Phase 7c will add the post-success email trigger; today there's a
+// placeholder comment marking the seam.
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
+import { getRestrictedCorsHeaders } from '../_shared/cors.ts';
+
+type ReviewDecision = 'approve_new' | 'approve_update' | 'needs_revision' | 'reject';
+
+interface CompleteReviewRequest {
+  submissionId?: string;
+  decision?: ReviewDecision;
+  metadata?: Record<string, unknown>;
+  notes?: string;
+  selectedLessonId?: string | null;
+}
+
+const VALID_DECISIONS: ReadonlyArray<ReviewDecision> = [
+  'approve_new',
+  'approve_update',
+  'needs_revision',
+  'reject',
+];
+
+function jsonResponse(body: unknown, status: number, corsHeaders: Record<string, string>) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const corsHeaders = getRestrictedCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return jsonResponse({ error: 'Missing authorization header' }, 401, corsHeaders);
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceKey) {
+      return jsonResponse({ error: 'Supabase env not configured' }, 500, corsHeaders);
+    }
+
+    const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const {
+      data: { user },
+      error: userErr,
+    } = await userClient.auth.getUser();
+    if (userErr || !user) {
+      return jsonResponse({ error: 'Invalid or expired token' }, 401, corsHeaders);
+    }
+
+    const { data: profile, error: profileErr } = await userClient
+      .from('user_profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+
+    if (profileErr || !profile) {
+      return jsonResponse({ error: 'User profile not found' }, 403, corsHeaders);
+    }
+
+    if (!['reviewer', 'admin', 'super_admin'].includes(profile.role)) {
+      return jsonResponse({ error: 'Insufficient role' }, 403, corsHeaders);
+    }
+
+    const body = (await req.json().catch(() => null)) as CompleteReviewRequest | null;
+    if (!body) {
+      return jsonResponse({ error: 'Invalid JSON body' }, 400, corsHeaders);
+    }
+
+    const { submissionId, decision, metadata, notes, selectedLessonId } = body;
+
+    if (!submissionId || typeof submissionId !== 'string') {
+      return jsonResponse({ error: 'Missing submissionId' }, 400, corsHeaders);
+    }
+    if (!decision || !VALID_DECISIONS.includes(decision)) {
+      return jsonResponse({ error: `Invalid decision: ${decision}` }, 400, corsHeaders);
+    }
+    if (decision === 'approve_update' && !selectedLessonId) {
+      return jsonResponse(
+        { error: 'approve_update requires selectedLessonId' },
+        400,
+        corsHeaders
+      );
+    }
+
+    const serviceClient = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Embedding handling. For non-approve decisions the embedding doesn't
+    // matter (no lessons row gets written). For approve_update we always
+    // regenerate — the doc content is the source of truth and the prior
+    // embedding is being replaced anyway. For approve_new we only
+    // regenerate when the submission's embedding is null (e.g. the
+    // process-submission run that originally created the row didn't have
+    // OpenAI configured at the time).
+    if (decision === 'approve_new' || decision === 'approve_update') {
+      const { data: submission, error: subErr } = await serviceClient
+        .from('lesson_submissions')
+        .select('content_embedding, extracted_content, extracted_title')
+        .eq('id', submissionId)
+        .single();
+
+      if (subErr || !submission) {
+        return jsonResponse({ error: 'Submission not found' }, 404, corsHeaders);
+      }
+
+      const embeddingMissing = !submission.content_embedding;
+      const needsRegen = decision === 'approve_update' || embeddingMissing;
+
+      if (needsRegen) {
+        if (!submission.extracted_content) {
+          return jsonResponse(
+            {
+              error:
+                'Submission has no extracted_content; cannot regenerate embedding. Re-run process-submission first.',
+            },
+            422,
+            corsHeaders
+          );
+        }
+
+        const openAIKey = Deno.env.get('OPENAI_API_KEY');
+        if (!openAIKey) {
+          return jsonResponse(
+            { error: 'OPENAI_API_KEY not configured; cannot regenerate embedding' },
+            500,
+            corsHeaders
+          );
+        }
+
+        const titlePrefix = submission.extracted_title ? `${submission.extracted_title}\n` : '';
+        const embedInput = `${titlePrefix}${submission.extracted_content}`.substring(0, 8000);
+
+        const embedRes = await fetch('https://api.openai.com/v1/embeddings', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${openAIKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: 'text-embedding-3-small',
+            input: embedInput,
+          }),
+        });
+
+        if (!embedRes.ok) {
+          const errText = await embedRes.text();
+          return jsonResponse(
+            {
+              error: `OpenAI embedding request failed: ${embedRes.status}`,
+              detail: errText.substring(0, 200),
+            },
+            502,
+            corsHeaders
+          );
+        }
+
+        const embedJson = await embedRes.json();
+        const embedding = embedJson?.data?.[0]?.embedding;
+        if (!Array.isArray(embedding) || embedding.length === 0) {
+          return jsonResponse(
+            { error: 'OpenAI returned an invalid embedding payload' },
+            502,
+            corsHeaders
+          );
+        }
+
+        // pgvector text format. Matches process-submission's storage shape.
+        const vectorString = `[${embedding.join(',')}]`;
+        const { error: updateErr } = await serviceClient
+          .from('lesson_submissions')
+          .update({ content_embedding: vectorString })
+          .eq('id', submissionId);
+
+        if (updateErr) {
+          return jsonResponse(
+            { error: `Failed to store regenerated embedding: ${updateErr.message}` },
+            500,
+            corsHeaders
+          );
+        }
+      }
+    }
+
+    const { data: lessonId, error: rpcErr } = await serviceClient.rpc('complete_review_atomic', {
+      p_submission_id: submissionId,
+      p_reviewer_id: user.id,
+      p_decision: decision,
+      p_metadata: metadata ?? {},
+      p_notes: notes ?? '',
+      p_selected_lesson_id: selectedLessonId ?? null,
+    });
+
+    if (rpcErr) {
+      return jsonResponse(
+        {
+          error: `complete_review_atomic failed: ${rpcErr.message}`,
+          code: rpcErr.code,
+          detail: rpcErr.details,
+        },
+        500,
+        corsHeaders
+      );
+    }
+
+    // Phase 7c hook: send-email trigger lands here. Today no-op so reject /
+    // needs_revision / approve_* don't accidentally email teachers about
+    // 2025 submissions during recovery.
+
+    return jsonResponse(
+      {
+        success: true,
+        lessonId: lessonId ?? null,
+        decision,
+      },
+      200,
+      corsHeaders
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return jsonResponse({ error: message }, 500, corsHeaders);
+  }
+});

--- a/supabase/migrations/20260428000000_phase_4_constraints.sql
+++ b/supabase/migrations/20260428000000_phase_4_constraints.sql
@@ -1,0 +1,69 @@
+-- =====================================================
+-- Migration: 20260428000000_phase_4_constraints.sql
+-- =====================================================
+-- Description: Phase 4 of the lesson-submission Tier-1 work — constraint
+-- changes. Splits out from the RPC + helper migrations (...000001 /
+-- ...000002 / ...000003) because the Supabase CLI's statement splitter
+-- struggles with multiple CREATE FUNCTION blocks in one file.
+--
+-- Two coordinated constraint changes:
+--
+--   1. UNIQUE(submission_id) on submission_reviews. Now safe to add after
+--      Phase 3 dedup (PROD verified 0 multi-review submissions on
+--      2026-04-27). Pairs with the RPC's UPSERT pattern in ...000003 — even
+--      if a future write path bypasses the RPC, the constraint blocks
+--      duplicate review rows.
+--
+--   2. Extend lesson_submissions.status CHECK to allow 'rejected'. Schema-
+--      only change in this phase; the UI for the 'reject' decision lands in
+--      Phase 8a. Ships now (per round-2 senior-dev review) so the RPC in
+--      ...000003 is schema-complete from day one — the 'reject' branch in
+--      the RPC body works end-to-end via tests/scripts even though it's
+--      UI-unreachable until Phase 8a wires the radio.
+--
+-- Pre-conditions verified on PROD 2026-04-27:
+--   - 0 submissions with more than one review row (Phase 3 invariant
+--     holds), so the UNIQUE add will not fail with a duplicate-key error.
+--   - Existing CHECK on lesson_submissions.status:
+--       CHECK ((status = ANY (ARRAY['submitted','in_review',
+--         'needs_revision','approved'])))
+--     This migration replaces it with the same set plus 'rejected'.
+
+-- =====================================================
+-- CHANGES
+-- =====================================================
+
+ALTER TABLE public.submission_reviews
+  ADD CONSTRAINT submission_reviews_submission_id_unique
+  UNIQUE (submission_id);
+
+ALTER TABLE public.lesson_submissions
+  DROP CONSTRAINT IF EXISTS lesson_submissions_status_check;
+
+ALTER TABLE public.lesson_submissions
+  ADD CONSTRAINT lesson_submissions_status_check
+  CHECK (status = ANY (ARRAY[
+    'submitted'::text,
+    'in_review'::text,
+    'needs_revision'::text,
+    'approved'::text,
+    'rejected'::text
+  ]));
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- Reverse order:
+--
+-- ALTER TABLE public.lesson_submissions
+--   DROP CONSTRAINT IF EXISTS lesson_submissions_status_check;
+-- ALTER TABLE public.lesson_submissions
+--   ADD CONSTRAINT lesson_submissions_status_check
+--   CHECK (status = ANY (ARRAY['submitted'::text, 'in_review'::text,
+--     'needs_revision'::text, 'approved'::text]));
+-- -- WARNING: rolling back the CHECK while any row has status='rejected'
+-- -- will fail. Migrate those rows first (e.g., to 'needs_revision') or
+-- -- defer the rollback.
+--
+-- ALTER TABLE public.submission_reviews
+--   DROP CONSTRAINT IF EXISTS submission_reviews_submission_id_unique;

--- a/supabase/migrations/20260428000001_phase_4_helper_jsonb_text_array.sql
+++ b/supabase/migrations/20260428000001_phase_4_helper_jsonb_text_array.sql
@@ -1,0 +1,43 @@
+-- =====================================================
+-- Migration: 20260428000001_phase_4_helper_jsonb_text_array.sql
+-- =====================================================
+-- Description: First of two private helper functions used by the Phase 4
+-- complete_review_atomic RPC (...000003). One helper per file so the
+-- Supabase CLI's statement splitter doesn't choke on multiple dollar-
+-- quoted blocks (cf. ...000000 header).
+--
+-- _phase4_jsonb_text_array(jsonb) → text[]
+--   Returns [] for null/scalar-quoting, scalar wrapped in single-element
+--   array, or unwraps a JSONB array to a text[]. Used by the approve_new
+--   branch of the RPC where "no value supplied" should default to an
+--   empty array (matching the existing ReviewDetail.tsx behavior).
+
+-- =====================================================
+-- CHANGES
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public._phase4_jsonb_text_array(p_value jsonb)
+RETURNS text[]
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF p_value IS NULL OR jsonb_typeof(p_value) = 'null' THEN
+    RETURN ARRAY[]::text[];
+  ELSIF jsonb_typeof(p_value) = 'array' THEN
+    RETURN ARRAY(SELECT jsonb_array_elements_text(p_value));
+  ELSE
+    -- Scalar value (string/number/bool) — wrap.
+    RETURN ARRAY[trim(both '"' from p_value::text)];
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public._phase4_jsonb_text_array(jsonb)
+  FROM PUBLIC, anon, authenticated;
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- DROP FUNCTION IF EXISTS public._phase4_jsonb_text_array(jsonb);

--- a/supabase/migrations/20260428000002_phase_4_helper_jsonb_text_array_or_null.sql
+++ b/supabase/migrations/20260428000002_phase_4_helper_jsonb_text_array_or_null.sql
@@ -1,0 +1,45 @@
+-- =====================================================
+-- Migration: 20260428000002_phase_4_helper_jsonb_text_array_or_null.sql
+-- =====================================================
+-- Description: Second of two private helper functions used by the Phase 4
+-- complete_review_atomic RPC (...000003). Sister to ...000001.
+--
+-- _phase4_jsonb_text_array_or_null(jsonb) → text[]
+--   Returns NULL (not []) when the input is absent/null/empty-array.
+--   Used by the approve_update branch of the RPC so a COALESCE chain
+--   can fall through to the existing column value when the reviewer
+--   didn't supply anything for that field. Returning [] instead would
+--   clobber the existing array, which is the behavior approve_new wants
+--   but approve_update doesn't.
+
+-- =====================================================
+-- CHANGES
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public._phase4_jsonb_text_array_or_null(p_value jsonb)
+RETURNS text[]
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF p_value IS NULL OR jsonb_typeof(p_value) = 'null' THEN
+    RETURN NULL;
+  ELSIF jsonb_typeof(p_value) = 'array' THEN
+    IF jsonb_array_length(p_value) = 0 THEN
+      RETURN NULL;
+    END IF;
+    RETURN ARRAY(SELECT jsonb_array_elements_text(p_value));
+  ELSE
+    RETURN ARRAY[trim(both '"' from p_value::text)];
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public._phase4_jsonb_text_array_or_null(jsonb)
+  FROM PUBLIC, anon, authenticated;
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- DROP FUNCTION IF EXISTS public._phase4_jsonb_text_array_or_null(jsonb);

--- a/supabase/migrations/20260428000003_phase_4_complete_review_atomic_rpc.sql
+++ b/supabase/migrations/20260428000003_phase_4_complete_review_atomic_rpc.sql
@@ -1,0 +1,313 @@
+-- =====================================================
+-- Migration: 20260428000003_phase_4_complete_review_atomic_rpc.sql
+-- =====================================================
+-- Description: Phase 4 of the lesson-submission Tier-1 work — the
+-- complete_review_atomic SECURITY DEFINER RPC. Final file in the Phase 4
+-- set (constraints in ...000000, helpers in ...000001 / ...000002).
+--
+-- Why an RPC: the existing ReviewDetail.tsx save path makes 3–4
+-- independent Supabase calls (submission_reviews INSERT,
+-- lesson_submissions UPDATE, lessons INSERT or UPDATE+lesson_versions
+-- INSERT). If step 3 fails after steps 1–2 succeed, the submission ends
+-- up "approved" with no lesson row — the structural cause of the orphan-
+-- creation pathway the Tier-1 work is recovering from. Wrapping the
+-- writes in one transaction means any failure rolls back the whole batch.
+--
+-- Why SECURITY DEFINER + service-role-only EXECUTE (Pattern A from the
+-- plan): the new complete-review edge function is the single auth
+-- boundary. It validates the JWT, checks role, then calls this RPC with
+-- the service-role key. The RPC trusts the p_reviewer_id parameter
+-- because only the edge function can reach it. Avoids duplicating the
+-- role check in two places and keeps the public attack surface small —
+-- same shape as the publish_approved_submissions lock-down in Phase 1b,
+-- in reverse.
+--
+-- Why fixed search_path: SECURITY DEFINER without a fixed search_path is
+-- vulnerable to a search-path-injection attack where a caller plants a
+-- malicious schema (e.g., pg_temp.user_profiles) ahead of public in the
+-- resolver. SET search_path = public, pg_temp pins resolution to the
+-- intended schema; pg_temp comes last so it can't shadow public.
+--
+-- Note on metadata semantics for approve_update: this RPC mirrors the
+-- existing ReviewDetail.tsx behavior — user-supplied value wins, else
+-- fall back to existing column value. That preserves the historical UX
+-- (clearing an optional pill doesn't clear it on the lesson) so this PR
+-- is strictly about atomicity, not metadata-handling cleanup.
+
+-- =====================================================
+-- CHANGES
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.complete_review_atomic(
+  p_submission_id      uuid,
+  p_reviewer_id        uuid,
+  p_decision           text,
+  p_metadata           jsonb,
+  p_notes              text,
+  p_selected_lesson_id text DEFAULT NULL
+) RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_status      text;
+  v_revision_reason text;
+  v_new_lesson_id   text;
+  v_submission      public.lesson_submissions%ROWTYPE;
+  v_existing        public.lessons%ROWTYPE;
+  v_meta            jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_notes           text  := COALESCE(p_notes, '');
+BEGIN
+  -- Validation
+  IF p_decision NOT IN ('approve_new', 'approve_update', 'needs_revision', 'reject') THEN
+    RAISE EXCEPTION 'Invalid decision: %', p_decision USING ERRCODE = '22023';
+  END IF;
+
+  IF p_decision = 'approve_update' AND p_selected_lesson_id IS NULL THEN
+    RAISE EXCEPTION 'approve_update requires p_selected_lesson_id' USING ERRCODE = '22023';
+  END IF;
+
+  -- Translate decision to submission status.
+  v_new_status := CASE p_decision
+    WHEN 'approve_new'    THEN 'approved'
+    WHEN 'approve_update' THEN 'approved'
+    WHEN 'needs_revision' THEN 'needs_revision'
+    WHEN 'reject'         THEN 'rejected'
+  END;
+
+  -- For needs_revision/reject the reviewer's note doubles as the
+  -- machine-readable "why" (revision_requested_reason). Phase 7c can
+  -- diverge these later if a separate UI field shows up.
+  v_revision_reason := CASE p_decision
+    WHEN 'needs_revision' THEN v_notes
+    WHEN 'reject'         THEN v_notes
+    ELSE NULL
+  END;
+
+  -- Lock + load the submission for its content/embedding (used by both
+  -- the lessons INSERT and the lesson_versions archive paths).
+  SELECT * INTO v_submission
+  FROM public.lesson_submissions
+  WHERE id = p_submission_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Submission not found: %', p_submission_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. UPSERT the review.
+  INSERT INTO public.submission_reviews (
+    submission_id, reviewer_id, decision, notes, tagged_metadata, review_completed_at
+  ) VALUES (
+    p_submission_id, p_reviewer_id, p_decision, v_notes, v_meta, now()
+  )
+  ON CONFLICT (submission_id) DO UPDATE SET
+    reviewer_id         = EXCLUDED.reviewer_id,
+    decision            = EXCLUDED.decision,
+    notes               = EXCLUDED.notes,
+    tagged_metadata     = EXCLUDED.tagged_metadata,
+    review_completed_at = EXCLUDED.review_completed_at;
+
+  -- 2. UPDATE the submission.
+  UPDATE public.lesson_submissions SET
+    status                    = v_new_status,
+    reviewed_at               = now(),
+    reviewed_by               = p_reviewer_id,
+    reviewer_id               = p_reviewer_id,
+    reviewer_notes            = v_notes,
+    revision_requested_reason = v_revision_reason,
+    review_completed_at       = now(),
+    updated_at                = now()
+  WHERE id = p_submission_id;
+
+  -- 3. Lessons write (only for approve_*).
+  IF p_decision = 'approve_new' THEN
+    v_new_lesson_id := 'lesson_' || replace(gen_random_uuid()::text, '-', '');
+
+    INSERT INTO public.lessons (
+      lesson_id, title, summary, file_link,
+      grade_levels, activity_type, thematic_categories, season_timing,
+      core_competencies, cultural_heritage, location_requirements, lesson_format,
+      academic_integration, social_emotional_learning, cooking_methods,
+      main_ingredients, garden_skills, cooking_skills, observances_holidays,
+      cultural_responsiveness_features,
+      metadata, content_text, content_hash, content_embedding,
+      original_submission_id, processing_notes, created_at, updated_at
+    ) VALUES (
+      v_new_lesson_id,
+      COALESCE(NULLIF(v_submission.extracted_title, ''), NULLIF(v_meta->>'title', ''), 'Untitled Lesson'),
+      COALESCE(v_meta->>'summary', ''),
+      v_submission.google_doc_url,
+      _phase4_jsonb_text_array(v_meta->'gradeLevels'),
+      CASE WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+           THEN ARRAY[v_meta->>'activityType']
+           ELSE ARRAY[]::text[] END,
+      _phase4_jsonb_text_array(v_meta->'themes'),
+      _phase4_jsonb_text_array(v_meta->'season'),
+      _phase4_jsonb_text_array(v_meta->'coreCompetencies'),
+      _phase4_jsonb_text_array(v_meta->'culturalHeritage'),
+      CASE WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+           THEN ARRAY[v_meta->>'location']
+           ELSE ARRAY[]::text[] END,
+      NULLIF(v_meta->>'lessonFormat', ''),
+      _phase4_jsonb_text_array(v_meta->'academicIntegration'),
+      _phase4_jsonb_text_array(v_meta->'socialEmotionalLearning'),
+      _phase4_jsonb_text_array(v_meta->'cookingMethods'),
+      _phase4_jsonb_text_array(v_meta->'mainIngredients'),
+      _phase4_jsonb_text_array(v_meta->'gardenSkills'),
+      _phase4_jsonb_text_array(v_meta->'cookingSkills'),
+      _phase4_jsonb_text_array(v_meta->'observancesHolidays'),
+      _phase4_jsonb_text_array(v_meta->'culturalResponsivenessFeatures'),
+      v_meta,
+      COALESCE(v_submission.extracted_content, ''),
+      v_submission.content_hash,
+      v_submission.content_embedding,
+      p_submission_id,
+      COALESCE(v_meta->>'processingNotes', ''),
+      now(),
+      now()
+    );
+
+    RETURN v_new_lesson_id;
+
+  ELSIF p_decision = 'approve_update' THEN
+    SELECT * INTO v_existing
+    FROM public.lessons
+    WHERE lesson_id = p_selected_lesson_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Selected lesson not found: %', p_selected_lesson_id USING ERRCODE = 'P0002';
+    END IF;
+
+    -- Archive the prior state. archived_from_submission_id is the
+    -- provenance link that Phase 6 verification queries hang off.
+    INSERT INTO public.lesson_versions (
+      lesson_id, version_number, title, summary, file_link, grade_levels,
+      metadata, content_text, archived_from_submission_id, archived_by, archive_reason
+    ) VALUES (
+      v_existing.lesson_id,
+      COALESCE(v_existing.version_number, 1),
+      COALESCE(v_existing.title, ''),
+      COALESCE(v_existing.summary, ''),
+      COALESCE(v_existing.file_link, ''),
+      COALESCE(v_existing.grade_levels, ARRAY[]::text[]),
+      v_existing.metadata,
+      v_existing.content_text,
+      p_submission_id,
+      p_reviewer_id,
+      'Content update from new submission'
+    );
+
+    -- Update the lesson. For metadata fields, mirror the existing
+    -- ReviewDetail.tsx semantic: user-supplied wins, else preserve
+    -- existing. original_submission_id is intentionally NOT touched
+    -- (Phase 6 provenance model).
+    UPDATE public.lessons SET
+      title = COALESCE(NULLIF(v_submission.extracted_title, ''), v_existing.title),
+      summary = COALESCE(NULLIF(v_meta->>'summary', ''), v_existing.summary),
+      file_link = v_submission.google_doc_url,
+      grade_levels = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gradeLevels'),
+        v_existing.grade_levels,
+        ARRAY[]::text[]
+      ),
+      activity_type = CASE
+        WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+          THEN ARRAY[v_meta->>'activityType']
+        ELSE COALESCE(v_existing.activity_type, ARRAY[]::text[])
+      END,
+      thematic_categories = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'themes'),
+        v_existing.thematic_categories,
+        ARRAY[]::text[]
+      ),
+      season_timing = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'season'),
+        v_existing.season_timing,
+        ARRAY[]::text[]
+      ),
+      core_competencies = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'coreCompetencies'),
+        v_existing.core_competencies,
+        ARRAY[]::text[]
+      ),
+      cultural_heritage = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalHeritage'),
+        v_existing.cultural_heritage,
+        ARRAY[]::text[]
+      ),
+      location_requirements = CASE
+        WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+          THEN ARRAY[v_meta->>'location']
+        ELSE COALESCE(v_existing.location_requirements, ARRAY[]::text[])
+      END,
+      lesson_format = COALESCE(NULLIF(v_meta->>'lessonFormat', ''), v_existing.lesson_format),
+      academic_integration = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'academicIntegration'),
+        v_existing.academic_integration,
+        ARRAY[]::text[]
+      ),
+      social_emotional_learning = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'socialEmotionalLearning'),
+        v_existing.social_emotional_learning,
+        ARRAY[]::text[]
+      ),
+      cooking_methods = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingMethods'),
+        v_existing.cooking_methods,
+        ARRAY[]::text[]
+      ),
+      main_ingredients = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'mainIngredients'),
+        v_existing.main_ingredients,
+        ARRAY[]::text[]
+      ),
+      garden_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gardenSkills'),
+        v_existing.garden_skills,
+        ARRAY[]::text[]
+      ),
+      cooking_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingSkills'),
+        v_existing.cooking_skills,
+        ARRAY[]::text[]
+      ),
+      observances_holidays = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'observancesHolidays'),
+        v_existing.observances_holidays,
+        ARRAY[]::text[]
+      ),
+      cultural_responsiveness_features = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalResponsivenessFeatures'),
+        v_existing.cultural_responsiveness_features,
+        ARRAY[]::text[]
+      ),
+      metadata = v_meta,
+      content_text = COALESCE(v_submission.extracted_content, ''),
+      content_hash = v_submission.content_hash,
+      content_embedding = v_submission.content_embedding,
+      version_number = COALESCE(v_existing.version_number, 1) + 1,
+      has_versions = true,
+      processing_notes = COALESCE(v_meta->>'processingNotes', ''),
+      updated_at = now()
+    WHERE lesson_id = p_selected_lesson_id;
+
+    RETURN p_selected_lesson_id;
+  END IF;
+
+  -- needs_revision / reject: no lessons write, return NULL.
+  RETURN NULL;
+END;
+$$;
+
+-- COMMENT, REVOKE, and GRANT live in 20260428000004_*.sql to dodge a
+-- Supabase CLI splitter quirk that bundles trailing statements into the
+-- same Parse message as the CREATE FUNCTION above.
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- DROP FUNCTION IF EXISTS public.complete_review_atomic(uuid, uuid, text, jsonb, text, text);
+-- (Helpers in ...000001 and ...000002 stay; they're harmless on their own.)

--- a/supabase/migrations/20260428000004_phase_4_complete_review_atomic_grants.sql
+++ b/supabase/migrations/20260428000004_phase_4_complete_review_atomic_grants.sql
@@ -1,0 +1,12 @@
+-- =====================================================
+-- Migration: 20260428000004_phase_4_complete_review_atomic_grants.sql
+-- =====================================================
+-- Description: REVOKE EXECUTE on complete_review_atomic from PUBLIC and
+-- the user-facing roles. The matching GRANT to service_role lives in
+-- ...000005, COMMENT in ...000006. The split is forced by a Supabase CLI
+-- splitter quirk where multiple non-CREATE/ALTER statements in one file
+-- get bundled into a single Parse message that Postgres rejects.
+
+REVOKE EXECUTE ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) FROM PUBLIC, anon, authenticated;
+
+-- ROLLBACK: GRANT EXECUTE ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) TO PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260428000005_phase_4_complete_review_atomic_grant_service_role.sql
+++ b/supabase/migrations/20260428000005_phase_4_complete_review_atomic_grant_service_role.sql
@@ -1,0 +1,12 @@
+-- =====================================================
+-- Migration: 20260428000005_phase_4_complete_review_atomic_grant_service_role.sql
+-- =====================================================
+-- Description: GRANT EXECUTE on complete_review_atomic to service_role.
+-- Pair to the REVOKE in ...000004. See ...000003 header for the full
+-- Pattern A (auth-boundary) explanation: the new complete-review edge
+-- function is the single auth boundary; it calls the RPC with the
+-- service-role key after validating role.
+
+GRANT EXECUTE ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) TO service_role;
+
+-- ROLLBACK: REVOKE EXECUTE ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) FROM service_role;

--- a/supabase/migrations/20260428000006_phase_4_complete_review_atomic_comment.sql
+++ b/supabase/migrations/20260428000006_phase_4_complete_review_atomic_comment.sql
@@ -1,0 +1,10 @@
+-- =====================================================
+-- Migration: 20260428000006_phase_4_complete_review_atomic_comment.sql
+-- =====================================================
+-- Description: Documentation comment on complete_review_atomic. Split
+-- into its own file for the same Supabase CLI splitter reason as
+-- ...000004 / ...000005.
+
+COMMENT ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) IS 'Phase 4 atomic review-completion RPC. Invoked by the complete-review edge function only (EXECUTE granted to service_role only). Wraps the submission_reviews UPSERT, lesson_submissions UPDATE, and lesson INSERT or UPDATE plus lesson_versions INSERT in one transaction so partial failures roll back cleanly.';
+
+-- ROLLBACK: COMMENT ON FUNCTION public.complete_review_atomic(uuid, uuid, text, jsonb, text, text) IS NULL;

--- a/supabase/migrations/20260428000007_phase_4_fix_metadata_shape.sql
+++ b/supabase/migrations/20260428000007_phase_4_fix_metadata_shape.sql
@@ -1,0 +1,301 @@
+-- =====================================================
+-- Migration: 20260428000007_phase_4_fix_metadata_shape.sql
+-- =====================================================
+-- Description: Fix lessons.metadata shape divergence in
+-- complete_review_atomic. The original Phase 4 RPC (...000003) stored
+-- v_meta directly into lessons.metadata, which uses ReviewMetadata-shape
+-- keys (themes, season, location, lessonFormat as a string). The
+-- pre-Phase-4 ReviewDetail.tsx wrote the LEGACY trigger-compatible shape
+-- (thematicCategories, seasonTiming, locationRequirements as array,
+-- lessonFormat as array). The handle_lessons_metadata_write function is
+-- defined but NOT attached as a trigger to lessons, so no current reader
+-- is broken — but post-PR lessons would have a different metadata shape
+-- than pre-PR lessons in the same JSONB column. This re-CREATE OR REPLACE
+-- preserves the legacy shape so the column contract stays consistent.
+--
+-- Identified during PR #449 bot-review triage (claude-review Finding #1).
+-- Fix migration rather than edit-in-place because ...000003 has already
+-- been applied to TEST DB.
+
+CREATE OR REPLACE FUNCTION public.complete_review_atomic(
+  p_submission_id      uuid,
+  p_reviewer_id        uuid,
+  p_decision           text,
+  p_metadata           jsonb,
+  p_notes              text,
+  p_selected_lesson_id text DEFAULT NULL
+) RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_status      text;
+  v_revision_reason text;
+  v_new_lesson_id   text;
+  v_submission      public.lesson_submissions%ROWTYPE;
+  v_existing        public.lessons%ROWTYPE;
+  v_meta            jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_notes           text  := COALESCE(p_notes, '');
+  v_legacy_meta     jsonb;
+BEGIN
+  -- Validation
+  IF p_decision NOT IN ('approve_new', 'approve_update', 'needs_revision', 'reject') THEN
+    RAISE EXCEPTION 'Invalid decision: %', p_decision USING ERRCODE = '22023';
+  END IF;
+
+  IF p_decision = 'approve_update' AND p_selected_lesson_id IS NULL THEN
+    RAISE EXCEPTION 'approve_update requires p_selected_lesson_id' USING ERRCODE = '22023';
+  END IF;
+
+  v_new_status := CASE p_decision
+    WHEN 'approve_new'    THEN 'approved'
+    WHEN 'approve_update' THEN 'approved'
+    WHEN 'needs_revision' THEN 'needs_revision'
+    WHEN 'reject'         THEN 'rejected'
+  END;
+
+  v_revision_reason := CASE p_decision
+    WHEN 'needs_revision' THEN v_notes
+    WHEN 'reject'         THEN v_notes
+    ELSE NULL
+  END;
+
+  SELECT * INTO v_submission
+  FROM public.lesson_submissions
+  WHERE id = p_submission_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Submission not found: %', p_submission_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Build the legacy trigger-compatible metadata shape that the
+  -- pre-Phase-4 ReviewDetail.tsx wrote. Keys mirror what
+  -- handle_lessons_metadata_write (defined in baseline 20251001) consumes
+  -- via NEW.metadata->>'thematicCategories' etc. Stored as JSONB arrays
+  -- even when the underlying React state uses scalars (location,
+  -- lessonFormat) — preserves historical column shape.
+  v_legacy_meta := jsonb_build_object(
+    'thematicCategories',             COALESCE(v_meta->'themes', '[]'::jsonb),
+    'seasonTiming',                   COALESCE(v_meta->'season', '[]'::jsonb),
+    'coreCompetencies',               COALESCE(v_meta->'coreCompetencies', '[]'::jsonb),
+    'culturalHeritage',               COALESCE(v_meta->'culturalHeritage', '[]'::jsonb),
+    'locationRequirements',
+      CASE WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+           THEN jsonb_build_array(v_meta->>'location')
+           ELSE '[]'::jsonb END,
+    'lessonFormat',
+      CASE WHEN v_meta ? 'lessonFormat' AND COALESCE(v_meta->>'lessonFormat', '') <> ''
+           THEN jsonb_build_array(v_meta->>'lessonFormat')
+           ELSE '[]'::jsonb END,
+    'academicIntegration',            COALESCE(v_meta->'academicIntegration', '[]'::jsonb),
+    'socialEmotionalLearning',        COALESCE(v_meta->'socialEmotionalLearning', '[]'::jsonb),
+    'cookingMethods',                 COALESCE(v_meta->'cookingMethods', '[]'::jsonb),
+    'mainIngredients',                COALESCE(v_meta->'mainIngredients', '[]'::jsonb),
+    'gardenSkills',                   COALESCE(v_meta->'gardenSkills', '[]'::jsonb),
+    'cookingSkills',                  COALESCE(v_meta->'cookingSkills', '[]'::jsonb),
+    'observancesHolidays',            COALESCE(v_meta->'observancesHolidays', '[]'::jsonb),
+    'culturalResponsivenessFeatures', COALESCE(v_meta->'culturalResponsivenessFeatures', '[]'::jsonb)
+  );
+
+  -- 1. UPSERT the review (tagged_metadata stays as the React state shape
+  -- because that's what the rest of the codebase reads from
+  -- submission_reviews.tagged_metadata).
+  INSERT INTO public.submission_reviews (
+    submission_id, reviewer_id, decision, notes, tagged_metadata, review_completed_at
+  ) VALUES (
+    p_submission_id, p_reviewer_id, p_decision, v_notes, v_meta, now()
+  )
+  ON CONFLICT (submission_id) DO UPDATE SET
+    reviewer_id         = EXCLUDED.reviewer_id,
+    decision            = EXCLUDED.decision,
+    notes               = EXCLUDED.notes,
+    tagged_metadata     = EXCLUDED.tagged_metadata,
+    review_completed_at = EXCLUDED.review_completed_at;
+
+  -- 2. UPDATE the submission.
+  UPDATE public.lesson_submissions SET
+    status                    = v_new_status,
+    reviewed_at               = now(),
+    reviewed_by               = p_reviewer_id,
+    reviewer_id               = p_reviewer_id,
+    reviewer_notes            = v_notes,
+    revision_requested_reason = v_revision_reason,
+    review_completed_at       = now(),
+    updated_at                = now()
+  WHERE id = p_submission_id;
+
+  -- 3. Lessons write (only for approve_*).
+  IF p_decision = 'approve_new' THEN
+    v_new_lesson_id := 'lesson_' || replace(gen_random_uuid()::text, '-', '');
+
+    INSERT INTO public.lessons (
+      lesson_id, title, summary, file_link,
+      grade_levels, activity_type, thematic_categories, season_timing,
+      core_competencies, cultural_heritage, location_requirements, lesson_format,
+      academic_integration, social_emotional_learning, cooking_methods,
+      main_ingredients, garden_skills, cooking_skills, observances_holidays,
+      cultural_responsiveness_features,
+      metadata, content_text, content_hash, content_embedding,
+      original_submission_id, processing_notes, created_at, updated_at
+    ) VALUES (
+      v_new_lesson_id,
+      COALESCE(NULLIF(v_submission.extracted_title, ''), NULLIF(v_meta->>'title', ''), 'Untitled Lesson'),
+      COALESCE(v_meta->>'summary', ''),
+      v_submission.google_doc_url,
+      _phase4_jsonb_text_array(v_meta->'gradeLevels'),
+      CASE WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+           THEN ARRAY[v_meta->>'activityType']
+           ELSE ARRAY[]::text[] END,
+      _phase4_jsonb_text_array(v_meta->'themes'),
+      _phase4_jsonb_text_array(v_meta->'season'),
+      _phase4_jsonb_text_array(v_meta->'coreCompetencies'),
+      _phase4_jsonb_text_array(v_meta->'culturalHeritage'),
+      CASE WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+           THEN ARRAY[v_meta->>'location']
+           ELSE ARRAY[]::text[] END,
+      NULLIF(v_meta->>'lessonFormat', ''),
+      _phase4_jsonb_text_array(v_meta->'academicIntegration'),
+      _phase4_jsonb_text_array(v_meta->'socialEmotionalLearning'),
+      _phase4_jsonb_text_array(v_meta->'cookingMethods'),
+      _phase4_jsonb_text_array(v_meta->'mainIngredients'),
+      _phase4_jsonb_text_array(v_meta->'gardenSkills'),
+      _phase4_jsonb_text_array(v_meta->'cookingSkills'),
+      _phase4_jsonb_text_array(v_meta->'observancesHolidays'),
+      _phase4_jsonb_text_array(v_meta->'culturalResponsivenessFeatures'),
+      v_legacy_meta,
+      COALESCE(v_submission.extracted_content, ''),
+      v_submission.content_hash,
+      v_submission.content_embedding,
+      p_submission_id,
+      COALESCE(v_meta->>'processingNotes', ''),
+      now(),
+      now()
+    );
+
+    RETURN v_new_lesson_id;
+
+  ELSIF p_decision = 'approve_update' THEN
+    SELECT * INTO v_existing
+    FROM public.lessons
+    WHERE lesson_id = p_selected_lesson_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Selected lesson not found: %', p_selected_lesson_id USING ERRCODE = 'P0002';
+    END IF;
+
+    INSERT INTO public.lesson_versions (
+      lesson_id, version_number, title, summary, file_link, grade_levels,
+      metadata, content_text, archived_from_submission_id, archived_by, archive_reason
+    ) VALUES (
+      v_existing.lesson_id,
+      COALESCE(v_existing.version_number, 1),
+      COALESCE(v_existing.title, ''),
+      COALESCE(v_existing.summary, ''),
+      COALESCE(v_existing.file_link, ''),
+      COALESCE(v_existing.grade_levels, ARRAY[]::text[]),
+      v_existing.metadata,
+      v_existing.content_text,
+      p_submission_id,
+      p_reviewer_id,
+      'Content update from new submission'
+    );
+
+    UPDATE public.lessons SET
+      title = COALESCE(NULLIF(v_submission.extracted_title, ''), v_existing.title),
+      summary = COALESCE(NULLIF(v_meta->>'summary', ''), v_existing.summary),
+      file_link = v_submission.google_doc_url,
+      grade_levels = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gradeLevels'),
+        v_existing.grade_levels,
+        ARRAY[]::text[]
+      ),
+      activity_type = CASE
+        WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+          THEN ARRAY[v_meta->>'activityType']
+        ELSE COALESCE(v_existing.activity_type, ARRAY[]::text[])
+      END,
+      thematic_categories = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'themes'),
+        v_existing.thematic_categories,
+        ARRAY[]::text[]
+      ),
+      season_timing = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'season'),
+        v_existing.season_timing,
+        ARRAY[]::text[]
+      ),
+      core_competencies = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'coreCompetencies'),
+        v_existing.core_competencies,
+        ARRAY[]::text[]
+      ),
+      cultural_heritage = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalHeritage'),
+        v_existing.cultural_heritage,
+        ARRAY[]::text[]
+      ),
+      location_requirements = CASE
+        WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+          THEN ARRAY[v_meta->>'location']
+        ELSE COALESCE(v_existing.location_requirements, ARRAY[]::text[])
+      END,
+      lesson_format = COALESCE(NULLIF(v_meta->>'lessonFormat', ''), v_existing.lesson_format),
+      academic_integration = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'academicIntegration'),
+        v_existing.academic_integration,
+        ARRAY[]::text[]
+      ),
+      social_emotional_learning = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'socialEmotionalLearning'),
+        v_existing.social_emotional_learning,
+        ARRAY[]::text[]
+      ),
+      cooking_methods = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingMethods'),
+        v_existing.cooking_methods,
+        ARRAY[]::text[]
+      ),
+      main_ingredients = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'mainIngredients'),
+        v_existing.main_ingredients,
+        ARRAY[]::text[]
+      ),
+      garden_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gardenSkills'),
+        v_existing.garden_skills,
+        ARRAY[]::text[]
+      ),
+      cooking_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingSkills'),
+        v_existing.cooking_skills,
+        ARRAY[]::text[]
+      ),
+      observances_holidays = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'observancesHolidays'),
+        v_existing.observances_holidays,
+        ARRAY[]::text[]
+      ),
+      cultural_responsiveness_features = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalResponsivenessFeatures'),
+        v_existing.cultural_responsiveness_features,
+        ARRAY[]::text[]
+      ),
+      metadata = v_legacy_meta,
+      content_text = COALESCE(v_submission.extracted_content, ''),
+      content_hash = v_submission.content_hash,
+      content_embedding = v_submission.content_embedding,
+      version_number = COALESCE(v_existing.version_number, 1) + 1,
+      has_versions = true,
+      processing_notes = COALESCE(v_meta->>'processingNotes', ''),
+      updated_at = now()
+    WHERE lesson_id = p_selected_lesson_id;
+
+    RETURN p_selected_lesson_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;

--- a/supabase/migrations/20260428000008_phase_4_status_guard.sql
+++ b/supabase/migrations/20260428000008_phase_4_status_guard.sql
@@ -1,0 +1,312 @@
+-- =====================================================
+-- Migration: 20260428000008_phase_4_status_guard.sql
+-- =====================================================
+-- Description: Idempotency guard on complete_review_atomic. Without this,
+-- if the RPC succeeds but the client never sees the response (network
+-- drop, edge-function timeout that completes after the proxy gives up,
+-- reviewer double-click before the first call finishes), a retry would:
+--   - approve_new:    INSERT a SECOND lessons row with a fresh
+--                     lesson_id (gen_random_uuid). Same submission,
+--                     two visible lessons with identical content.
+--   - approve_update: INSERT a SECOND lesson_versions row archiving the
+--                     already-replaced state, then UPDATE the lesson
+--                     with the same values (no-op).
+--
+-- Both are the same class of orphan/duplicate problem the Tier-1 work
+-- is fixing — Phase 4 closes the partial-failure pathway but, without
+-- this guard, opens a retry-creates-duplicate pathway. Identified during
+-- PR #449 round-2 bot review (claude-review BLOCKING finding).
+--
+-- The guard rejects re-entry on terminal statuses (approved, rejected).
+-- Non-terminal statuses (submitted, in_review, needs_revision) are still
+-- writable so the legitimate "reviewer changes mind, flips
+-- needs_revision back to approve_new" flow keeps working through the
+-- UPSERT path.
+--
+-- ERRCODE 55000 (object_not_in_prerequisite_state) is the standard PG
+-- code for "wrong state to perform this operation" and propagates
+-- through PostgREST as a 500 with a useful message.
+
+CREATE OR REPLACE FUNCTION public.complete_review_atomic(
+  p_submission_id      uuid,
+  p_reviewer_id        uuid,
+  p_decision           text,
+  p_metadata           jsonb,
+  p_notes              text,
+  p_selected_lesson_id text DEFAULT NULL
+) RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_status      text;
+  v_revision_reason text;
+  v_new_lesson_id   text;
+  v_submission      public.lesson_submissions%ROWTYPE;
+  v_existing        public.lessons%ROWTYPE;
+  v_meta            jsonb := COALESCE(p_metadata, '{}'::jsonb);
+  v_notes           text  := COALESCE(p_notes, '');
+  v_legacy_meta     jsonb;
+BEGIN
+  IF p_decision NOT IN ('approve_new', 'approve_update', 'needs_revision', 'reject') THEN
+    RAISE EXCEPTION 'Invalid decision: %', p_decision USING ERRCODE = '22023';
+  END IF;
+
+  IF p_decision = 'approve_update' AND p_selected_lesson_id IS NULL THEN
+    RAISE EXCEPTION 'approve_update requires p_selected_lesson_id' USING ERRCODE = '22023';
+  END IF;
+
+  v_new_status := CASE p_decision
+    WHEN 'approve_new'    THEN 'approved'
+    WHEN 'approve_update' THEN 'approved'
+    WHEN 'needs_revision' THEN 'needs_revision'
+    WHEN 'reject'         THEN 'rejected'
+  END;
+
+  v_revision_reason := CASE p_decision
+    WHEN 'needs_revision' THEN v_notes
+    WHEN 'reject'         THEN v_notes
+    ELSE NULL
+  END;
+
+  SELECT * INTO v_submission
+  FROM public.lesson_submissions
+  WHERE id = p_submission_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Submission not found: %', p_submission_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Idempotency guard: refuse re-entry on terminal statuses. The UPSERT
+  -- on submission_reviews + UPDATE on lesson_submissions are idempotent
+  -- on their own, but the lessons INSERT (approve_new) and
+  -- lesson_versions INSERT (approve_update) are NOT — both would create
+  -- new rows on retry. The 'needs_revision' status is intentionally
+  -- excluded so a reviewer flipping their mind (needs_revision →
+  -- approve_new) can still progress through the UPSERT path.
+  IF v_submission.status IN ('approved', 'rejected') THEN
+    RAISE EXCEPTION 'Submission % already completed (status: %)',
+      p_submission_id, v_submission.status
+      USING ERRCODE = '55000'; -- object_not_in_prerequisite_state
+  END IF;
+
+  v_legacy_meta := jsonb_build_object(
+    'thematicCategories',             COALESCE(v_meta->'themes', '[]'::jsonb),
+    'seasonTiming',                   COALESCE(v_meta->'season', '[]'::jsonb),
+    'coreCompetencies',               COALESCE(v_meta->'coreCompetencies', '[]'::jsonb),
+    'culturalHeritage',               COALESCE(v_meta->'culturalHeritage', '[]'::jsonb),
+    'locationRequirements',
+      CASE WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+           THEN jsonb_build_array(v_meta->>'location')
+           ELSE '[]'::jsonb END,
+    'lessonFormat',
+      CASE WHEN v_meta ? 'lessonFormat' AND COALESCE(v_meta->>'lessonFormat', '') <> ''
+           THEN jsonb_build_array(v_meta->>'lessonFormat')
+           ELSE '[]'::jsonb END,
+    'academicIntegration',            COALESCE(v_meta->'academicIntegration', '[]'::jsonb),
+    'socialEmotionalLearning',        COALESCE(v_meta->'socialEmotionalLearning', '[]'::jsonb),
+    'cookingMethods',                 COALESCE(v_meta->'cookingMethods', '[]'::jsonb),
+    'mainIngredients',                COALESCE(v_meta->'mainIngredients', '[]'::jsonb),
+    'gardenSkills',                   COALESCE(v_meta->'gardenSkills', '[]'::jsonb),
+    'cookingSkills',                  COALESCE(v_meta->'cookingSkills', '[]'::jsonb),
+    'observancesHolidays',            COALESCE(v_meta->'observancesHolidays', '[]'::jsonb),
+    'culturalResponsivenessFeatures', COALESCE(v_meta->'culturalResponsivenessFeatures', '[]'::jsonb)
+  );
+
+  INSERT INTO public.submission_reviews (
+    submission_id, reviewer_id, decision, notes, tagged_metadata, review_completed_at
+  ) VALUES (
+    p_submission_id, p_reviewer_id, p_decision, v_notes, v_meta, now()
+  )
+  ON CONFLICT (submission_id) DO UPDATE SET
+    reviewer_id         = EXCLUDED.reviewer_id,
+    decision            = EXCLUDED.decision,
+    notes               = EXCLUDED.notes,
+    tagged_metadata     = EXCLUDED.tagged_metadata,
+    review_completed_at = EXCLUDED.review_completed_at;
+
+  UPDATE public.lesson_submissions SET
+    status                    = v_new_status,
+    reviewed_at               = now(),
+    reviewed_by               = p_reviewer_id,
+    reviewer_id               = p_reviewer_id,
+    reviewer_notes            = v_notes,
+    revision_requested_reason = v_revision_reason,
+    review_completed_at       = now(),
+    updated_at                = now()
+  WHERE id = p_submission_id;
+
+  IF p_decision = 'approve_new' THEN
+    v_new_lesson_id := 'lesson_' || replace(gen_random_uuid()::text, '-', '');
+
+    INSERT INTO public.lessons (
+      lesson_id, title, summary, file_link,
+      grade_levels, activity_type, thematic_categories, season_timing,
+      core_competencies, cultural_heritage, location_requirements, lesson_format,
+      academic_integration, social_emotional_learning, cooking_methods,
+      main_ingredients, garden_skills, cooking_skills, observances_holidays,
+      cultural_responsiveness_features,
+      metadata, content_text, content_hash, content_embedding,
+      original_submission_id, processing_notes, created_at, updated_at
+    ) VALUES (
+      v_new_lesson_id,
+      COALESCE(NULLIF(v_submission.extracted_title, ''), NULLIF(v_meta->>'title', ''), 'Untitled Lesson'),
+      COALESCE(v_meta->>'summary', ''),
+      v_submission.google_doc_url,
+      _phase4_jsonb_text_array(v_meta->'gradeLevels'),
+      CASE WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+           THEN ARRAY[v_meta->>'activityType']
+           ELSE ARRAY[]::text[] END,
+      _phase4_jsonb_text_array(v_meta->'themes'),
+      _phase4_jsonb_text_array(v_meta->'season'),
+      _phase4_jsonb_text_array(v_meta->'coreCompetencies'),
+      _phase4_jsonb_text_array(v_meta->'culturalHeritage'),
+      CASE WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+           THEN ARRAY[v_meta->>'location']
+           ELSE ARRAY[]::text[] END,
+      NULLIF(v_meta->>'lessonFormat', ''),
+      _phase4_jsonb_text_array(v_meta->'academicIntegration'),
+      _phase4_jsonb_text_array(v_meta->'socialEmotionalLearning'),
+      _phase4_jsonb_text_array(v_meta->'cookingMethods'),
+      _phase4_jsonb_text_array(v_meta->'mainIngredients'),
+      _phase4_jsonb_text_array(v_meta->'gardenSkills'),
+      _phase4_jsonb_text_array(v_meta->'cookingSkills'),
+      _phase4_jsonb_text_array(v_meta->'observancesHolidays'),
+      _phase4_jsonb_text_array(v_meta->'culturalResponsivenessFeatures'),
+      v_legacy_meta,
+      COALESCE(v_submission.extracted_content, ''),
+      v_submission.content_hash,
+      v_submission.content_embedding,
+      p_submission_id,
+      COALESCE(v_meta->>'processingNotes', ''),
+      now(),
+      now()
+    );
+
+    RETURN v_new_lesson_id;
+
+  ELSIF p_decision = 'approve_update' THEN
+    SELECT * INTO v_existing
+    FROM public.lessons
+    WHERE lesson_id = p_selected_lesson_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Selected lesson not found: %', p_selected_lesson_id USING ERRCODE = 'P0002';
+    END IF;
+
+    INSERT INTO public.lesson_versions (
+      lesson_id, version_number, title, summary, file_link, grade_levels,
+      metadata, content_text, archived_from_submission_id, archived_by, archive_reason
+    ) VALUES (
+      v_existing.lesson_id,
+      COALESCE(v_existing.version_number, 1),
+      COALESCE(v_existing.title, ''),
+      COALESCE(v_existing.summary, ''),
+      COALESCE(v_existing.file_link, ''),
+      COALESCE(v_existing.grade_levels, ARRAY[]::text[]),
+      v_existing.metadata,
+      v_existing.content_text,
+      p_submission_id,
+      p_reviewer_id,
+      'Content update from new submission'
+    );
+
+    UPDATE public.lessons SET
+      title = COALESCE(NULLIF(v_submission.extracted_title, ''), v_existing.title),
+      summary = COALESCE(NULLIF(v_meta->>'summary', ''), v_existing.summary),
+      file_link = v_submission.google_doc_url,
+      grade_levels = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gradeLevels'),
+        v_existing.grade_levels,
+        ARRAY[]::text[]
+      ),
+      activity_type = CASE
+        WHEN v_meta ? 'activityType' AND COALESCE(v_meta->>'activityType', '') <> ''
+          THEN ARRAY[v_meta->>'activityType']
+        ELSE COALESCE(v_existing.activity_type, ARRAY[]::text[])
+      END,
+      thematic_categories = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'themes'),
+        v_existing.thematic_categories,
+        ARRAY[]::text[]
+      ),
+      season_timing = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'season'),
+        v_existing.season_timing,
+        ARRAY[]::text[]
+      ),
+      core_competencies = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'coreCompetencies'),
+        v_existing.core_competencies,
+        ARRAY[]::text[]
+      ),
+      cultural_heritage = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalHeritage'),
+        v_existing.cultural_heritage,
+        ARRAY[]::text[]
+      ),
+      location_requirements = CASE
+        WHEN v_meta ? 'location' AND COALESCE(v_meta->>'location', '') <> ''
+          THEN ARRAY[v_meta->>'location']
+        ELSE COALESCE(v_existing.location_requirements, ARRAY[]::text[])
+      END,
+      lesson_format = COALESCE(NULLIF(v_meta->>'lessonFormat', ''), v_existing.lesson_format),
+      academic_integration = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'academicIntegration'),
+        v_existing.academic_integration,
+        ARRAY[]::text[]
+      ),
+      social_emotional_learning = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'socialEmotionalLearning'),
+        v_existing.social_emotional_learning,
+        ARRAY[]::text[]
+      ),
+      cooking_methods = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingMethods'),
+        v_existing.cooking_methods,
+        ARRAY[]::text[]
+      ),
+      main_ingredients = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'mainIngredients'),
+        v_existing.main_ingredients,
+        ARRAY[]::text[]
+      ),
+      garden_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'gardenSkills'),
+        v_existing.garden_skills,
+        ARRAY[]::text[]
+      ),
+      cooking_skills = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'cookingSkills'),
+        v_existing.cooking_skills,
+        ARRAY[]::text[]
+      ),
+      observances_holidays = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'observancesHolidays'),
+        v_existing.observances_holidays,
+        ARRAY[]::text[]
+      ),
+      cultural_responsiveness_features = COALESCE(
+        _phase4_jsonb_text_array_or_null(v_meta->'culturalResponsivenessFeatures'),
+        v_existing.cultural_responsiveness_features,
+        ARRAY[]::text[]
+      ),
+      metadata = v_legacy_meta,
+      content_text = COALESCE(v_submission.extracted_content, ''),
+      content_hash = v_submission.content_hash,
+      content_embedding = v_submission.content_embedding,
+      version_number = COALESCE(v_existing.version_number, 1) + 1,
+      has_versions = true,
+      processing_notes = COALESCE(v_meta->>'processingNotes', ''),
+      updated_at = now()
+    WHERE lesson_id = p_selected_lesson_id;
+
+    RETURN p_selected_lesson_id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;


### PR DESCRIPTION
## Summary

Phase 4 of the lesson-submission Tier-1 work. Closes the orphan-creation pathway in the review-completion flow by replacing the existing 3–4 independent Supabase calls in `ReviewDetail.tsx` with a single atomic RPC wrapped behind a new edge function.

If step 3 of the old save path (lessons INSERT / UPDATE+lesson_versions INSERT) failed after steps 1–2 succeeded, the submission ended up `status='approved'` with no matching lesson row — the structural cause of the 30 orphans recovered in Phases 2/3.

## What's in this PR

**DB layer** (split across 7 migration files due to a Supabase CLI splitter quirk that bundles multi-statement files into one Parse message; see ...000004 header for context):
- `UNIQUE(submission_id)` on `submission_reviews`. Now safe after Phase 3 dedup (PROD verified 0 multi-review submissions on 2026-04-27).
- `lesson_submissions.status` CHECK extended to allow `'rejected'`. Schema-only here; the UI for the reject decision lands in Phase 8a (moved to Phase 4 per round-2 senior-dev review so the RPC is schema-complete on day one).
- `complete_review_atomic` SECURITY DEFINER RPC. Wraps `submission_reviews` UPSERT + `lesson_submissions` UPDATE + `lessons` INSERT/UPDATE + `lesson_versions` INSERT in one transaction. EXECUTE granted only to `service_role`. `SET search_path = public, pg_temp` to prevent search-path injection. Two private helpers (`_phase4_jsonb_text_array`, `_or_null`) for JSONB → text[] unwrapping.

**Application layer**:
- New `supabase/functions/complete-review` edge function as the single auth boundary (Pattern A): validates JWT, checks role via `user_profiles`, optionally regenerates OpenAI embedding (always for `approve_update`, when null for `approve_new`), calls the RPC with the service-role key. Phase 7c email hook is a placeholder comment.
- `ReviewDetail.tsx` rewires from 3–4 separate calls to a single `supabase.functions.invoke('complete-review', ...)`. Adds a user-visible `saveError` banner so atomicity rollbacks don't leave the reviewer guessing (per pre-push self-review finding).

## Verification done locally

- All 6 schema checks pass: UNIQUE constraint added, CHECK includes `'rejected'`, RPC exists, SECURITY DEFINER, `search_path` set, EXECUTE only to `service_role`.
- `approve_new` smoke test: lesson created with correct title/grades/seasons/activity_type/location, `original_submission_id` linked, submission flipped to `'approved'`, `reviewer_notes` + `review_completed_at` + `reviewer_id` all written.
- **Partial-failure invariant test (the load-bearing test of the phase):** seed a clean submission, force a CHECK violation via `season=Sproingo`, verify all 3 table counters return to pre-state exactly (`review_total`, `sub_total`, `lesson_total` unchanged; status reverted to `'submitted'`; no review row created). PASSED.
- 430/430 unit tests pass; type-check + lint clean; `npm run test:rls` shows 16/16 tables with RLS, 16/16 with policies.

## Test plan

- [ ] CI: TypeScript, lint, unit tests, E2E pass
- [ ] CI applies migrations to TEST DB cleanly
- [ ] On TEST DB via `mcp__supabase-test__execute_sql`:
  - [ ] UNIQUE constraint exists on `submission_reviews.submission_id`
  - [ ] `lesson_submissions_status_check` includes `'rejected'`
  - [ ] `complete_review_atomic` exists with SECURITY DEFINER + fixed search_path
  - [ ] EXECUTE granted only to service_role (not authenticated/anon)
  - [ ] End-to-end RPC call with seed-and-cleanup succeeds
  - [ ] Partial-failure invariant test (seed → force CHECK violation → verify rollback) passes
- [ ] Bot reviews triaged per project's per-PR ritual (claude-review, claude-database-review)
- [ ] After merge: production migration workflow approved + applied; post-apply MCP verification on PROD (per CLAUDE.md MANDATORY step)

## Out of scope

- `'reject'` decision UI (Phase 8a)
- Phase 7c email triggers (placeholder comment in the edge function)
- B-new and B-update orphan recovery (Phases 5/6 — separate scripts, do NOT route through this RPC because they'd duplicate historical review rows)

## Plan reference

`~/.claude/plans/lesson-submission-tier1-implementation.md` §6 (lines 515–629).

🤖 Generated with [Claude Code](https://claude.com/claude-code)