### PR TITLE
feat(db): Phase 5 — publish 5 Category B-new orphan submissions

### DIFF
--- a/scripts/orphan-recovery/phase-5-b-new-publish.ts
+++ b/scripts/orphan-recovery/phase-5-b-new-publish.ts
@@ -1,0 +1,500 @@
+#!/usr/bin/env npx tsx
+/**
+ * Phase 5 — Category B-new publish (lesson submission Tier-1 recovery).
+ *
+ * Publishes 5 approved orphan submissions whose Google Doc is NOT already in
+ * the library and whose extracted content has no plausible duplicate among
+ * existing lessons (cosine sim < 0.85 against full library). All 5 already
+ * have `submission_reviews` rows with populated `tagged_metadata`
+ * (decision='approve_new', canonical_lesson_id=NULL); recovery only writes
+ * the missing `lessons` INSERT — no second review row, no email side effect,
+ * no auth/embedding/email orchestration of `complete-review`.
+ *
+ * Plan-only mode: reads PROD via Supabase JS (service-role + --i-mean-prod),
+ * emits an artifact JSON, a snapshot file, and two SQL files (rehearsal and
+ * commit) that differ in exactly one line — the final `ROLLBACK;` vs
+ * `COMMIT;` terminator. Both are produced by the same buildSql() call with
+ * identical inputs. The migration file shipped with this script
+ * (supabase/migrations/20260429000000_phase_5_b_new_publish.sql) is the
+ * canonical write path; the SQL artifacts here exist for local rehearsal
+ * and as the audit record for which 5 rows + which projection.
+ *
+ * Selection contract (verified live against PROD on the day this script was
+ * added — see the project anchor for the verification queries):
+ *   - status = 'approved' AND no lessons row links via original_submission_id
+ *   - submission_type = 'new' (all 30 orphans are; not a filter, just a fact)
+ *   - exactly 1 submission_reviews row, decision='approve_new'
+ *   - tagged_metadata IS NOT NULL (React-state shape: themes/season/location/...)
+ *   - content_embedding IS NOT NULL (mandatory preflight; NULL → hard-stop)
+ *   - extracted_content non-empty
+ *   - google_doc_id not present in any lessons.file_link
+ *   - top cosine similarity to any library lesson < 0.85
+ *
+ * Smallest-first order (by extracted_content length, ascending) for the
+ * Option C migration shape: each row's INSERT is a separate statement
+ * inside the transaction so a failure on row N rolls back rows 1..N-1
+ * cleanly and the manual surgical-revert path stays one-row-at-a-time.
+ *
+ * Recovery-script contract: see ~/.claude/plans/lesson-submission-tier1-implementation.md §11.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+// @ts-ignore — .mjs helper, not part of the TS project
+import { requireNonProd, describeSupabaseTarget } from '../lib/require-env.mjs';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error('Missing required environment variables:');
+  console.error(`  VITE_SUPABASE_URL: ${supabaseUrl ? 'set' : 'unset'}`);
+  console.error(`  SUPABASE_SERVICE_ROLE_KEY: ${supabaseServiceKey ? 'set' : 'unset'}`);
+  process.exit(1);
+}
+
+requireNonProd({ scriptName: 'phase-5-b-new-publish' });
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Frozen list of submission_ids — verified Phase 5 candidates as of
+// 2026-04-27. Order is content_length ascending (smallest blast radius
+// first). Re-verify against live data before authoring the migration.
+const PHASE_5_B_NEW_SUBMISSION_IDS = [
+  '4e4f3ae3-4c51-4439-87ee-f20d2ec94921', // Bees                             (4277 chars)
+  '4c2bacdb-7018-4ff2-badb-3701c8c974c0', // Food Justice Advocates           (4504 chars)
+  '0369743c-8b6c-4037-a90e-790c2cbcef52', // All About Lanternflies lesson    (4738 chars)
+  'ae8f00b4-a4ea-4601-85f3-9b720d0ced89', // NEW Place Based: Native Plants   (5328 chars)
+  'dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7', // Puppet Pollinators               (5794 chars)
+];
+
+interface SubmissionRow {
+  id: string;
+  google_doc_id: string;
+  google_doc_url: string;
+  extracted_title: string | null;
+  extracted_content: string;
+  content_hash: string;
+  content_embedding: unknown;
+  status: string;
+  submission_type: string;
+}
+
+interface ReviewRow {
+  id: string;
+  submission_id: string;
+  reviewer_id: string;
+  decision: string;
+  canonical_lesson_id: string | null;
+  tagged_metadata: Record<string, unknown>;
+  notes: string | null;
+}
+
+interface SelectedRow {
+  submission_id: string;
+  extracted_title: string;
+  content_length: number;
+  has_embedding: boolean;
+  review_id: string;
+  decision: string;
+  metadata_keys_present: string[];
+}
+
+interface Artifact {
+  phase: 'phase-5-b-new';
+  generated_at: string;
+  git_sha: string;
+  target: { target: string; url: string };
+  selected_rows: SelectedRow[];
+  preflight: {
+    embedding_check_passed: boolean;
+    doc_id_collision_check_passed: boolean;
+    not_already_published_check_passed: boolean;
+    review_present_check_passed: boolean;
+  };
+  summary: {
+    total_candidates: number;
+    selected: number;
+  };
+  artifact_hash?: string;
+}
+
+const generatedAt = new Date();
+const ts = generatedAt.toISOString().replace(/[:.]/g, '-');
+const outDir = path.join(__dirname, 'dryrun-artifacts');
+const snapshotDir = path.join(__dirname, 'snapshots');
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+for (const dir of [outDir, snapshotDir]) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+const artifactPath = path.join(outDir, `phase-5-b-new-${ts}.json`);
+const rehearsalPath = path.join(outDir, `phase-5-b-new-${ts}-rehearsal.sql`);
+const commitPath = path.join(outDir, `phase-5-b-new-${ts}-commit.sql`);
+const snapshotPath = path.join(snapshotDir, `category-b-new-pre-${ts}.json`);
+
+function gitSha(): string {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: repoRoot }).toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(',')}}`;
+}
+
+function sqlLit(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+async function fetchSubmission(id: string): Promise<SubmissionRow> {
+  const { data, error } = await supabase
+    .from('lesson_submissions')
+    .select('id, google_doc_id, google_doc_url, extracted_title, extracted_content, content_hash, content_embedding, status, submission_type')
+    .eq('id', id)
+    .single();
+  if (error) throw error;
+  return data as SubmissionRow;
+}
+
+async function fetchReview(submissionId: string): Promise<ReviewRow> {
+  const { data, error } = await supabase
+    .from('submission_reviews')
+    .select('id, submission_id, reviewer_id, decision, canonical_lesson_id, tagged_metadata, notes')
+    .eq('submission_id', submissionId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+  if (error) throw error;
+  return data as ReviewRow;
+}
+
+async function fetchAlreadyPublishedCount(submissionId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('lessons')
+    .select('lesson_id', { count: 'exact', head: true })
+    .eq('original_submission_id', submissionId);
+  if (error) throw error;
+  return count ?? 0;
+}
+
+async function fetchDocIdCollisionLessons(googleDocId: string): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('lessons')
+    .select('lesson_id')
+    .like('file_link', `%${googleDocId}%`);
+  if (error) throw error;
+  return (data ?? []).map((r) => r.lesson_id);
+}
+
+/**
+ * SQL projection of the React-state-shape `tagged_metadata` to:
+ *   (a) the legacy `lessons.metadata` JSONB shape (thematicCategories /
+ *       seasonTiming / locationRequirements:[...] / lessonFormat:[...] / etc.)
+ *   (b) the typed array columns (text[]) and the lone activity_type / lesson_format
+ *       text scalars on lessons.
+ *
+ * Logic mirrors `complete_review_atomic`'s approve_new branch (see migration
+ * 20260428000007_phase_4_fix_metadata_shape.sql) line-for-line. We INSERT
+ * inline here rather than calling the RPC because (1) the RPC's status guard
+ * (added in 000008) would refuse to run on already-approved submissions
+ * (ERRCODE 55000), and (2) routing through the RPC would UPSERT a second
+ * submission_reviews row with `review_completed_at = now()`, overwriting
+ * the historical reviewer's timestamp.
+ */
+function buildLessonInsertStatement(sub: SubmissionRow, review: ReviewRow, ordinalLabel: string): string {
+  const subId = sqlLit(sub.id);
+  const docUrl = sqlLit(sub.google_doc_url);
+  const reviewMetaLit = sqlLit(JSON.stringify(review.tagged_metadata ?? {}));
+  const titleHint = sqlLit(sub.extracted_title ?? '');
+
+  return `-- ${ordinalLabel}: submission_id ${sub.id} — ${(sub.extracted_title ?? '(no title)').replace(/\n/g, ' ')}
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = ${subId}::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = ${subId}::uuid
+);
+
+-- Local sanity hint (not asserted at SQL level; used by post-apply MCP verification):
+--   src title hint: ${titleHint}
+--   embedding source: live submission row content_embedding column
+--   raw tagged_metadata (review id ${review.id}):
+--     ${reviewMetaLit.length > 200 ? reviewMetaLit.slice(0, 200) + '… (truncated)' : reviewMetaLit}
+`;
+}
+
+function buildSql(
+  selected: { sub: SubmissionRow; review: ReviewRow }[],
+  terminator: 'ROLLBACK' | 'COMMIT'
+): string {
+  const header = `-- Phase 5 — Category B-new publish (smallest-content-first order)
+-- Generated by scripts/orphan-recovery/phase-5-b-new-publish.ts
+-- Selected rows: ${selected.length}
+--
+-- Each INSERT is its own statement, idempotent via WHERE NOT EXISTS on
+-- lessons.original_submission_id. The transaction wrapper is for atomic
+-- rollback if any individual INSERT trips a constraint. Re-applying is
+-- safe — the WHERE NOT EXISTS guard makes already-published rows no-ops.
+--
+-- This SQL is the rehearsal/commit artifact paired with the canonical
+-- migration file at supabase/migrations/20260429000000_phase_5_b_new_publish.sql.
+-- The migration's body is structurally identical to this file's body
+-- (same header, same per-row statements). Diff between rehearsal and
+-- commit shows exactly one line — the final terminator.
+`;
+
+  const statements = selected
+    .map(({ sub, review }, i) => buildLessonInsertStatement(sub, review, `Row ${i + 1} of ${selected.length}`))
+    .join('\n');
+
+  const verification = `
+-- Post-write verification (visible in the same transaction):
+SELECT
+  count(*)::int AS lessons_published_for_b_new,
+  count(*) FILTER (WHERE search_vector IS NOT NULL)::int AS with_fts,
+  count(*) FILTER (WHERE content_embedding IS NOT NULL)::int AS with_embedding,
+  count(*) FILTER (WHERE metadata ? 'thematicCategories')::int AS with_legacy_meta_keys
+FROM lessons
+WHERE original_submission_id IN (
+  ${selected.map((r) => sqlLit(r.sub.id) + '::uuid').join(',\n  ')}
+);
+`;
+
+  return `${header}
+BEGIN;
+
+${statements}
+${verification}
+${terminator};
+`;
+}
+
+async function main() {
+  const target = describeSupabaseTarget();
+  console.log(`Phase 5 — Category B-new publish (plan mode) against ${target.target}`);
+
+  const fetched: { sub: SubmissionRow; review: ReviewRow }[] = [];
+  for (const id of PHASE_5_B_NEW_SUBMISSION_IDS) {
+    const sub = await fetchSubmission(id);
+    if (sub.status !== 'approved') {
+      console.error(`Pre-flight failed: submission ${id} status='${sub.status}', expected 'approved'.`);
+      process.exit(1);
+    }
+    if (sub.content_embedding == null) {
+      console.error(`Pre-flight failed: submission ${id} has NULL content_embedding. Hard-stop.`);
+      console.error('  Recovery options: (1) regenerate via process-submission with regenerateEmbedding=true, (2) skip and document.');
+      process.exit(1);
+    }
+    if (!sub.extracted_content || sub.extracted_content.length === 0) {
+      console.error(`Pre-flight failed: submission ${id} has empty extracted_content.`);
+      process.exit(1);
+    }
+
+    const alreadyPublished = await fetchAlreadyPublishedCount(id);
+    if (alreadyPublished > 0) {
+      console.error(`Pre-flight failed: submission ${id} already has ${alreadyPublished} lessons row(s) linked. Skip or investigate.`);
+      process.exit(1);
+    }
+
+    const docCollisions = await fetchDocIdCollisionLessons(sub.google_doc_id);
+    if (docCollisions.length > 0) {
+      console.error(`Pre-flight failed: submission ${id} google_doc_id matches ${docCollisions.length} existing lessons rows: ${docCollisions.join(', ')}.`);
+      console.error('  This submission is Category A (doc-id match), not B-new. Re-classify.');
+      process.exit(1);
+    }
+
+    const review = await fetchReview(id);
+    if (review.decision !== 'approve_new') {
+      console.error(`Pre-flight failed: submission ${id} review decision='${review.decision}', expected 'approve_new'.`);
+      process.exit(1);
+    }
+    if (review.canonical_lesson_id != null) {
+      console.error(`Pre-flight failed: submission ${id} review canonical_lesson_id=${review.canonical_lesson_id}, expected NULL for approve_new.`);
+      process.exit(1);
+    }
+    if (review.tagged_metadata == null || typeof review.tagged_metadata !== 'object') {
+      console.error(`Pre-flight failed: submission ${id} review tagged_metadata is missing or non-object.`);
+      process.exit(1);
+    }
+
+    fetched.push({ sub, review });
+    console.log(`  ✓ ${id} preflight passed (title="${(sub.extracted_title ?? '').slice(0, 60)}", content_length=${sub.extracted_content.length}, metadata_keys=${Object.keys(review.tagged_metadata).length})`);
+  }
+
+  const selectedRows: SelectedRow[] = fetched.map(({ sub, review }) => ({
+    submission_id: sub.id,
+    extracted_title: sub.extracted_title ?? '',
+    content_length: sub.extracted_content.length,
+    has_embedding: sub.content_embedding != null,
+    review_id: review.id,
+    decision: review.decision,
+    metadata_keys_present: Object.keys(review.tagged_metadata ?? {}),
+  }));
+
+  // Snapshot: full submission + review rows for the selected 5. Used as
+  // rollback context if a published lesson needs to be deleted and
+  // republished from a different metadata snapshot. Snapshot is local-only
+  // (gitignored) — contains teacher content.
+  fs.writeFileSync(
+    snapshotPath,
+    JSON.stringify(
+      {
+        generated_at: generatedAt.toISOString(),
+        target: target.target,
+        submissions: fetched.map(({ sub }) => ({ ...sub, content_embedding: '<<vector elided>>' })),
+        reviews: fetched.map(({ review }) => review),
+      },
+      null,
+      2
+    )
+  );
+  console.log(`  Snapshot written: ${path.relative(process.cwd(), snapshotPath)} (${fetched.length} rows)`);
+
+  const artifactWithoutHash: Omit<Artifact, 'artifact_hash'> = {
+    phase: 'phase-5-b-new',
+    generated_at: generatedAt.toISOString(),
+    git_sha: gitSha(),
+    target,
+    selected_rows: selectedRows,
+    preflight: {
+      embedding_check_passed: true,
+      doc_id_collision_check_passed: true,
+      not_already_published_check_passed: true,
+      review_present_check_passed: true,
+    },
+    summary: {
+      total_candidates: PHASE_5_B_NEW_SUBMISSION_IDS.length,
+      selected: selectedRows.length,
+    },
+  };
+
+  const artifact: Artifact = {
+    ...artifactWithoutHash,
+    artifact_hash: sha256(canonicalJson(artifactWithoutHash)),
+  };
+
+  fs.writeFileSync(artifactPath, JSON.stringify(artifact, null, 2));
+  console.log(`  Artifact: ${path.relative(process.cwd(), artifactPath)}`);
+
+  fs.writeFileSync(rehearsalPath, buildSql(fetched, 'ROLLBACK'));
+  fs.writeFileSync(commitPath, buildSql(fetched, 'COMMIT'));
+  console.log(`  Rehearsal SQL: ${path.relative(process.cwd(), rehearsalPath)}`);
+  console.log(`  Commit SQL:    ${path.relative(process.cwd(), commitPath)}`);
+
+  console.log('');
+  console.log('Next steps:');
+  console.log('  1. Review the artifact and the rehearsal.sql file.');
+  console.log('  2. Local rehearsal: `psql -f ${rehearsal}` against a local DB seeded with the 5 submissions.');
+  console.log('  3. The migration file at supabase/migrations/20260429000000_phase_5_b_new_publish.sql is the canonical write path.');
+  console.log('  4. CI applies the migration to TEST DB on PR push; verify with mcp__supabase-test__execute_sql before merging.');
+  console.log('  5. After merge, the production migration workflow runs; verify with mcp__supabase-remote__execute_sql.');
+}
+
+main().catch((err) => {
+  console.error('phase-5-b-new-publish failed:', err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260429000000_phase_5_b_new_publish.sql
+++ b/supabase/migrations/20260429000000_phase_5_b_new_publish.sql
@@ -1,0 +1,503 @@
+-- =====================================================
+-- Migration: 20260429000000_phase_5_b_new_publish.sql
+-- =====================================================
+-- Description: Phase 5 of the lesson-submission Tier-1 orphan recovery.
+-- Publishes 5 approved orphan submissions whose Google Doc is NOT already
+-- in the library (Category B-new — verified via doc-id collision check
+-- and < 0.85 cosine similarity to any existing lesson).
+--
+-- Reasoning artifact: scripts/orphan-recovery/phase-5-b-new-publish.ts.
+-- That script encodes the same 5 submission IDs, the embedding preflight
+-- (NULL → hard-stop), and the post-write verification SELECT.
+--
+-- Each INSERT is a separate statement, ordered by extracted_content
+-- length ascending (smallest blast radius first) and idempotent via
+-- `WHERE NOT EXISTS (SELECT 1 FROM lessons WHERE original_submission_id
+-- = $1)`. Re-application is a 0-row no-op. If any single INSERT trips a
+-- constraint, Postgres aborts the transaction so we land at "0
+-- published" rather than partial — no per-row rollback needed.
+--
+-- Why this is NOT routed through complete_review_atomic:
+--   - The Phase 4 status guard (...000008) refuses to run when status is
+--     already 'approved' (ERRCODE 55000); these 5 submissions all are.
+--   - Routing would UPSERT a second submission_reviews row, overwriting
+--     the historical reviewer's review_completed_at timestamp.
+--   - Phase 7c email triggers (when implemented) would fire on the RPC
+--     path; we do not want to send 2026-dated approval emails to
+--     teachers for lessons they submitted in 2025.
+--
+-- Metadata projection (React-state shape → legacy lessons.metadata shape)
+-- mirrors complete_review_atomic's approve_new branch line-for-line. See
+-- 20260428000007_phase_4_fix_metadata_shape.sql for the canonical
+-- definition. Helper _phase4_jsonb_text_array(jsonb) is reused; it was
+-- created by 20260428000001_*. Migrations run as the postgres role,
+-- which has implicit EXECUTE on locked-down helpers it owns — the
+-- REVOKE FROM PUBLIC/anon/authenticated does not affect this path.
+--
+-- Held out from Phase 5's batch (separate manual decisions; both still
+-- present in PROD orphan set as of 2026-04-27):
+--   - submission ea271d13-78db-437c-aa9f-594ce567f90c "Applesauce lesson
+--     plan" (multi-doc-id-match — three plausible link targets)
+--   - submission 16603243-0eed-4cc8-886f-f9c37d25276f "Green 'Acai' Bowls
+--     (Mobile Education)" (matched lesson row 11oY-EaKF7FT… is broken)
+
+-- =====================================================
+-- CHANGES
+-- =====================================================
+
+-- Row 1 of 5: 4e4f3ae3-4c51-4439-87ee-f20d2ec94921 — Bees (4277 chars; smallest)
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = '4e4f3ae3-4c51-4439-87ee-f20d2ec94921'::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = '4e4f3ae3-4c51-4439-87ee-f20d2ec94921'::uuid
+);
+
+-- Row 2 of 5: 4c2bacdb-7018-4ff2-badb-3701c8c974c0 — Food Justice Advocates: Food Scarcity (4504 chars)
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = '4c2bacdb-7018-4ff2-badb-3701c8c974c0'::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = '4c2bacdb-7018-4ff2-badb-3701c8c974c0'::uuid
+);
+
+-- Row 3 of 5: 0369743c-8b6c-4037-a90e-790c2cbcef52 — All About Lanternflies lesson (4738 chars)
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = '0369743c-8b6c-4037-a90e-790c2cbcef52'::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = '0369743c-8b6c-4037-a90e-790c2cbcef52'::uuid
+);
+
+-- Row 4 of 5: ae8f00b4-a4ea-4601-85f3-9b720d0ced89 — NEW Place Based: Native Plants in Our Garden (5328 chars)
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = 'ae8f00b4-a4ea-4601-85f3-9b720d0ced89'::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = 'ae8f00b4-a4ea-4601-85f3-9b720d0ced89'::uuid
+);
+
+-- Row 5 of 5: dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7 — Puppet Pollinators (5794 chars; largest)
+WITH src AS (
+  SELECT s.id                AS submission_id,
+         s.extracted_title   AS extracted_title,
+         s.extracted_content AS extracted_content,
+         s.content_hash      AS content_hash,
+         s.content_embedding AS content_embedding,
+         s.google_doc_url    AS google_doc_url,
+         sr.tagged_metadata  AS v_meta,
+         jsonb_build_object(
+           'thematicCategories',             COALESCE(sr.tagged_metadata->'themes', '[]'::jsonb),
+           'seasonTiming',                   COALESCE(sr.tagged_metadata->'season', '[]'::jsonb),
+           'coreCompetencies',               COALESCE(sr.tagged_metadata->'coreCompetencies', '[]'::jsonb),
+           'culturalHeritage',               COALESCE(sr.tagged_metadata->'culturalHeritage', '[]'::jsonb),
+           'locationRequirements',
+             CASE WHEN sr.tagged_metadata ? 'location'
+                       AND COALESCE(sr.tagged_metadata->>'location', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'location')
+                  ELSE '[]'::jsonb END,
+           'lessonFormat',
+             CASE WHEN sr.tagged_metadata ? 'lessonFormat'
+                       AND COALESCE(sr.tagged_metadata->>'lessonFormat', '') <> ''
+                  THEN jsonb_build_array(sr.tagged_metadata->>'lessonFormat')
+                  ELSE '[]'::jsonb END,
+           'academicIntegration',            COALESCE(sr.tagged_metadata->'academicIntegration', '[]'::jsonb),
+           'socialEmotionalLearning',        COALESCE(sr.tagged_metadata->'socialEmotionalLearning', '[]'::jsonb),
+           'cookingMethods',                 COALESCE(sr.tagged_metadata->'cookingMethods', '[]'::jsonb),
+           'mainIngredients',                COALESCE(sr.tagged_metadata->'mainIngredients', '[]'::jsonb),
+           'gardenSkills',                   COALESCE(sr.tagged_metadata->'gardenSkills', '[]'::jsonb),
+           'cookingSkills',                  COALESCE(sr.tagged_metadata->'cookingSkills', '[]'::jsonb),
+           'observancesHolidays',            COALESCE(sr.tagged_metadata->'observancesHolidays', '[]'::jsonb),
+           'culturalResponsivenessFeatures', COALESCE(sr.tagged_metadata->'culturalResponsivenessFeatures', '[]'::jsonb)
+         ) AS v_legacy_meta
+  FROM lesson_submissions s
+  JOIN submission_reviews sr ON sr.submission_id = s.id
+  WHERE s.id = 'dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7'::uuid
+    AND s.status = 'approved'
+    AND sr.decision = 'approve_new'
+    AND s.content_embedding IS NOT NULL
+)
+INSERT INTO lessons (
+  lesson_id, title, summary, file_link,
+  grade_levels, activity_type, thematic_categories, season_timing,
+  core_competencies, cultural_heritage, location_requirements, lesson_format,
+  academic_integration, social_emotional_learning, cooking_methods,
+  main_ingredients, garden_skills, cooking_skills, observances_holidays,
+  cultural_responsiveness_features,
+  metadata, content_text, content_hash, content_embedding,
+  original_submission_id, processing_notes, created_at, updated_at
+)
+SELECT
+  'lesson_' || replace(gen_random_uuid()::text, '-', ''),
+  COALESCE(NULLIF(src.extracted_title, ''), NULLIF(src.v_meta->>'title', ''), 'Untitled Lesson'),
+  COALESCE(src.v_meta->>'summary', ''),
+  src.google_doc_url,
+  public._phase4_jsonb_text_array(src.v_meta->'gradeLevels'),
+  CASE WHEN src.v_meta ? 'activityType' AND COALESCE(src.v_meta->>'activityType', '') <> ''
+       THEN ARRAY[src.v_meta->>'activityType']
+       ELSE ARRAY[]::text[] END,
+  public._phase4_jsonb_text_array(src.v_meta->'themes'),
+  public._phase4_jsonb_text_array(src.v_meta->'season'),
+  public._phase4_jsonb_text_array(src.v_meta->'coreCompetencies'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalHeritage'),
+  CASE WHEN src.v_meta ? 'location' AND COALESCE(src.v_meta->>'location', '') <> ''
+       THEN ARRAY[src.v_meta->>'location']
+       ELSE ARRAY[]::text[] END,
+  NULLIF(src.v_meta->>'lessonFormat', ''),
+  public._phase4_jsonb_text_array(src.v_meta->'academicIntegration'),
+  public._phase4_jsonb_text_array(src.v_meta->'socialEmotionalLearning'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingMethods'),
+  public._phase4_jsonb_text_array(src.v_meta->'mainIngredients'),
+  public._phase4_jsonb_text_array(src.v_meta->'gardenSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'cookingSkills'),
+  public._phase4_jsonb_text_array(src.v_meta->'observancesHolidays'),
+  public._phase4_jsonb_text_array(src.v_meta->'culturalResponsivenessFeatures'),
+  src.v_legacy_meta,
+  COALESCE(src.extracted_content, ''),
+  src.content_hash,
+  src.content_embedding,
+  src.submission_id,
+  COALESCE(src.v_meta->>'processingNotes', ''),
+  now(),
+  now()
+FROM src
+WHERE NOT EXISTS (
+  SELECT 1 FROM lessons WHERE original_submission_id = 'dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7'::uuid
+);
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- Each published lesson gets a fresh `lesson_<random>` id at INSERT time, so
+-- the rollback selector is `original_submission_id IN (...the 5 source uuids)`.
+-- These are all net-new lessons (no prior lesson_versions, no other tables
+-- reference them yet at apply time), so DELETE is safe.
+--
+-- DELETE FROM lessons
+-- WHERE original_submission_id IN (
+--   '4e4f3ae3-4c51-4439-87ee-f20d2ec94921'::uuid,
+--   '4c2bacdb-7018-4ff2-badb-3701c8c974c0'::uuid,
+--   '0369743c-8b6c-4037-a90e-790c2cbcef52'::uuid,
+--   'ae8f00b4-a4ea-4601-85f3-9b720d0ced89'::uuid,
+--   'dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7'::uuid
+-- );


### PR DESCRIPTION
## Summary

- Recovers **5 approved orphan submissions** whose Google Doc is not in the library and whose content has no plausible duplicate (cosine sim < 0.85). Each already has a `submission_reviews` row with `decision='approve_new'`; only the `lessons` INSERT is missing — the exact atomicity-gap pathway that Phase 4 closes going forward.
- **Migration is the canonical write path** (`supabase/migrations/20260429000000_phase_5_b_new_publish.sql`): 5 separate `INSERT … WITH src AS (...) SELECT … WHERE NOT EXISTS` statements, ordered by `extracted_content` length ascending (smallest blast radius first), each idempotent on re-run.
- **Reasoning artifact** (`scripts/orphan-recovery/phase-5-b-new-publish.ts`): plan-only audit script with embedding preflight + doc-id-collision check + decision verification; emits JSON manifest + snapshot + rehearsal/commit SQL. Snapshots are gitignored (teacher content).

## The 5 submissions (smallest content first)

| # | submission_id | extracted_title | content_len |
|---|---|---|---|
| 1 | `4e4f3ae3-…` | Bees | 4277 |
| 2 | `4c2bacdb-…` | Food Justice Advocates: Food Scarcity | 4504 |
| 3 | `0369743c-…` | All About Lanternflies lesson | 4738 |
| 4 | `ae8f00b4-…` | NEW Place Based: Native Plants in Our Garden | 5328 |
| 5 | `dd2c3e79-…` | Puppet Pollinators | 5794 |

## Why not route through `complete_review_atomic`?

Three reasons (all called out in the plan and migration header):
1. Phase 4's status guard (`…000008`) refuses on already-approved submissions (ERRCODE 55000).
2. Routing would UPSERT a 2nd `submission_reviews` row, clobbering the historical reviewer's `review_completed_at`.
3. Routing would fire (eventual) Phase 7c email triggers, sending 2026 approval emails for 2025 submissions.

Recovery does the missing `lessons` INSERT only. Metadata projection (React-state shape → legacy `lessons.metadata` shape) mirrors `complete_review_atomic`'s `approve_new` branch line-for-line — see `20260428000007_phase_4_fix_metadata_shape.sql`.

## Held out (still in orphan set, not part of this batch)

- `ea271d13-…` "Applesauce lesson plan" — multi-doc-id-match (3 plausible link targets); needs Google Docs eyeball.
- `16603243-…` "Green 'Acai' Bowls (Mobile Education)" — matched library row `11oY-EaKF7FT…` is broken (`title='Unknown'`, `summary='Error processing lesson'`).

## Verification done before authoring

- **All 5 doc-id-collision-free against library** (no Cat A miss): verified via `mcp__supabase-remote__execute_sql`.
- **All 5 cosine similarity peak 0.84** against library (well below 0.85 duplicate threshold).
- **All 5 pass mandatory embedding preflight** (`content_embedding IS NOT NULL`).
- **Each has exactly 1 `submission_reviews` row** with `decision='approve_new'`, `canonical_lesson_id IS NULL`, `tagged_metadata` populated in React-state shape.
- **TEST DB state matches PROD for all 5** — CI's TEST DB rehearsal will exercise the migration with real source data.
- **Local rehearsal**: `supabase db reset` applies migration cleanly. Per-row projection separately rehearsed against the actual Bees `tagged_metadata` blob; output matches legacy shape exactly.
- **Pre-push self-review** (feature-dev:code-reviewer agent): no BLOCKING/HIGH findings; one LOW (`fetchReview` defensive ordering) deferred.

## Test plan

- [ ] CI applies migration to TEST DB → verify via `mcp__supabase-test__execute_sql`:
  - 5 lessons rows with `original_submission_id IN (…the 5 uuids…)` exist
  - Each has `search_vector IS NOT NULL`, `content_embedding IS NOT NULL`
  - Each has `metadata ? 'thematicCategories'` (legacy shape preserved)
  - Each has the right title/summary/file_link from the source submission
- [ ] Eyeball one published lesson on the TEST Netlify preview to confirm UI renders (filters, search hit, lesson detail panel).
- [ ] After merge, production migration workflow applies → verify same checks via `mcp__supabase-remote__execute_sql`.
- [ ] Confirm orphan count drops from 13 → 8 (5 published + 6 B-update + 2 held-out).

## Rollback

If a published lesson needs to be removed (these are net-new lessons; no prior `lesson_versions`, no other tables reference them yet at apply time):

```sql
DELETE FROM lessons
WHERE original_submission_id IN (
  '4e4f3ae3-4c51-4439-87ee-f20d2ec94921'::uuid,
  '4c2bacdb-7018-4ff2-badb-3701c8c974c0'::uuid,
  '0369743c-8b6c-4037-a90e-790c2cbcef52'::uuid,
  'ae8f00b4-a4ea-4601-85f3-9b720d0ced89'::uuid,
  'dd2c3e79-6dbb-4863-b60b-6c37a1fcc2f7'::uuid
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)