### PR TITLE
feat(db): Phase 8b Section 1 — FK ON DELETE SET NULL

### DIFF
--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -45,15 +45,15 @@ Three alternatives were considered and rejected:
 | **Hybrid-of-hybrid** (search bar + "skip — it's new" link) | Same backend mechanics as intent-first but with a "skip" link as a UI smell. The search-bar-as-default implies "you should search," which the new-case user must actively dismiss. Intent-first asks the right question (intent) without that cognitive load. |
 | **Original Option C** (single form: URL + radio + typeahead picker, hint-not-binding) | Cheapest fix (~1.5 days) but preserves the structural smell of "submitter declares but it's just a hint." Per workflows-not-sacred, the right move is to invest in a real redesign once. |
 
-## 4. Section 1 — Schema (2 small migrations)
+## 4. Section 1 — Schema (1 migration)
 
-Three things change at the database layer. None require RLS additions, status enum changes, or a cron job.
+Two things change at the database layer in scope; one was already done. None require RLS additions, status enum changes, or a cron job.
 
-1. **FK `lesson_submissions.original_lesson_id` → `ON DELETE SET NULL`.**
+1. **FK `lesson_submissions.original_lesson_id` → `ON DELETE SET NULL`.** (NEW migration in PR 1)
    *Why:* if a reviewer deletes the lesson a submitter linked to (rare but possible), the submission row should survive with its intent neutralized rather than cascade-deleting. Defense in depth.
 
-2. **Status guard in `complete_review_atomic` RPC.**
-   *Why:* defends against double-submit races. If a reviewer's session writes succeed but the row was already approved by another concurrent reviewer, the second write should fail loudly rather than silently overwriting. Adds at the top of the RPC: `IF status NOT IN ('submitted', 'in_review') THEN RAISE EXCEPTION ...`
+2. **Status guard in `complete_review_atomic` RPC.** (Already shipped in Phase 4 — `supabase/migrations/20260428000008_phase_4_status_guard.sql`)
+   The shipped guard refuses re-entry on terminal statuses (`approved`, `rejected`) and *intentionally* allows `needs_revision` flip-back through the UPSERT path. The earlier draft of this design proposed `IF status NOT IN ('submitted', 'in_review') THEN RAISE EXCEPTION` which would have blocked the legitimate "reviewer flips needs_revision back to approve_new" flow. The Phase 4 predicate is the correct one. **No new migration needed for this item.**
 
 3. **(NO new CHECK constraint.)** The earlier draft proposed `submission_type != 'update' OR original_lesson_id IS NOT NULL`. Dropped because the redesign needs to support `(submission_type='update', original_lesson_id=NULL)` as a valid state — "submitter said update but couldn't find target." Application-level validation in the `process-submission` edge function covers the case where a non-null `original_lesson_id` references a non-existent lesson.
 
@@ -211,7 +211,15 @@ Target title is **visible inline next to the UPDATE badge**, not hidden in a too
 
 ### 6.8 Override-tracking (deferred)
 
-A future admin query joining `lesson_submissions` ↔ `submission_reviews` to surface "submissions where reviewer overrode submitter intent" is worth building if patterns emerge. **No new schema needed** — derived from existing `original_lesson_id` and `published_lesson_id`. Out of 8b scope; captured as follow-up.
+A future admin query to surface "submissions where reviewer overrode submitter intent" is worth building if patterns emerge. **No new schema needed**, but the derivation is a JOIN, not a column comparison: the published lesson ID isn't stored on `submission_reviews` directly (the `canonical_lesson_id` column exists on that table but is NOT populated by the current `complete_review_atomic` RPC — it's a leftover from earlier infrastructure). The right derivation is:
+
+- For `approve_new`: `lessons.original_submission_id = submission.id` gives the published lesson_id
+- For `approve_update`: `lesson_versions.archived_from_submission_id = submission.id` gives the lesson_id whose old version was archived (the merge target)
+- Compare either of those to `lesson_submissions.original_lesson_id` (submitter intent) to flag overrides
+
+Alternatively (cheaper but requires a one-line RPC change): modify `complete_review_atomic` to write `canonical_lesson_id` on `submission_reviews` when decision is `approve_new` or `approve_update`. Then the comparison becomes `original_lesson_id` (submitter) vs `submission_reviews.canonical_lesson_id` (reviewer) — much simpler, but bumps the scope past pure follow-up.
+
+Out of 8b scope; captured as follow-up.
 
 ### 6.9 Race condition (acknowledged, deferred)
 
@@ -321,7 +329,7 @@ Per `feedback_pr_bot_review_workflow.md`:
 - Past-submissions-first revising flow (UX agent alternative — show user's own published lessons before library-wide search)
 - Brand-new branch safety check (similarity check before submit)
 - Submission "claim" mechanism (status → `in_review` on reviewer open) to prevent concurrent-edit collisions
-- Override-tracking admin view (compare `original_lesson_id` to `published_lesson_id` for audit signal)
+- Override-tracking admin view (JOIN through `lessons.original_submission_id` + `lesson_versions.archived_from_submission_id` to derive reviewer's chosen lesson; compare to submitter's `original_lesson_id`. Or land a one-line RPC change to write `submission_reviews.canonical_lesson_id` and use a direct column compare.)
 - Snapshot of lesson title at picker-time (for v2 if title-edit-during-review patterns emerge)
 - Title mismatch via DB trigram (if v1's in-browser Jaccard proves insufficient)
 - Separate queue lane for UPDATE-NO-TARGET (if volume warrants focused review surface)

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -1,0 +1,319 @@
+# Phase 8b — `approve_update` Workflow Redesign — Design Document
+
+**Date:** 2026-04-27
+**Status:** Design approved; ready for implementation planning
+**Phase reference:** Tier-1 #9 in `~/.claude/plans/lesson-submission-tier1-implementation.md`
+**Original investigation:** `~/.claude/plans/i-want-you-to-pure-iverson.md`
+
+---
+
+## 1. Why this exists
+
+The `approve_update` workflow has been broken end-to-end since launch. Submitters were asked to declare `submission_type='update'` upfront and type a raw `lesson_<UUID>` into a freetext field; reviewers never saw that field; reviewers could only merge into lessons that surfaced in `submission_similarities` (the dup-detection results table). When dup detection didn't surface the lesson the submitter intended, reviewers fell back to `approve_new`, creating literal duplicates of lessons the library already had. This produced 30 orphan submissions in PROD, all from one teacher (Liza Engelberg) clustered Sept 5–19 2025. The orphans have been recovered (Phases 5/6/6.2/6.3, all shipped 2026-04-27).
+
+Phase 8b is the forward fix — redesigning the workflow so this class of bug can't recur. Per the user's "workflows are not sacred" preference, this is a workflow-level redesign rather than a patch within the current shape.
+
+## 2. Three failure modes the redesign must close
+
+For Liza's orphans to have been prevented under the new flow, three things had to align:
+
+1. **Dup detection had to surface the right target.** Year-tagged "X 25-26" titles may not have crossed the trigram threshold against bare "X." Any design that depends on dup-detection accuracy as the primary recovery path inherits this risk.
+2. **Submitter had to be able to express update intent cleanly.** The freetext `lesson_<UUID>` field had no validation and no support — a teacher would never know what to type.
+3. **Reviewer had to see and act on the submitter's intent.** The reviewer UI ignored the `original_lesson_id` field entirely.
+
+A successful redesign removes all three failure modes simultaneously. The chosen shape (intent-first, see §3) does this by making the submitter-side intent declaration:
+- explicit (binding, not a hint),
+- supported by a real picker (not freetext),
+- routed to the reviewer UI prominently (not hidden in a database column).
+
+## 3. The chosen shape: Intent-first
+
+The submitter is asked up front, *before any URL paste*, what they're submitting. Two paths:
+
+- **"Add a new lesson to the library"** → URL paste page. One field. Done.
+- **"Update a lesson that's already in the library"** → search picker (find the lesson) → URL paste → submit.
+
+The reviewer sees a binding intent flag — not a hint — and the merge target is pre-selected (or, if the submitter couldn't find the target, an explicit yellow "needs-search" signal).
+
+### Why intent-first over the alternatives
+
+Three alternatives were considered and rejected:
+
+| Option | Why rejected |
+|---|---|
+| **Hybrid gate** (URL paste → backend extracts → if matches found, gate page asks submitter to pick/dismiss) | Recovery still depends on dup-detection accuracy. If detection misses the right target, the gate doesn't fire and we're back to the orphan-producing flow. Also has asymmetric UX (gate fires for some, not others) and forces submitters to interpret similarity scores. |
+| **Hybrid-of-hybrid** (search bar + "skip — it's new" link) | Same backend mechanics as intent-first but with a "skip" link as a UI smell. The search-bar-as-default implies "you should search," which the new-case user must actively dismiss. Intent-first asks the right question (intent) without that cognitive load. |
+| **Original Option C** (single form: URL + radio + typeahead picker, hint-not-binding) | Cheapest fix (~1.5 days) but preserves the structural smell of "submitter declares but it's just a hint." Per workflows-not-sacred, the right move is to invest in a real redesign once. |
+
+## 4. Section 1 — Schema (2 small migrations)
+
+Three things change at the database layer. None require RLS additions, status enum changes, or a cron job.
+
+1. **FK `lesson_submissions.original_lesson_id` → `ON DELETE SET NULL`.**
+   *Why:* if a reviewer deletes the lesson a submitter linked to (rare but possible), the submission row should survive with its intent neutralized rather than cascade-deleting. Defense in depth.
+
+2. **Status guard in `complete_review_atomic` RPC.**
+   *Why:* defends against double-submit races. If a reviewer's session writes succeed but the row was already approved by another concurrent reviewer, the second write should fail loudly rather than silently overwriting. Adds at the top of the RPC: `IF status NOT IN ('submitted', 'in_review') THEN RAISE EXCEPTION ...`
+
+3. **(NO new CHECK constraint.)** The earlier draft proposed `submission_type != 'update' OR original_lesson_id IS NOT NULL`. Dropped because the redesign needs to support `(submission_type='update', original_lesson_id=NULL)` as a valid state — "submitter said update but couldn't find target." Application-level validation in the `process-submission` edge function covers the case where a non-null `original_lesson_id` references a non-existent lesson.
+
+**Schema items dropped from the prior session's draft** (because intent-first never creates a row pre-submission):
+- `draft` and `abandoned` status enum values — no half-finished state to track
+- `submitter_dismissed_matches` BOOLEAN — no gate page to dismiss matches on
+- Teacher UPDATE policy on `lesson_submissions` — no client-side PATCH happens
+- Teacher SELECT policy on `submission_similarities` — submitter never sees that table
+- `SubmissionStatus` TypeScript type sync — no new statuses
+- `ReviewDashboard.tsx` queue filter for draft/abandoned — no such statuses
+- Nightly cron auto-cleanup — no drafts to clean
+
+## 5. Section 2 — Submitter flow
+
+### Routes
+
+| Route | Purpose |
+|---|---|
+| `/submit` | Intent picker (new home for submission). Two large cards. Auth enforced at click via existing `AuthModal`. |
+| `/submit/new` | URL paste form. One field, regex-validated. |
+| `/submit/revising` | Two-step form: search picker → URL paste. Submit disabled until both complete. |
+
+Direct-link to either branch works (no forced redirect through intent picker). Browser back from either branch returns to `/submit`. Small breadcrumb on each branch: "Adding a new lesson · ← Change" / "Updating a lesson · ← Change."
+
+### Intent picker copy
+
+- **"Add a new lesson to the library"** — helper: "Use this if no version of this lesson has been added yet"
+- **"Update a lesson that's already in the library"** — helper: "Use this if a version of your lesson is already published"
+
+1–2 lines of orientation copy above the cards: "Submit a Google Doc lesson plan for the ESYNYC library. A reviewer will check it and either publish it or get back to you."
+
+### Auth gating
+
+`pendingIntent` state on the picker (`'new' | 'revising' | null`). On card click without auth, set `pendingIntent` and show `AuthModal`. On modal `onSuccess`, `navigate('/submit/${pendingIntent}')`. This pattern replaces the existing `AuthModal.onSuccess`-calls-handleSubmit pattern, which doesn't translate to a multi-route flow.
+
+### `LessonSearchPicker` component (new, reusable)
+
+- Debounced ~300ms text input
+- Direct `.from('lessons').select('lesson_id, title, grade_levels, season').ilike('title', '%${query}%').limit(10)` against existing `idx_lessons_title_trgm` GIN index. (Do not reuse `search_lessons` RPC — it has 14 params and uses `to_tsquery` which can throw on partial words.)
+- Empty state: placeholder "Search by lesson title or topic" + example "e.g., 'Three Sisters' or 'composting'"
+- Mid-debounce: keep prior results visible with subtle spinner (don't blank out)
+- Zero results / "Don't see your lesson?": **"I'm updating but can't find it — let a reviewer help"** (binding intent, no target — closes the orphan regression hole)
+- Selected target: chip above input with × clear; sticky on mobile
+
+**Reusable shape:**
+```
+<LessonSearchPicker
+  selected={lesson | null}
+  onSelect={(lesson) => ...}
+  onClear={() => ...}
+  cantFindOption={boolean}        // true on submitter side, false on reviewer side
+  onCantFind={() => ...}          // submitter-side callback
+/>
+```
+
+### Submit copy on revising branch
+
+- With target: **"Submit as a revision of [X]"** with sub-line "A reviewer will replace the published lesson with this content."
+- Without target (can't-find): **"Submit for reviewer to match"** with sub-line "A reviewer will identify which lesson this updates."
+
+### Edge function changes
+
+`process-submission`:
+- **Add server-side validation BEFORE the row INSERT** (before line 174): if `submissionType === 'update'` and `originalLessonId` is non-null, do `SELECT COUNT(*)` on `lessons` for that ID; return 400 if zero rows. The DB-level FK constraint serves as the final TOCTOU backstop. Pre-INSERT validation prevents orphan rows on the error path.
+- `(update, null)` is allowed (binding intent, no target).
+
+### Removed code in `SubmissionPage.tsx`
+
+- `submissionType` state, `originalLessonId` state, the radio fieldset (lines 133-157), the conditional `originalLessonId` input (lines 159-174)
+- The post-submit duplicates panel (lines 286-**350**, not 286-348 — corrected per code review)
+
+### Success page
+
+- (update, X): "We'll merge this into '[X]' once a reviewer approves."
+- (update, null): "A reviewer will identify which lesson this updates and either merge or publish as new."
+- (new): "We'll publish this once a reviewer approves."
+
+### Explicit non-handlings (deferred)
+
+- **Extraction failure recovery** — today's behavior preserved (row stays with NULL extracted_content). Highest-priority deferred item per UX critique.
+- **Repeated-submission detection** (`user_id + doc_url` collision) — separate feature.
+- **Wrong-doc-pasted-after-target-pick** mismatch — reviewer catches via Section 3's title mismatch helper.
+- **Past-submissions-first revising flow** (UX agent alternative) — not folded into v1; defer.
+- **Brand-new branch safety check** (UX agent's "we found similar lessons — is this an update?") — defer; reviewer-side dup detection is the safety net.
+
+## 6. Section 3 — Reviewer flow
+
+### 6.1 Color-coded banner at top of decision panel
+
+Always visible:
+- (new) → **green**: "Submitter says: New lesson"
+- (update, X) → **blue**: "Submitter says: Updating **[X title]**" with link/preview
+- (update, null) → **yellow ⚠**: "Submitter says: Updating, but couldn't find target — please search to identify"
+
+Color is load-bearing for muscle memory (peripheral vision catches state change).
+
+### 6.2 Pre-selection logic
+
+| Intent state | Pre-selected decision | Pre-selected target |
+|---|---|---|
+| (new) | `approve_new` | none |
+| (update, X) | `approve_update` | X (auto-fetched if not in dup list) |
+| (update, null) | `approve_update` | none — reviewer must pick via search |
+
+### 6.3 Fixed enable/disable logic (CRITICAL)
+
+The current `ReviewDetail.tsx` has `<radio approve_update disabled={!selectedDuplicate}>`. This breaks under intent-first because we want to show `approve_update` as pre-selected even when target is unset (the (update, null) case).
+
+**Fix:** all decision radios always selectable. **Submit button** disabled when `decision === 'approve_update' && target === null`, with inline guidance: *"Pick a target lesson to merge into, or change to Approve as new."*
+
+This forces the (update, null) reviewer to either find a target or actively flip to `approve_new` — the override becomes a deliberate radio click rather than the path of least resistance, which closes the regression hole.
+
+### 6.4 Unified "Candidate matches" list
+
+Single list (not two side-by-side lists for "dup detection results" and "submitter selected"):
+
+- Submitter's bound target (if any) appears at top with a **"Submitter's choice"** badge — regardless of dup-detection score, even with score 0%
+- Dup detection results follow with their similarity scores
+- Reviewer can pick any card; selected card gets visual ring; "Submitter's choice" badge stays anchored to the submitter's pick regardless of which card the reviewer selects
+
+When `submission.original_lesson_id` is non-null AND not already in `submission_similarities`, `loadSubmission` does an additional `lessons_with_metadata` SELECT for that lesson and prepends it to the unified list.
+
+### 6.5 Search escape hatch (collapsed by default)
+
+Below the unified card list:
+- Disclosure: **"Search the library for a different lesson"**
+- **Auto-expanded for `(update, null)` and when zero dup matches found**
+- Reuses `LessonSearchPicker` with `cantFindOption=false`
+- Contextual help text per state:
+  - default: "Use this when no card above is the right match"
+  - `(update, null)`: "Use this to find the lesson the submitter couldn't"
+  - `(update, X)` override mode: "Use this if you disagree with the submitter's pick"
+
+### 6.6 Title mismatch helper
+
+When the picked target's title differs significantly from the extracted submission title, show a yellow inline note: "Heads up: submitter linked to '[X]' but submission's extracted title is '[Y]' — confirm this is the right merge target."
+
+- **Algorithm**: word-set Jaccard at ~0.3 threshold (in-browser, no DB call). Lowercase + strip punctuation, split on whitespace, intersect/union.
+- **Only fires on auto-picks** (submitter binding or dup detector). Not when reviewer manually picked via search — manual pick is already deliberate confirmation.
+- For v1: uses *current* lesson title (no snapshot at submit-time). Defer snapshotting if patterns emerge.
+
+### 6.7 Three-state queue badges
+
+In `ReviewDashboard.tsx` queue cards (via `IntQueueRow.tsx`):
+
+| Badge | Color | Tooltip |
+|---|---|---|
+| NEW | green | (none / extracted title) |
+| UPDATE | blue | Target lesson title |
+| UPDATE? | yellow | "Submitter is updating but couldn't find target — needs reviewer search" |
+
+Lets reviewers triage the queue (batch the easy ones, focus on the work-required ones).
+
+### 6.8 Override-tracking (deferred)
+
+A future admin query joining `lesson_submissions` ↔ `submission_reviews` to surface "submissions where reviewer overrode submitter intent" is worth building if patterns emerge. **No new schema needed** — derived from existing `original_lesson_id` and `published_lesson_id`. Out of 8b scope; captured as follow-up.
+
+### 6.9 Race condition (acknowledged, deferred)
+
+Section 4's RPC status guard catches concurrent reviewers at commit time. Pre-existing gap: no "claim" mechanism, so two reviewers can edit the same submission silently until one save fails. Not 8b's job to fix; document as known.
+
+### Files changed in Section 3
+
+- `src/pages/ReviewDetail.tsx` — banner, pre-select logic, fixed enable/disable, unified card list, search escape hatch, mismatch helper, `loadSubmission` modification for off-list submitter target
+- `src/pages/ReviewDashboard.tsx` — pass `originalLessonId` and badge state into row props
+- `src/components/IntQueueRow.tsx` — accept new prop, render three-state badge
+- Reuses `LessonSearchPicker` from Section 2
+
+## 7. Section 4 — Migration / shipping strategy
+
+Three sequential PRs:
+
+| # | PR | Contains | Notes |
+|---|---|---|---|
+| 1 | **Schema** | Section 1's 2 items: FK alter + RPC guard | Defensive only. Forward-rollback migration ready before merge. Idempotent (`DROP CONSTRAINT IF EXISTS`, `CREATE OR REPLACE FUNCTION`). |
+| 2 | **Submitter flow + LessonSearchPicker** | Section 2: rewrite `SubmissionPage.tsx`, add `/submit/new` and `/submit/revising` routes, new `LessonSearchPicker` + `NewSubmissionForm` + `RevisingSubmissionForm`, `process-submission` pre-INSERT validation | Picker created here since Section 2 is its first consumer. Forward-compatible with old reviewer UI. |
+| 3 | **Reviewer flow** | Section 3: `ReviewDetail.tsx` rewrites, `ReviewDashboard.tsx` + `IntQueueRow.tsx` 3-state badge, reuse `LessonSearchPicker` | Lands once new submitters are producing binding-intent data. Old-shape submissions still display correctly. |
+
+### TEST DB rehearsal
+
+- PR 1: CI applies migration to TEST. Verify with `mcp__supabase-test__execute_sql`: confirm FK definition shows `ON DELETE SET NULL`; confirm RPC source contains the status guard.
+- PR 2/3: no schema, no rehearsal needed beyond Netlify deploy preview + manual smoke.
+
+### Rollback paths
+
+- PR 1: forward-rollback migration that reverts FK to `NO ACTION` and removes the RPC status guard. Idempotent.
+- PR 2/3: standard frontend git revert. No data side effects to reverse.
+
+### Per-PR ritual
+
+Per `feedback_pr_bot_review_workflow.md`:
+1. Pre-push self-review (manual diff scan)
+2. Push → dispatch own reviewer agent before bot reviews
+3. Investigate every bot finding (don't auto-accept)
+4. Consolidated fix-up commits
+5. Round-cap after 2 rounds
+
+### Known issues
+
+- `migrate-production.yml` Verify-step SASL flake (cosmetic; PROD MCP verification is mandatory after every apply)
+- Email pipeline broken in PROD for non-`mail@danfeder.org` recipients — Phase 8b doesn't add email triggers, so not a blocker
+
+## 8. Section 5 — Testing strategy
+
+### Unit
+
+- `LessonSearchPicker.test.tsx`: debounce timing, result rendering, selection state, clear affordance, can't-find option enable/disable
+- `titlesAreSimilar` helper (word-set Jaccard at 0.3): assert "Updated for 2026" + "Spring Planting" → similar; "Apple Crisp" + "Solar Eclipse" → not similar; case/punctuation normalization
+- Pre-selection logic: `ReviewDetail` unit tests covering all three intent states produce correct `(decision, target)` defaults and submit-button enable state
+
+### Integration
+
+- `process-submission` edge function:
+  - `(submission_type='new')` → row created, `status='submitted'`
+  - `(update, valid_target)` → row created, `original_lesson_id` populated
+  - `(update, invalid_target)` → 400 error, **no row inserted**
+  - `(update, null)` → row created, `original_lesson_id=null`
+- `complete-review`: existing approve_update tests must still pass; add a test for status-guard rejection (already-approved submission cannot be re-approved)
+
+### E2E (Playwright, against Netlify deploy preview)
+
+- Submitter — Add new
+- Submitter — Update with target
+- Submitter — Update without target ("can't find it")
+- Reviewer — `(update, X)` happy path (banner + pre-selection + approve)
+- Reviewer — `(update, null)` happy path (yellow banner + auto-expanded search + approve)
+
+### Regression
+
+- Existing E2E smoke test continues to pass
+- Legacy submission rows (pre-Phase-8b `(update, freetext_string_id)`) still render in reviewer UI without crashing — defensive handling required
+
+### RLS
+
+- No RLS changes. `npm run test:rls` must pass unchanged.
+- Picker reads `lessons` via existing public-readable policy.
+
+### Manual smoke checklist (per `superpowers:verification-before-completion`, before claiming a PR done)
+
+- Submit a new lesson via `/submit` → verify row in TEST DB
+- Submit an update with target → verify `original_lesson_id` populated
+- Submit an update without target → verify `original_lesson_id` null + `submission_type='update'`
+- Open each submission as reviewer → verify banner color, pre-selection, badge anchoring
+- Override pre-selection → verify save succeeds with overridden value
+
+## 9. Out of scope for Phase 8b (captured for future work)
+
+- Extraction failure recovery (detect synchronously, surface "couldn't read your Google Doc" with retry)
+- Repeated-submission detection (`user_id + doc_url` collision)
+- Past-submissions-first revising flow (UX agent alternative — show user's own published lessons before library-wide search)
+- Brand-new branch safety check (similarity check before submit)
+- Submission "claim" mechanism (status → `in_review` on reviewer open) to prevent concurrent-edit collisions
+- Override-tracking admin view (compare `original_lesson_id` to `published_lesson_id` for audit signal)
+- Snapshot of lesson title at picker-time (for v2 if title-edit-during-review patterns emerge)
+- Title mismatch via DB trigram (if v1's in-browser Jaccard proves insufficient)
+- Separate queue lane for UPDATE-NO-TARGET (if volume warrants focused review surface)
+
+## 10. References
+
+- Original investigation: `~/.claude/plans/i-want-you-to-pure-iverson.md`
+- Tier-1 implementation plan: `~/.claude/plans/lesson-submission-tier1-implementation.md` (lines 47-73 = Q2 framing; lines 1042-1066 = the Phase 8b sketch this doc supersedes)
+- Mid-brainstorm handoff: `~/.claude/plans/2026-04-27-phase-8b-workflow-redesign-handoff.md`
+- Auto-memory: `project_lesson_submission_tier1.md`, `project_embedding_pipeline_mismatch.md`, `feedback_workflows_not_sacred.md`, `feedback_data_safety_top_priority.md`, `feedback_pr_bot_review_workflow.md`, `feedback_bot_review_investigation.md`

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -231,7 +231,7 @@ Section 4's RPC status guard catches concurrent reviewers at commit time. Pre-ex
 
 - `src/pages/ReviewDetail.tsx` — banner, pre-select logic, fixed enable/disable, unified card list, search escape hatch, mismatch helper, `loadSubmission` modification for off-list submitter target
 - `src/pages/ReviewDashboard.tsx` — pass `originalLessonId` and badge state into row props
-- `src/components/IntQueueRow.tsx` — accept new prop, render three-state badge
+- `src/components/Internal/IntQueueRow.tsx` — accept new prop, render three-state badge
 - Reuses `LessonSearchPicker` from Section 2
 
 ## 7. Section 4 — Migration / shipping strategy

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -256,6 +256,8 @@ Alternatives considered and rejected:
 - *Ship PR 2 and PR 3 in tight sequence with reviewer activity paused*: relies on humans not making the mistake during a rushed window
 - *Feature-flag `/submit/revising` until PR 3 is deployed*: adds env-var ceremony and "we forgot to flip the flag" risk; submitter UI ships partially-functional during the gap
 - *Combine PR 2 and PR 3 into a single mega-PR*: sacrifices per-PR-ritual + rollback granularity for atomicity
+- *Add a confirmation modal in PR 2 that fires when reviewer clicks Approve on `(update, *)` with `decision='approve_new'`*: would actually block the failure (banner is just a sign), but adds ~30 lines of PR 2 state + JSX that PR 3 must keep or refactor. Rejected because the reviewer team is 3 people internal-only and the gap window is hours-to-days, not weeks; banner is judged sufficient signal for that operating context. Reconsider this if the team grows or PRs ship slowly.
+- *Disable the approve_new radio in PR 2 for `(update, *)` rows*: most aggressive variant — reviewer must explicitly re-enable to override. Rejected as paternalistic for an internal tool with a small team that already has the banner.
 
 ### TEST DB rehearsal
 

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -141,14 +141,14 @@ Direct-link to either branch works (no forced redirect through intent picker). B
 
 ## 6. Section 3 — Reviewer flow
 
-### 6.1 Color-coded banner at top of decision panel
+### 6.1 Banner at top of decision panel
 
 Always visible:
-- (new) → **green**: "Submitter says: New lesson"
-- (update, X) → **blue**: "Submitter says: Updating **[X title]**" with link/preview
-- (update, null) → **yellow ⚠**: "Submitter says: Updating, but couldn't find target — please search to identify"
+- (new) → green wrapper: "Submitter says: New lesson"
+- (update, X) → blue wrapper: "Submitter says: Updating **[X title]**" with link/preview
+- (update, null) → yellow wrapper + ⚠ icon: "Submitter says: Updating, but couldn't find target — please search to identify"
 
-Color is load-bearing for muscle memory (peripheral vision catches state change).
+Color reinforces the text + icon (which carry the state semantics). Color alone is never the only signal — every state has explicit text and the yellow state pairs with `AlertTriangle`. Reviewers using high-contrast modes or with color-vision differences still see the state via copy and icon.
 
 ### 6.2 Pre-selection logic
 
@@ -157,6 +157,8 @@ Color is load-bearing for muscle memory (peripheral vision catches state change)
 | (new) | `approve_new` | none |
 | (update, X) | `approve_update` | X (auto-fetched if not in dup list) |
 | (update, null) | `approve_update` | none — reviewer must pick via search |
+
+**State preservation:** pre-selection only fires when there is no existing review row (`submission.review === undefined`). If the submission already has a review (e.g., reviewer flipped from `needs_revision` back to `submitted`, or is mid-edit and refreshed), the existing decision/target/notes are preserved exactly as stored. We never overwrite reviewer-in-progress work with submitter intent — the submitter intent banner still renders, but pre-selection is a no-op when prior reviewer state exists.
 
 ### 6.3 Fixed enable/disable logic (CRITICAL)
 
@@ -199,13 +201,13 @@ When the picked target's title differs significantly from the extracted submissi
 
 In `ReviewDashboard.tsx` queue cards (via `IntQueueRow.tsx`):
 
-| Badge | Color | Tooltip |
+| Badge | Color | Inline text shown next to badge |
 |---|---|---|
-| NEW | green | (none / extracted title) |
-| UPDATE | blue | Target lesson title |
-| UPDATE? | yellow | "Submitter is updating but couldn't find target — needs reviewer search" |
+| NEW | green | (none) |
+| UPDATE | blue | Target lesson title (visible, truncated to ~40 chars; full title in `title` attribute for accessibility) |
+| UPDATE? | yellow | "needs reviewer search" |
 
-Lets reviewers triage the queue (batch the easy ones, focus on the work-required ones).
+Target title is **visible inline next to the UPDATE badge**, not hidden in a tooltip — tooltips are unreliable on mobile/touch and slow for queue scanning. Truncation handles long titles without breaking row height. Lets reviewers triage the queue (batch the easy ones, focus on the work-required ones).
 
 ### 6.8 Override-tracking (deferred)
 
@@ -229,8 +231,21 @@ Three sequential PRs:
 | # | PR | Contains | Notes |
 |---|---|---|---|
 | 1 | **Schema** | Section 1's 2 items: FK alter + RPC guard | Defensive only. Forward-rollback migration ready before merge. Idempotent (`DROP CONSTRAINT IF EXISTS`, `CREATE OR REPLACE FUNCTION`). |
-| 2 | **Submitter flow + LessonSearchPicker** | Section 2: rewrite `SubmissionPage.tsx`, add `/submit/new` and `/submit/revising` routes, new `LessonSearchPicker` + `NewSubmissionForm` + `RevisingSubmissionForm`, `process-submission` pre-INSERT validation | Picker created here since Section 2 is its first consumer. Forward-compatible with old reviewer UI. |
-| 3 | **Reviewer flow** | Section 3: `ReviewDetail.tsx` rewrites, `ReviewDashboard.tsx` + `IntQueueRow.tsx` 3-state badge, reuse `LessonSearchPicker` | Lands once new submitters are producing binding-intent data. Old-shape submissions still display correctly. |
+| 2 | **Submitter flow + LessonSearchPicker + reviewer-side safety banner** | Section 2: rewrite `SubmissionPage.tsx`, add `/submit/new` and `/submit/revising` routes, new `LessonSearchPicker` + `NewSubmissionForm` + `RevisingSubmissionForm`, `process-submission` pre-INSERT validation. PLUS minimal reviewer safety banner (see "Gap risk between PR 2 and PR 3" below). | Picker created here since Section 2 is its first consumer. Safety banner closes the gap-window where new (update, X) and (update, null) submissions would reach the old reviewer UI before PR 3 ships. |
+| 3 | **Reviewer flow (full)** | Section 3: `ReviewDetail.tsx` full banner (replaces PR 2's minimal version), pre-selection, fixed enable/disable, unified card list, search escape hatch, mismatch helper, `ReviewDashboard.tsx` + `IntQueueRow.tsx` 3-state badge, reuse `LessonSearchPicker` | Enriches PR 2's safety banner into the full state-aware UX. Old-shape submissions still display correctly. |
+
+### Gap risk between PR 2 and PR 3 (and the safety banner)
+
+Once PR 2 ships, `/submit/revising` can produce `(update, X)` and `(update, null)` rows. The pre-PR-3 reviewer UI ignores `original_lesson_id` and the `submission_type` field, so during the deploy gap a reviewer could approve such a submission as new — recreating the exact orphan-producing failure mode this redesign is meant to prevent.
+
+**Mitigation: ship a minimal reviewer safety banner as part of PR 2.** When `submission_type === 'update'`, render a yellow banner above the decision panel that reads "Submitter says: Update of an existing lesson — verify before approving as new" with the raw `original_lesson_id` (or "could not find target" for `(update, null)`). It does NOT lookup the target title (that's PR 3's job) and does NOT change the radio/submit button behavior. ~12 lines of code.
+
+This is **progressive enhancement, not throwaway**: PR 3's full Section 6.1 banner replaces this minimal version with target-title lookup, color-coding by intent state, and pre-selection. The PR 2 banner is the gap-window safety net — strict superset of the danger sign needed during the gap, strict subset of what Section 3 ultimately ships.
+
+Alternatives considered and rejected:
+- *Ship PR 2 and PR 3 in tight sequence with reviewer activity paused*: relies on humans not making the mistake during a rushed window
+- *Feature-flag `/submit/revising` until PR 3 is deployed*: adds env-var ceremony and "we forgot to flip the flag" risk; submitter UI ships partially-functional during the gap
+- *Combine PR 2 and PR 3 into a single mega-PR*: sacrifices per-PR-ritual + rollback granularity for atomicity
 
 ### TEST DB rehearsal
 

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
@@ -93,7 +93,7 @@ Direct-link to either branch works (no forced redirect through intent picker). B
 
 - Debounced ~300ms text input
 - Direct `.from('lessons').select('lesson_id, title, grade_levels, season').ilike('title', '%${query}%').limit(10)` against existing `idx_lessons_title_trgm` GIN index. (Do not reuse `search_lessons` RPC — it has 14 params and uses `to_tsquery` which can throw on partial words.)
-- Empty state: placeholder "Search by lesson title or topic" + example "e.g., 'Three Sisters' or 'composting'"
+- Empty state: placeholder "Search by lesson title" + example "e.g., 'Three Sisters' or 'Apple Crisp'" (query is title-only via `.ilike('title', ...)`; do NOT advertise topic/keyword search in copy)
 - Mid-debounce: keep prior results visible with subtle spinner (don't blank out)
 - Zero results / "Don't see your lesson?": **"I'm updating but can't find it — let a reviewer help"** (binding intent, no target — closes the orphan regression hole)
 - Selected target: chip above input with × clear; sticky on mobile
@@ -158,7 +158,9 @@ Color reinforces the text + icon (which carry the state semantics). Color alone 
 | (update, X) | `approve_update` | X (auto-fetched if not in dup list) |
 | (update, null) | `approve_update` | none — reviewer must pick via search |
 
-**State preservation:** pre-selection only fires when there is no existing review row (`submission.review === undefined`). If the submission already has a review (e.g., reviewer flipped from `needs_revision` back to `submitted`, or is mid-edit and refreshed), the existing decision/target/notes are preserved exactly as stored. We never overwrite reviewer-in-progress work with submitter intent — the submitter intent banner still renders, but pre-selection is a no-op when prior reviewer state exists.
+**State preservation:** pre-selection only fires when there is no existing review row (the implementation guard is `reviews?.length === 0`). If a review exists, the **existing prior-review restoration logic at `ReviewDetail.tsx:302-325` already restores `decision`, `notes`, and `metadata`** — Phase 8b just adds the guard so its new pre-selection block does NOT clobber those restored values. The submitter intent banner still renders.
+
+Known pre-existing limitation (out of Phase 8b scope): the prior **merge target** (`selectedDuplicate`) is not restored from the prior review row. The Phase 4 RPC does not write `submission_reviews.canonical_lesson_id`, so deriving the previous target requires a JOIN through `lesson_versions.archived_from_submission_id` (for `approve_update`) or `lessons.original_submission_id` (for `approve_new`) — captured as a follow-up in Section 9. A reviewer who refreshes mid-edit on an `(update, X)` submission will see decision=`approve_update` restored but target=null (they re-pick from cards). This is not new in 8b; it's a current limitation of the review-restoration code that 8b does not regress.
 
 ### 6.3 Fixed enable/disable logic (CRITICAL)
 
@@ -238,7 +240,7 @@ Three sequential PRs:
 
 | # | PR | Contains | Notes |
 |---|---|---|---|
-| 1 | **Schema** | Section 1's 2 items: FK alter + RPC guard | Defensive only. Forward-rollback migration ready before merge. Idempotent (`DROP CONSTRAINT IF EXISTS`, `CREATE OR REPLACE FUNCTION`). |
+| 1 | **Schema** | Section 1's only NEW item: FK alter (`lesson_submissions.original_lesson_id` → `ON DELETE SET NULL`). The RPC status guard from Section 1 item 2 is **already shipped** in Phase 4 (`20260428000008_phase_4_status_guard.sql`); PR 1 only verifies it, does not modify it. | Defensive only. Forward-rollback migration ready before merge. Idempotent (`DROP CONSTRAINT IF EXISTS`). |
 | 2 | **Submitter flow + LessonSearchPicker + reviewer-side safety banner** | Section 2: rewrite `SubmissionPage.tsx`, add `/submit/new` and `/submit/revising` routes, new `LessonSearchPicker` + `NewSubmissionForm` + `RevisingSubmissionForm`, `process-submission` pre-INSERT validation. PLUS minimal reviewer safety banner (see "Gap risk between PR 2 and PR 3" below). | Picker created here since Section 2 is its first consumer. Safety banner closes the gap-window where new (update, X) and (update, null) submissions would reach the old reviewer UI before PR 3 ships. |
 | 3 | **Reviewer flow (full)** | Section 3: `ReviewDetail.tsx` full banner (replaces PR 2's minimal version), pre-selection, fixed enable/disable, unified card list, search escape hatch, mismatch helper, `ReviewDashboard.tsx` + `IntQueueRow.tsx` 3-state badge, reuse `LessonSearchPicker` | Enriches PR 2's safety banner into the full state-aware UX. Old-shape submissions still display correctly. |
 
@@ -257,12 +259,12 @@ Alternatives considered and rejected:
 
 ### TEST DB rehearsal
 
-- PR 1: CI applies migration to TEST. Verify with `mcp__supabase-test__execute_sql`: confirm FK definition shows `ON DELETE SET NULL`; confirm RPC source contains the status guard.
+- PR 1: CI applies the FK migration to TEST. Verify with `mcp__supabase-test__execute_sql`: `SELECT confdeltype FROM pg_constraint WHERE conname = 'lesson_submissions_original_lesson_id_fkey'` returns `n` (SET NULL). Optionally re-confirm the Phase-4 RPC guard is still in place — but do NOT modify it as part of PR 1.
 - PR 2/3: no schema, no rehearsal needed beyond Netlify deploy preview + manual smoke.
 
 ### Rollback paths
 
-- PR 1: forward-rollback migration that reverts FK to `NO ACTION` and removes the RPC status guard. Idempotent.
+- PR 1: forward-rollback migration that reverts ONLY the FK to `NO ACTION` (drop and re-add without `ON DELETE SET NULL`). Idempotent. **Do NOT touch the Phase-4 RPC status guard during rollback** — it predates Phase 8b and is load-bearing for unrelated double-submit safety.
 - PR 2/3: standard frontend git revert. No data side effects to reverse.
 
 ### Per-PR ritual

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
@@ -37,18 +37,19 @@
 
 ### Task 1.1: Create the FK alter migration
 
-**Sub-skill:** `database-migrations`
+**Sub-skill:** `database-migrations` (mandatory before touching anything in `supabase/migrations/`)
 
 **Files:**
-- Create: `supabase/migrations/20260428000009_phase_8b_fk_on_delete_set_null.sql`
+- Create: `supabase/migrations/20260504000000_phase_8b_fk_on_delete_set_null.sql`
 
-**Why this filename:** must sort AFTER `20260428000008_phase_4_status_guard.sql` and before `20260429000000_phase_5_b_new_publish.sql`. Using the next sequential same-day timestamp is correct here (the Phase 4 sub-migrations established `20260428000NNN` as the pattern for this date).
+**Why this filename:** must sort AFTER the latest existing migration. Run `ls supabase/migrations/ | sort | tail -3` to confirm the latest before naming. As of design time, the latest is `20260503000000_phase_6_2_fix_lost_applesauce_link.sql`, so `20260504000000_*` is the next safe slot. **Do not** insert a migration with a smaller numeric prefix than any existing migration — it would not run on TEST/PROD where the older-but-higher-numbered files are already applied (per `supabase/migrations/CLAUDE.md` and the user's auto-memory note about ASCII ordering of timestamp prefixes).
 
 **Step 1: Write the migration**
 
 ```sql
 -- =====================================================
--- Migration: 20260428000009_phase_8b_fk_on_delete_set_null.sql
+-- Migration: 20260504000000_phase_8b_fk_on_delete_set_null.sql
+-- (verify the date prefix beats the latest existing migration before creating!)
 -- =====================================================
 -- Description: Phase 8b Section 1 — re-create the FK on
 -- lesson_submissions.original_lesson_id with ON DELETE SET NULL.
@@ -111,7 +112,7 @@ Expected: all tests pass; no new failures.
 **Step 5: Commit**
 
 ```bash
-git add supabase/migrations/20260428000009_phase_8b_fk_on_delete_set_null.sql
+git add supabase/migrations/20260504000000_phase_8b_fk_on_delete_set_null.sql
 git commit -m "feat(db): Phase 8b — FK on lesson_submissions.original_lesson_id ON DELETE SET NULL
 
 Section 1 of the Phase 8b design. Re-creates the FK so deleting a
@@ -807,15 +808,17 @@ export function NewSubmissionForm() {
     setError(null);
     setIsSubmitting(true);
     try {
-      const { data, error: invokeError } = await supabase.functions.invoke('process-submission', {
+      const { data: response, error: invokeError } = await supabase.functions.invoke('process-submission', {
         body: { googleDocUrl, submissionType: 'new', originalLessonId: null },
       });
       if (invokeError) throw invokeError;
-      if (!data?.success) throw new Error(data?.error ?? 'Submission failed.');
+      if (!response?.success) throw new Error(response?.error ?? 'Submission failed.');
+      // process-submission returns { success, data: { submissionId, status, extractedTitle, ... } }
+      const payload = response.data;
       setSubmissionResult({
-        submissionId: data.submissionId,
-        extractedTitle: data.extractedTitle,
-        status: data.status,
+        submissionId: payload.submissionId,
+        extractedTitle: payload.extractedTitle,
+        status: payload.status,
       });
     } catch (err) {
       logger.debug('NewSubmissionForm submit failed:', err);
@@ -857,13 +860,16 @@ export function NewSubmissionForm() {
       <IntPageHeader title="Add a new lesson" />
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <IntFormField
-          label="Google Doc URL"
-          value={googleDocUrl}
-          onChange={setGoogleDocUrl}
-          placeholder="https://docs.google.com/document/d/..."
-          required
-        />
+        <IntFormField label="Google Doc URL" required>
+          <input
+            type="url"
+            value={googleDocUrl}
+            onChange={(e) => setGoogleDocUrl(e.target.value)}
+            placeholder="https://docs.google.com/document/d/..."
+            required
+            className="adm-input"
+          />
+        </IntFormField>
         {error && (
           <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800 flex items-start">
             <AlertCircle size={16} className="mr-2 mt-0.5 flex-shrink-0" />
@@ -952,7 +958,7 @@ export function RevisingSubmissionForm() {
     setError(null);
     setIsSubmitting(true);
     try {
-      const { data, error: invokeError } = await supabase.functions.invoke('process-submission', {
+      const { data: response, error: invokeError } = await supabase.functions.invoke('process-submission', {
         body: {
           googleDocUrl,
           submissionType: 'update',
@@ -960,11 +966,13 @@ export function RevisingSubmissionForm() {
         },
       });
       if (invokeError) throw invokeError;
-      if (!data?.success) throw new Error(data?.error ?? 'Submission failed.');
+      if (!response?.success) throw new Error(response?.error ?? 'Submission failed.');
+      // process-submission returns { success, data: { submissionId, status, extractedTitle, ... } }
+      const payload = response.data;
       setSubmissionResult({
-        submissionId: data.submissionId,
-        extractedTitle: data.extractedTitle,
-        status: data.status,
+        submissionId: payload.submissionId,
+        extractedTitle: payload.extractedTitle,
+        status: payload.status,
         targetTitle: selectedLesson?.title ?? null,
       });
     } catch (err) {
@@ -1040,16 +1048,17 @@ export function RevisingSubmissionForm() {
         </div>
 
         <div className={targetReady ? '' : 'opacity-50 pointer-events-none'}>
-          <label className="block text-sm font-medium text-gray-900 mb-2">
-            Step 2 · Paste your Google Doc link
-          </label>
-          <IntFormField
-            label=""
-            value={googleDocUrl}
-            onChange={setGoogleDocUrl}
-            placeholder="https://docs.google.com/document/d/..."
-            disabled={!targetReady}
-          />
+          <IntFormField label="Step 2 · Paste your Google Doc link" required>
+            <input
+              type="url"
+              className="adm-input"
+              value={googleDocUrl}
+              onChange={(e) => setGoogleDocUrl(e.target.value)}
+              placeholder="https://docs.google.com/document/d/..."
+              disabled={!targetReady}
+              required
+            />
+          </IntFormField>
         </div>
 
         {error && (
@@ -1123,14 +1132,23 @@ Expected: line ~173.
 Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMatch[1];`) and BEFORE line 173 (`// Step 1: Create submission record`):
 
 ```typescript
+      // Phase 8b: normalize originalLessonId — treat undefined/null/empty
+      // string/whitespace-only as NULL. Without this, an empty string
+      // would skip the truthy check below but then fail the FK at INSERT
+      // with a less-helpful error than a clean 400.
+      const normalizedOriginalLessonId =
+        typeof originalLessonId === 'string' && originalLessonId.trim().length > 0
+          ? originalLessonId.trim()
+          : null;
+
       // Phase 8b: validate originalLessonId BEFORE INSERT to avoid orphan
       // rows on the error path. The DB-level FK serves as the TOCTOU
       // backstop; this check provides fast user feedback.
-      if (submissionType === 'update' && originalLessonId) {
+      if (submissionType === 'update' && normalizedOriginalLessonId) {
         const { count: lessonCount, error: lessonCheckError } = await supabaseAdmin
           .from('lessons')
           .select('lesson_id', { count: 'exact', head: true })
-          .eq('lesson_id', originalLessonId);
+          .eq('lesson_id', normalizedOriginalLessonId);
         if (lessonCheckError) {
           throw lessonCheckError;
         }
@@ -1138,7 +1156,7 @@ Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMat
           return new Response(
             JSON.stringify({
               success: false,
-              error: `Original lesson not found: ${originalLessonId}`,
+              error: `Original lesson not found: ${normalizedOriginalLessonId}`,
             }),
             { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
@@ -1146,27 +1164,26 @@ Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMat
       }
 ```
 
-**Step 3: Local test**
+Then in the existing INSERT (line 174-185), replace `original_lesson_id: originalLessonId` with `original_lesson_id: normalizedOriginalLessonId` so the normalized value is what's persisted.
 
-Start the function locally:
+**Step 3: Local verification (via UI, not curl)**
+
+A direct curl against the locally-served function would fail because the non-`regenerateEmbedding` path calls `auth.getUser(token)` which requires a real user JWT, not a service-role token (verified at `process-submission/index.ts:106-127`). Test through the UI instead:
+
 ```bash
-supabase functions serve process-submission --no-verify-jwt
+# Terminal 1
+supabase start
+supabase db reset
+npm run dev
 ```
 
-Send a test request with an invalid `originalLessonId` from a separate terminal:
-```bash
-curl -X POST 'http://localhost:54321/functions/v1/process-submission' \
-  -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $(supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2 | tr -d '"')" \
-  -d '{"googleDocUrl":"https://docs.google.com/document/d/abc/edit","submissionType":"update","originalLessonId":"lesson_nonsense_uuid"}'
-```
-Expected: HTTP 400 with `{"success":false,"error":"Original lesson not found: lesson_nonsense_uuid"}`. Verify NO row was inserted:
-```bash
-psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c "
-  SELECT count(*) FROM lesson_submissions WHERE google_doc_url LIKE '%abc/edit%';
-"
-```
-Expected: `0`.
+Then in browser at `http://localhost:5173/submit/revising`:
+1. Sign in as `admin@test.com` / `password123` (per `reference_test_credentials.md`)
+2. In DevTools console, simulate the submit with a known-bad target by patching the request via the network tab (or briefly hardcode `originalLessonId='lesson_nonsense_uuid'` in `RevisingSubmissionForm.tsx` for the test, then revert)
+3. Expect a red error banner: "Original lesson not found: lesson_nonsense_uuid"
+4. Verify no row was inserted: `psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c "SELECT count(*) FROM lesson_submissions WHERE google_doc_url LIKE '%nonsense%';"` → `0`
+
+Optional: write a Vitest integration test against the edge function module — see existing tests in `supabase/functions/__tests__/` if any (run `find supabase/functions -name "*.test.*"` to confirm).
 
 **Step 4: Commit**
 
@@ -1179,6 +1196,63 @@ the target lesson exists BEFORE inserting the submission row. Returns
 400 on missing target without inserting; the existing FK constraint
 remains the TOCTOU backstop. Allows (update, null) — that's the
 'submitter said update but couldn't find target' state from PR 2."
+```
+
+### Task 2.7.5: Minimal reviewer safety banner (gap-window mitigation)
+
+**Why:** once PR 2 ships, `/submit/revising` can produce `(update, X)` and `(update, null)` rows. The pre-PR-3 reviewer UI ignores `submission_type` and `original_lesson_id`, so during the deploy gap a reviewer could approve such a submission as new — recreating the orphan-producing failure mode. This minimal banner is a danger sign that PR 3's full Section 6.1 banner enriches with target-title lookup, color coding, and pre-selection. **Strict superset of the gap-window safety net; strict subset of what Section 3 ships.** No throwaway code.
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx` (one small JSX block above the existing decision panel)
+
+**Step 1: Add the banner JSX**
+
+Find the decision panel area in `ReviewDetail.tsx` (around line 913-920 — the `<div className="adm-card">` that wraps the decision UI). Insert this block IMMEDIATELY ABOVE that wrapper:
+
+```tsx
+{/* Phase 8b PR 2 — minimal safety banner. Replaced + enriched by PR 3
+    full Section 6.1 banner (color-coded, target-title lookup,
+    pre-selection). Lives here in PR 2 to close the deploy-gap window
+    where /submit/revising produces (update, X) and (update, null) rows
+    before the reviewer UI knows how to consume them. */}
+{submission?.submission_type === 'update' && (
+  <div className="adm-card" style={{ borderColor: '#fbbf24', background: '#fffbeb', marginBottom: 12 }}>
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+      <AlertTriangle size={16} style={{ color: '#b45309', marginTop: 2, flexShrink: 0 }} />
+      <div>
+        <strong style={{ color: '#92400e' }}>Submitter says: Update of an existing lesson.</strong>{' '}
+        <span style={{ color: '#92400e' }}>
+          {submission.original_lesson_id
+            ? `Submitter linked to lesson ID ${submission.original_lesson_id}.`
+            : 'Submitter could not find the target lesson in the picker.'}
+        </span>{' '}
+        <span style={{ color: '#92400e' }}>
+          Please verify before approving — do not approve as new without checking.
+        </span>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+(Make sure `AlertTriangle` is imported from `lucide-react` at the top of the file if it's not already; check the existing imports.)
+
+**Step 2: Type-check + visual smoke**
+
+Run: `npm run type-check`
+Then start dev server and open a submission with `submission_type='update'` (manually edit a row in local DB if needed). Verify the yellow banner renders above the decision panel with the correct copy for both `(update, X)` and `(update, null)` cases.
+
+**Step 3: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): minimal safety banner for Phase 8b gap window
+
+Until PR 3 ships the full Section 6.1 banner with target-title lookup
+and pre-selection, this minimal yellow banner ensures reviewers can't
+silently approve (update, X) or (update, null) submissions as new
+during the PR 2 -> PR 3 deploy gap. Progressive enhancement, not
+throwaway: PR 3 enriches this banner rather than replacing it."
 ```
 
 ### Task 2.8: E2E tests for the three submitter paths
@@ -1263,8 +1337,9 @@ gh pr create --title "feat: Phase 8b — intent-first submitter flow + LessonSea
 - Adds `/submit/new` and `/submit/revising` routes
 - New `LessonSearchPicker` component (reused by PR 3 reviewer flow)
 - New `titlesAreSimilar` utility (consumed by PR 3)
-- `process-submission` edge function pre-INSERT validation of `originalLessonId`
+- `process-submission` edge function pre-INSERT validation of `originalLessonId` (with empty-string normalization)
 - Drops the post-submit duplicates panel (per design)
+- Minimal reviewer safety banner — gap-window mitigation; enriched by PR 3 into the full Section 6.1 banner
 
 ## Phase 8b context
 This is PR 2 of 3. PR 1 (the FK migration) is already merged. PR 3 (reviewer flow) lands after this. See `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md` for full context.
@@ -1317,35 +1392,55 @@ Use `mcp__supabase-test__execute_sql` to verify each of the three submission pat
 
 **Why:** if the submitter bound to lesson X but X doesn't appear in `submission_similarities`, the unified card list (Task 3.5) needs X's metadata to render the "Submitter's choice" card.
 
-**Step 1: Find the spot in `loadSubmission` where similarities-with-lessons are assembled**
+**Step 1: Re-read the actual `SimilarityWithLesson` type at `src/pages/ReviewDetail.tsx:33-44`**
+
+```typescript
+interface SimilarityWithLesson {
+  lesson_id: string;            // top-level — this is the lesson's ID
+  combined_score: number | null;
+  match_type: string | null;
+  title_similarity: number | null;
+  content_similarity: number | null;
+  lesson: {
+    title: string | null;       // nested only carries display fields
+    grade_levels: string[] | null;
+    thematic_categories: string[] | null;
+  };
+}
+```
+
+`lesson_id` is at the **top level** of each similarity row, not under `.lesson`. The nested `.lesson` only carries display fields.
+
+**Step 2: Find the spot in `loadSubmission` where similarities-with-lessons are assembled**
 
 Run: `grep -n "similaritiesWithLessons\|lessons_with_metadata" src/pages/ReviewDetail.tsx`
 Expected: a few lines around the join logic (likely 240-280).
 
-**Step 2: After the existing similarities-with-lessons assembly, add this block**
+**Step 3: After the existing similarities-with-lessons assembly, add this block**
 
 ```typescript
 // Phase 8b: if submitter bound to a lesson that's NOT in the dup list,
 // fetch it separately so the unified card list can render it as
-// "Submitter's choice."
+// "Submitter's choice." Note: SimilarityWithLesson has lesson_id at TOP
+// level, not nested under .lesson — see type definition above.
 const submitterTargetId = submissionData?.original_lesson_id ?? null;
 const targetInDupList = submitterTargetId
-  ? similaritiesWithLessons.some((s) => s.lesson?.lesson_id === submitterTargetId)
+  ? similaritiesWithLessons.some((s) => s.lesson_id === submitterTargetId)
   : false;
-let submitterTargetLesson: any = null;
+let submitterTargetLesson: { lesson_id: string; title: string; summary?: string; grade_levels?: string[] | null; thematic_categories?: string[] | null } | null = null;
 if (submitterTargetId && !targetInDupList) {
   const { data: targetData, error: targetErr } = await supabase
     .from('lessons_with_metadata')
     .select('lesson_id, title, summary, file_link, grade_levels, thematic_categories')
     .eq('lesson_id', submitterTargetId)
     .single();
-  if (!targetErr) {
+  if (!targetErr && targetData) {
     submitterTargetLesson = targetData;
   }
 }
 ```
 
-Then attach `submitterTargetLesson` to the `setSubmission(...)` payload (extend the type as needed).
+Then attach `submitterTargetLesson` to the `setSubmission(...)` payload (extend the `SubmissionDetail` interface to include `submitterTargetLesson?: typeof submitterTargetLesson` so consumers downstream can read it).
 
 **Step 3: Verify type-check passes**
 
@@ -1363,22 +1458,24 @@ the dup-detection list, fetch it from lessons_with_metadata so the
 upcoming unified card list can render it as 'Submitter's choice.'"
 ```
 
-### Task 3.2: Add color-coded binding-intent banner
+### Task 3.2: Replace the PR 2 minimal safety banner with the full color-coded version
 
 **Files:**
-- Modify: `src/pages/ReviewDetail.tsx` (top of decision panel — find the wrapper around the decision radio set, likely around line 920-940; add a new block ABOVE the existing decision UI)
+- Modify: `src/pages/ReviewDetail.tsx` (REPLACE the Task 2.7.5 minimal yellow banner with the richer three-state version)
 
-**Step 1: Add the banner component logic**
+**Step 1: Replace the existing minimal banner block with this full-state version**
 
-Inside the render function, near the top of the decision panel area, add:
+Find and delete the Task 2.7.5 banner block (the `submission?.submission_type === 'update' && (...)` JSX inside the inline-styled `.adm-card`). Replace it with:
 
 ```tsx
 {/* Phase 8b: binding-intent banner */}
 {(() => {
   const type = submission?.submission_type;
   const targetId = submission?.original_lesson_id;
-  const targetTitle = submitterTargetLesson?.title
-    || topDuplicates.find((d) => d.id === targetId)?.title
+  // SimilarityWithLesson has lesson_id at top level, lesson.title nested.
+  // submitterTargetLesson (off-list fetch) has title at top level.
+  const targetTitle = submission?.submitterTargetLesson?.title
+    || topDuplicates.find((d) => d.lesson_id === targetId)?.lesson?.title
     || null;
 
   if (type === 'update' && targetId && targetTitle) {
@@ -1420,10 +1517,13 @@ Then `npm run dev` and open a sample submission to confirm the banner renders. V
 
 ```bash
 git add src/pages/ReviewDetail.tsx
-git commit -m "feat(review): Phase 8b binding-intent banner with three colored states
+git commit -m "feat(review): Phase 8b full binding-intent banner (three colored states)
 
-Green (new), blue (update with target), yellow ⚠ (update without target).
-Color is load-bearing for muscle memory."
+Replaces PR 2's minimal safety banner with the richer three-state
+version: green (new), blue (update with target), yellow ⚠ (update
+without target). Color reinforces text + icon — every state is
+distinguishable without color (relevant for high-contrast modes and
+color-vision differences)."
 ```
 
 ### Task 3.3 + 3.4: Pre-selection logic + fixed enable/disable
@@ -1433,22 +1533,32 @@ Color is load-bearing for muscle memory."
 
 These are tightly coupled — do them in one step.
 
-**Step 1: Pre-select decision and target after `loadSubmission` resolves**
+**Step 1: Pre-select decision and target after `loadSubmission` resolves — but ONLY when no existing reviewer state exists**
 
 Inside `loadSubmission`, after `setSubmission(...)`, add:
 
 ```typescript
 // Phase 8b: pre-select decision + target based on submitter intent.
-// Both setState calls batch in React 19 so the radio renders enabled
-// on first paint when target is set.
-if (submissionData?.submission_type === 'update') {
-  setDecision('approve_update');
-  if (submissionData.original_lesson_id) {
-    setSelectedDuplicate(submissionData.original_lesson_id);
+// CRITICAL: only fire when there's no existing review row. Otherwise we'd
+// clobber a reviewer's in-progress decision (e.g., they flipped from
+// needs_revision back to submitted, or they refreshed mid-edit). The
+// banner still renders for these cases — only the auto-pre-select
+// fires conditionally.
+const hasExistingReview = !!submissionData?.review;
+if (!hasExistingReview) {
+  if (submissionData?.submission_type === 'update') {
+    setDecision('approve_update');
+    if (submissionData.original_lesson_id) {
+      setSelectedDuplicate(submissionData.original_lesson_id);
+    }
+  } else {
+    setDecision('approve_new');
   }
-} else {
-  setDecision('approve_new');
 }
+// If hasExistingReview is true, the existing setSubmission(...) call
+// already restored decision/notes/metadata from submissionData.review
+// (verify this in the existing loadSubmission flow; if not, ensure it
+// does — pre-existing behavior, not new in 8b).
 ```
 
 (Confirm `setDecision` is the existing setter; if not, name-match to whatever the file calls it.)
@@ -1513,45 +1623,97 @@ mode for the (update, null) state."
 
 **Step 1: Verify `IntDuplicateCard` supports `matchLabel`**
 
-Run: `grep -n "matchLabel" src/components/IntDuplicateCard.tsx`
-Expected: prop already exists per agent verification.
+Run: `grep -n "matchLabel\|export interface\|export type" src/components/IntDuplicateCard.tsx`
+Confirm the prop name (the prior agent review reported it exists; double-check the actual prop name — it might be `matchLabel`, `badge`, or similar).
 
-**Step 2: Build a unified `candidateMatches` array**
+**Step 2: Re-read the existing `topDuplicates.map` rendering at `src/pages/ReviewDetail.tsx:885-908`**
 
-Around the existing `topDuplicates` derivation (line ~412-415), add:
+The existing code already maps `SimilarityWithLesson` → `IntDuplicateCard`'s `dup` prop shape `{ id, title, meta, similarity, matchType }`. Phase 8b needs to extend this to:
+- accept an optional pre-built "submitter's choice" card that's not derived from a similarity row
+- hoist or prepend that card with a label
+
+**Step 3: Build a `candidateCards` array (a list of `dup`-prop-ready objects, NOT raw `SimilarityWithLesson` rows)**
+
+Place this `useMemo` near the existing `topDuplicates` declaration (around `src/pages/ReviewDetail.tsx:412`):
 
 ```typescript
-// Phase 8b: unified candidate-matches list — submitter's pick at top
-// (with "Submitter's choice" badge), then dup-detection results.
-const candidateMatches = useMemo(() => {
+// Phase 8b: unified card list for the decision panel.
+// Each entry is already in IntDuplicateCard `dup` prop shape (id, title,
+// meta, similarity, matchType, optional matchLabel for "Submitter's
+// choice" badge). NOT raw SimilarityWithLesson — that mapping happens here.
+const candidateCards = useMemo(() => {
   if (!submission) return [];
-  const dupList = topDuplicates ?? [];
-  const submitterTargetId = submission.original_lesson_id ?? null;
-  if (!submitterTargetId) return dupList;
 
-  // If submitter target is in the dup list, hoist it to the top and label.
-  const inListIdx = dupList.findIndex((d) => d.id === submitterTargetId);
-  if (inListIdx >= 0) {
-    const hoisted = { ...dupList[inListIdx], matchLabel: 'Submitter\'s choice' };
-    return [hoisted, ...dupList.filter((_, i) => i !== inListIdx)];
-  }
-  // Otherwise prepend the off-list submitter target as a synthetic card.
-  if (submitterTargetLesson) {
-    const synthetic = {
-      id: submitterTargetLesson.lesson_id,
-      title: submitterTargetLesson.title,
-      summary: submitterTargetLesson.summary ?? '',
-      similarityScore: 0,
-      matchType: 'submitter',
-      matchLabel: 'Submitter\'s choice',
+  const fromDups = topDuplicates.map((d) => {
+    const grades = d.lesson.grade_levels?.length
+      ? `Grades ${d.lesson.grade_levels.join(', ')}`
+      : 'Grades —';
+    return {
+      id: d.lesson_id,
+      title: d.lesson.title || 'Untitled',
+      meta: `${grades} · ${d.lesson_id}`,
+      similarity: d.combined_score ?? 0,
+      matchType: normalizeMatchType(d.match_type),
+      matchLabel: undefined as string | undefined,
     };
-    return [synthetic, ...dupList];
+  });
+
+  const submitterTargetId = submission.original_lesson_id ?? null;
+  if (!submitterTargetId) return fromDups;
+
+  // Case 1: target IS in the dup list — hoist + label.
+  const inListIdx = fromDups.findIndex((c) => c.id === submitterTargetId);
+  if (inListIdx >= 0) {
+    const hoisted = { ...fromDups[inListIdx], matchLabel: "Submitter's choice" };
+    return [hoisted, ...fromDups.filter((_, i) => i !== inListIdx)];
   }
-  return dupList;
-}, [submission, topDuplicates, submitterTargetLesson]);
+
+  // Case 2: target is OFF-list — prepend a synthetic card from the
+  // off-list lookup (loaded by Task 3.1 into submission.submitterTargetLesson).
+  const off = submission.submitterTargetLesson;
+  if (off) {
+    const grades = off.grade_levels?.length ? `Grades ${off.grade_levels.join(', ')}` : 'Grades —';
+    return [
+      {
+        id: off.lesson_id,
+        title: off.title || 'Untitled',
+        meta: `${grades} · ${off.lesson_id}`,
+        similarity: 0,
+        matchType: null,
+        matchLabel: "Submitter's choice",
+      },
+      ...fromDups,
+    ];
+  }
+
+  return fromDups;
+}, [submission, topDuplicates]);
 ```
 
-**Step 3: Replace the rendering of `topDuplicates` with `candidateMatches`** in the duplicate cards section (around line 876-911).
+**Step 4: Replace the existing `topDuplicates.map(...)` block at `src/pages/ReviewDetail.tsx:885-908` with a `candidateCards.map(...)` block**
+
+```tsx
+{candidateCards.map((c) => (
+  <IntDuplicateCard
+    key={c.id}
+    dup={{
+      id: c.id,
+      title: c.title,
+      meta: c.meta,
+      similarity: c.similarity,
+      matchType: c.matchType,
+      matchLabel: c.matchLabel,
+    }}
+    selected={selectedDuplicate === c.id}
+    onSelect={() => {
+      setSelectedDuplicate(selectedDuplicate === c.id ? null : c.id);
+      setSaveError(null);
+    }}
+  />
+))}
+```
+
+(If the actual `IntDuplicateCard` prop name for the badge isn't `matchLabel`, update accordingly per Step 1's verification.)
 
 **Step 4: Type-check + visual smoke**
 
@@ -1575,54 +1737,63 @@ selects."
 **Files:**
 - Modify: `src/pages/ReviewDetail.tsx`
 
-**Step 1: Add disclosure UI below the candidate-matches list**
+**Step 1: Add hook state at the TOP of the `ReviewDetail` component (with the other `useState` calls, NOT inside an IIFE — React rules of hooks)**
 
-Find the spot just below the cards (still within the decision panel). Add:
+```typescript
+// Phase 8b: search escape hatch toggle. Default-open when reviewer must
+// search (update with no target) or when there are no dup matches at all.
+const needsSearch =
+  submission?.submission_type === 'update' && !submission?.original_lesson_id;
+const noDups = candidateCards.length === 0;
+const [showSearch, setShowSearch] = useState<boolean>(false);
+useEffect(() => {
+  setShowSearch(needsSearch || noDups);
+}, [needsSearch, noDups]);
+```
+
+(Order these AFTER `submission` state and AFTER `candidateCards` `useMemo` so they read fresh values. Note: `candidateCards` from Task 3.5 is a derived `useMemo`, so it can be referenced in this `useEffect`'s deps.)
+
+**Step 2: Compute `helpText` as a derived value (not a hook)**
+
+Just below the hooks above:
+
+```typescript
+const searchHelpText = needsSearch
+  ? "Use this to find the lesson the submitter couldn't"
+  : submission?.original_lesson_id
+    ? "Use this if you disagree with the submitter's pick"
+    : "Use this when no card above is the right match";
+```
+
+**Step 3: Render the disclosure JSX**
+
+Place this in the decision-panel render below the candidate-matches list:
 
 ```tsx
 {/* Phase 8b: search escape hatch */}
-{(() => {
-  const needsSearch = submission?.submission_type === 'update' && !submission?.original_lesson_id;
-  const noDups = candidateMatches.length === 0;
-  const [showSearch, setShowSearch] = React.useState(needsSearch || noDups);
-  // When intent changes (rare), keep the toggle in sync
-  React.useEffect(() => {
-    setShowSearch(needsSearch || noDups);
-  }, [needsSearch, noDups]);
-
-  const helpText =
-    needsSearch
-      ? "Use this to find the lesson the submitter couldn't"
-      : submission?.original_lesson_id
-        ? "Use this if you disagree with the submitter's pick"
-        : "Use this when no card above is the right match";
-
-  return (
-    <div className="mt-3">
-      <button
-        type="button"
-        onClick={() => setShowSearch((v) => !v)}
-        className="text-sm text-blue-600 hover:text-blue-800 underline"
-      >
-        {showSearch ? '− Hide library search' : '+ Search the library for a different lesson'}
-      </button>
-      {showSearch && (
-        <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
-          <p className="text-xs text-gray-600 mb-2">{helpText}</p>
-          <LessonSearchPicker
-            selected={null}
-            onSelect={(l) => setSelectedDuplicate(l.lesson_id)}
-            onClear={() => {}}
-            cantFindOption={false}
-          />
-        </div>
-      )}
+<div className="mt-3">
+  <button
+    type="button"
+    onClick={() => setShowSearch((v) => !v)}
+    className="text-sm text-blue-600 hover:text-blue-800 underline"
+  >
+    {showSearch ? '− Hide library search' : '+ Search the library for a different lesson'}
+  </button>
+  {showSearch && (
+    <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
+      <p className="text-xs text-gray-600 mb-2">{searchHelpText}</p>
+      <LessonSearchPicker
+        selected={null}
+        onSelect={(l) => setSelectedDuplicate(l.lesson_id)}
+        onClear={() => {}}
+        cantFindOption={false}
+      />
     </div>
-  );
-})()}
+  )}
+</div>
 ```
 
-(Hoist the `useState` and `useEffect` to the component body if linting rejects them inside the IIFE; the IIFE is just for readability of the design spec.)
+No IIFE, no hooks-in-callback. JSX uses values computed by hooks at the top of the component.
 
 **Step 2: Add the import**
 
@@ -1668,7 +1839,7 @@ Below the candidate-matches list, before the search escape hatch:
 {(() => {
   if (!selectedDuplicate || manualPickRef.current) return null;
   const targetTitle =
-    candidateMatches.find((c) => c.id === selectedDuplicate)?.title ?? '';
+    candidateCards.find((c) => c.id === selectedDuplicate)?.title ?? '';
   const submissionTitle = submission?.extracted_title ?? '';
   if (!targetTitle || !submissionTitle) return null;
   if (titlesAreSimilar(targetTitle, submissionTitle)) return null;
@@ -1718,21 +1889,34 @@ Inside the row render, add badge logic (replacing or supplementing the existing 
     return <span className="px-2 py-0.5 text-xs bg-green-100 text-green-800 rounded">NEW</span>;
   }
   if (submission.originalLessonId) {
+    // Visible target title, truncated. Full title in title attr for a11y / hover.
+    const fullTitle = submission.originalLessonTitle ?? '';
+    const truncated =
+      fullTitle.length > 40 ? `${fullTitle.slice(0, 40).trim()}…` : fullTitle;
     return (
-      <span
-        className="px-2 py-0.5 text-xs bg-blue-100 text-blue-800 rounded"
-        title={submission.originalLessonTitle ?? ''}
-      >
-        UPDATE
+      <span className="inline-flex items-center gap-1 max-w-full">
+        <span className="px-2 py-0.5 text-xs bg-blue-100 text-blue-800 rounded shrink-0">
+          UPDATE
+        </span>
+        <span
+          className="text-xs text-gray-700 truncate"
+          title={fullTitle}
+          aria-label={`Updating lesson: ${fullTitle}`}
+        >
+          {truncated || '(target unknown)'}
+        </span>
       </span>
     );
   }
   return (
-    <span
-      className="px-2 py-0.5 text-xs bg-amber-100 text-amber-800 rounded"
-      title="Submitter is updating but couldn't find target — needs reviewer search"
-    >
-      UPDATE?
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="px-2 py-0.5 text-xs bg-amber-100 text-amber-800 rounded"
+        aria-label="Submitter is updating but couldn't find target — needs reviewer search"
+      >
+        UPDATE?
+      </span>
+      <span className="text-xs text-amber-700">needs reviewer search</span>
     </span>
   );
 })()}

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
@@ -1,0 +1,1942 @@
+# Phase 8b — `approve_update` Workflow Redesign — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Ship the intent-first lesson submission redesign over three sequential PRs (schema → submitter flow → reviewer flow), closing the orphan-producing failure mode in `approve_update` end-to-end.
+
+**Architecture:** The submitter declares intent up front via two-button picker (`/submit` → `/submit/new` or `/submit/revising`); the revising branch uses a search picker to bind a target lesson; the reviewer UI consumes binding intent with pre-selection, color-coded banner, and three-state queue badges. Schema work collapses to a single FK alter (the Phase 4 status guard at `20260428000008_phase_4_status_guard.sql` already covers item 2 of Section 1).
+
+**Tech Stack:** React 19 + TypeScript + Vite + Tailwind, Zustand, React Router v6, Supabase (Postgres + Edge Functions on Deno), Vitest + React Testing Library, Playwright for E2E.
+
+**Design reference:** `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md`. Read it before starting any task.
+
+**Sub-skills to invoke (per phase):**
+- `superpowers:test-driven-development` — every code-bearing task is test-first
+- `superpowers:verification-before-completion` — before claiming any task done, run the verification commands in that task's "Verify" step
+- `superpowers:requesting-code-review` — between phases (after PR 1, after PR 2)
+- `database-migrations` — before touching any file in `supabase/migrations/`
+
+**Per-PR ritual (mandatory, every PR):**
+1. Pre-push self-review: `git diff main...HEAD` and read every change
+2. Push → dispatch your own `feature-dev:code-reviewer` agent BEFORE bot reviews land
+3. Investigate every bot finding (don't auto-accept; per `feedback_bot_review_investigation.md`)
+4. Consolidated fix-up commits (don't amend pushed commits)
+5. **Round-cap after 2 rounds** of bot review — if there's a 3rd round, stop, document open issues, ship anyway
+
+**Beads is broken** (per `project_beads_broken.md`): use `TaskCreate`, NOT `bd`. Every PR also runs `npm run type-check && npm run lint` before push (per CLAUDE.md mandatory pre-PR checklist).
+
+---
+
+## PR 1 — Schema (single FK migration)
+
+**Branch:** `feat/phase-8b-fk-on-delete-set-null`
+
+**What ships:** one migration that re-creates the FK on `lesson_submissions.original_lesson_id` with `ON DELETE SET NULL`. (The Phase 4 status guard already covers Section 1's second item — verified at `supabase/migrations/20260428000008_phase_4_status_guard.sql:89-93`.)
+
+**Why this is its own PR:** schema-first per `feedback_data_safety_top_priority.md`. Defensive change with no UI dependency. Smallest possible blast radius (single ALTER TABLE).
+
+### Task 1.1: Create the FK alter migration
+
+**Sub-skill:** `database-migrations`
+
+**Files:**
+- Create: `supabase/migrations/20260428000009_phase_8b_fk_on_delete_set_null.sql`
+
+**Why this filename:** must sort AFTER `20260428000008_phase_4_status_guard.sql` and before `20260429000000_phase_5_b_new_publish.sql`. Using the next sequential same-day timestamp is correct here (the Phase 4 sub-migrations established `20260428000NNN` as the pattern for this date).
+
+**Step 1: Write the migration**
+
+```sql
+-- =====================================================
+-- Migration: 20260428000009_phase_8b_fk_on_delete_set_null.sql
+-- =====================================================
+-- Description: Phase 8b Section 1 — re-create the FK on
+-- lesson_submissions.original_lesson_id with ON DELETE SET NULL.
+--
+-- Rationale: Phase 8b makes the submitter's binding intent ("updating
+-- lesson X") a first-class signal. If a reviewer or admin later
+-- deletes lesson X, the submission row should survive with its intent
+-- neutralized (original_lesson_id = NULL) rather than cascade-deleting
+-- the submission. The original FK had no ON DELETE clause (defaults to
+-- NO ACTION), which would block the lesson delete — also wrong, since
+-- a delete shouldn't be vetoed by an old submission's reference.
+--
+-- Section 1 of the design doc had a second item (RPC status guard) but
+-- that already exists from Phase 4 (see 20260428000008_phase_4_status_guard.sql),
+-- which refuses re-entry on terminal statuses ('approved', 'rejected').
+-- This file is the only schema migration needed for Phase 8b.
+
+ALTER TABLE public.lesson_submissions
+  DROP CONSTRAINT IF EXISTS lesson_submissions_original_lesson_id_fkey;
+
+ALTER TABLE public.lesson_submissions
+  ADD CONSTRAINT lesson_submissions_original_lesson_id_fkey
+    FOREIGN KEY (original_lesson_id)
+    REFERENCES public.lessons(lesson_id)
+    ON DELETE SET NULL;
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- ALTER TABLE public.lesson_submissions
+--   DROP CONSTRAINT IF EXISTS lesson_submissions_original_lesson_id_fkey;
+-- ALTER TABLE public.lesson_submissions
+--   ADD CONSTRAINT lesson_submissions_original_lesson_id_fkey
+--     FOREIGN KEY (original_lesson_id)
+--     REFERENCES public.lessons(lesson_id);
+```
+
+**Step 2: Apply locally**
+
+Run: `supabase db reset`
+Expected: completes without errors; "Finished supabase db reset on branch main."
+
+**Step 3: Verify the FK clause locally**
+
+Run:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c "
+SELECT conname, confdeltype
+FROM pg_constraint
+WHERE conname = 'lesson_submissions_original_lesson_id_fkey';
+"
+```
+Expected: one row, `confdeltype = n` (where `n` = SET NULL; reference: `pg_constraint.confdeltype` codes are `a` no action, `r` restrict, `c` cascade, `n` set null, `d` set default).
+
+**Step 4: Run RLS tests (regression check)**
+
+Run: `npm run test:rls`
+Expected: all tests pass; no new failures.
+
+**Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260428000009_phase_8b_fk_on_delete_set_null.sql
+git commit -m "feat(db): Phase 8b — FK on lesson_submissions.original_lesson_id ON DELETE SET NULL
+
+Section 1 of the Phase 8b design. Re-creates the FK so deleting a
+lesson the submitter linked to neutralizes the submission's intent
+rather than cascade-deleting or vetoing the lesson delete. Section 1's
+second item (RPC status guard) already exists from Phase 4
+(20260428000008_phase_4_status_guard.sql), so this file is the only
+schema migration for Phase 8b."
+```
+
+### Task 1.2: Push, verify on TEST DB, merge
+
+**Step 1: Push**
+
+```bash
+git push -u origin feat/phase-8b-fk-on-delete-set-null
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(db): Phase 8b Section 1 — FK ON DELETE SET NULL" --body "$(cat <<'EOF'
+## Summary
+- Re-creates `lesson_submissions_original_lesson_id_fkey` with `ON DELETE SET NULL`
+- First of three Phase 8b PRs (schema → submitter flow → reviewer flow)
+- Section 1's second item (RPC status guard) is already in production from Phase 4 — no migration needed for it
+
+## Why this matters
+Phase 8b makes the submitter's binding intent ("updating lesson X") a first-class signal. The current FK (no ON DELETE clause) would let lesson deletes silently fail with a vague constraint error if any submission references the lesson. Setting NULL on delete keeps both the submission row intact and the delete operation succeeding.
+
+## Test plan
+- [ ] Local `supabase db reset` succeeds
+- [ ] `pg_constraint.confdeltype = 'n'` for the new FK locally
+- [ ] `npm run test:rls` passes
+- [ ] After CI applies migration to TEST DB, verify via `mcp__supabase-test__execute_sql` that the FK shows `ON DELETE SET NULL`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Wait for CI to apply migration to TEST DB**, then verify
+
+Run via `mcp__supabase-test__execute_sql`:
+```sql
+SELECT conname, confdeltype
+FROM pg_constraint
+WHERE conname = 'lesson_submissions_original_lesson_id_fkey';
+```
+Expected: one row, `confdeltype = n`.
+
+**Step 4: Per-PR ritual**
+
+Dispatch own `feature-dev:code-reviewer` agent on the PR before any bot review. Investigate every finding from any reviewer (claude-review, etc.) per `feedback_bot_review_investigation.md`. Round-cap after 2 rounds.
+
+**Step 5: Merge after approval; production migration runs after manual approval in `migrate-production.yml`.** Verify on PROD via `mcp__supabase-remote__execute_sql` (same query as Step 3) — per `feedback_data_safety_top_priority.md`, MCP verification is mandatory after every PROD migrate.
+
+---
+
+## PR 2 — Submitter flow + LessonSearchPicker
+
+**Branch:** `feat/phase-8b-intent-first-submitter-flow`
+
+**What ships:** rewrite of `SubmissionPage.tsx` as an intent picker; new routes `/submit/new` and `/submit/revising`; new `LessonSearchPicker`, `NewSubmissionForm`, `RevisingSubmissionForm` components; `process-submission` edge function pre-INSERT validation; new utility `titlesAreSimilar` (for Section 3 to consume but built here so PR 3 stays narrow).
+
+**Pre-flight: read these files first to internalize current shape:**
+- `src/pages/SubmissionPage.tsx` (entire — 413 lines)
+- `src/components/Auth/AuthModal.tsx` (existing modal pattern + `onSuccess` signature)
+- `src/components/Internal/IntButton.tsx`, `IntFormField.tsx`, `IntPageHeader.tsx` (the design system components used by submission UI)
+- `supabase/functions/process-submission/index.ts` (entire — verify line numbers haven't shifted from 173-187 INSERT region)
+- `src/App.tsx` lines 89-130 (where new routes go)
+
+### Task 2.1: TDD — `titlesAreSimilar` utility
+
+**Sub-skill:** `superpowers:test-driven-development`
+
+**Files:**
+- Create: `src/utils/titleSimilarity.ts`
+- Create: `src/utils/__tests__/titleSimilarity.test.ts`
+
+**Step 1: Write the failing tests**
+
+```typescript
+// src/utils/__tests__/titleSimilarity.test.ts
+import { describe, it, expect } from 'vitest';
+import { titlesAreSimilar } from '@/utils/titleSimilarity';
+
+describe('titlesAreSimilar', () => {
+  // Threshold is 0.3 (per design Section 6.6)
+  const SIMILAR = true;
+  const NOT_SIMILAR = false;
+
+  it.each([
+    ['Apple Crisp', 'Apple Crisp', SIMILAR],                              // identical
+    ['Apple Crisp', 'apple crisp', SIMILAR],                              // case
+    ['Apple Crisp', 'Apple-Crisp', SIMILAR],                              // punctuation
+    ['Apple Crisp Lesson', 'Apple Crisp', SIMILAR],                       // contains
+    ['Spring Planting', 'Spring Planting Updated for 2026', SIMILAR],     // legitimate revision
+    ['Three Sisters Garden', 'Planting the Three Sisters', SIMILAR],      // word reorder
+    ['Apple Crisp', 'Solar Eclipse', NOT_SIMILAR],                        // unrelated
+    ['Pumpkin Pie', 'Apple Crisp', NOT_SIMILAR],                          // unrelated 2
+    ['', '', NOT_SIMILAR],                                                // both empty
+    ['Apple Crisp', '', NOT_SIMILAR],                                     // one empty
+  ])('titlesAreSimilar(%s, %s) === %s', (a, b, expected) => {
+    expect(titlesAreSimilar(a, b)).toBe(expected);
+  });
+});
+```
+
+**Step 2: Run test, verify it fails**
+
+Run: `npx vitest run src/utils/__tests__/titleSimilarity.test.ts`
+Expected: FAIL — module not found `@/utils/titleSimilarity`.
+
+**Step 3: Implement minimal code to pass**
+
+```typescript
+// src/utils/titleSimilarity.ts
+/**
+ * Word-set Jaccard similarity for short titles.
+ * Used as a non-blocking UX hint on the reviewer side when an auto-picked
+ * merge target's title differs from the submission's extracted title.
+ *
+ * Threshold 0.3 — generous enough to match legitimate revisions
+ * ("Spring Planting" vs "Spring Planting Updated for 2026") while
+ * still flagging unrelated targets ("Apple Crisp" vs "Solar Eclipse").
+ *
+ * Empty strings always return false (no signal to compare).
+ */
+const SIMILARITY_THRESHOLD = 0.3;
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+}
+
+export function titlesAreSimilar(a: string, b: string): boolean {
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+  if (na.includes(nb) || nb.includes(na)) return true;
+
+  const wa = new Set(na.split(' '));
+  const wb = new Set(nb.split(' '));
+  const intersection = [...wa].filter((w) => wb.has(w)).length;
+  const union = new Set([...wa, ...wb]).size;
+  if (union === 0) return false;
+  return intersection / union >= SIMILARITY_THRESHOLD;
+}
+```
+
+**Step 4: Run tests, verify all pass**
+
+Run: `npx vitest run src/utils/__tests__/titleSimilarity.test.ts`
+Expected: 10/10 pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/titleSimilarity.ts src/utils/__tests__/titleSimilarity.test.ts
+git commit -m "feat(utils): add titlesAreSimilar (word-set Jaccard, 0.3 threshold)
+
+Used by Section 3 reviewer flow as a non-blocking UX hint when an
+auto-picked merge target's title differs from the submission's
+extracted title. In-browser, no DB call. Threshold tuned so legitimate
+revisions ('Spring Planting' vs 'Spring Planting Updated for 2026')
+don't trigger; unrelated targets do."
+```
+
+### Task 2.2: TDD — `LessonSearchPicker` component
+
+**Sub-skill:** `superpowers:test-driven-development`
+
+**Files:**
+- Create: `src/components/LessonSearchPicker.tsx`
+- Create: `src/components/__tests__/LessonSearchPicker.test.tsx`
+
+This is the meatiest component. It's used by both submitter (PR 2) and reviewer (PR 3).
+
+**Step 1: Write the failing tests**
+
+```typescript
+// src/components/__tests__/LessonSearchPicker.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LessonSearchPicker } from '@/components/LessonSearchPicker';
+
+// Mock supabase client. Returns Apple Crisp + Pumpkin Pie when query has chars.
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({
+        data: [
+          { lesson_id: 'lesson_1', title: 'Apple Crisp Lesson', grade_levels: ['3', '4'], season_timing: ['Fall'] },
+          { lesson_id: 'lesson_2', title: 'Pumpkin Pie Math', grade_levels: ['5'], season_timing: ['Fall'] },
+        ],
+        error: null,
+      }),
+    })),
+  },
+}));
+
+describe('LessonSearchPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders empty state with placeholder + example', () => {
+    render(<LessonSearchPicker selected={null} onSelect={vi.fn()} onClear={vi.fn()} />);
+    expect(screen.getByPlaceholderText(/search by lesson title/i)).toBeInTheDocument();
+    expect(screen.getByText(/three sisters/i)).toBeInTheDocument();
+  });
+
+  it('debounces input and queries lessons after typing', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<LessonSearchPicker selected={null} onSelect={onSelect} onClear={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'apple');
+    await waitFor(
+      () => expect(screen.getByText('Apple Crisp Lesson')).toBeInTheDocument(),
+      { timeout: 1000 }
+    );
+  });
+
+  it('calls onSelect when a result card is clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<LessonSearchPicker selected={null} onSelect={onSelect} onClear={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'apple');
+    await waitFor(() => screen.getByText('Apple Crisp Lesson'));
+    await user.click(screen.getByText('Apple Crisp Lesson'));
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ lesson_id: 'lesson_1', title: 'Apple Crisp Lesson' })
+    );
+  });
+
+  it('renders a chip with × clear when selected is non-null', async () => {
+    const user = userEvent.setup();
+    const onClear = vi.fn();
+    render(
+      <LessonSearchPicker
+        selected={{ lesson_id: 'lesson_1', title: 'Apple Crisp Lesson' }}
+        onSelect={vi.fn()}
+        onClear={onClear}
+      />
+    );
+
+    expect(screen.getByText(/apple crisp lesson/i)).toBeInTheDocument();
+    await user.click(screen.getByLabelText(/clear selected lesson/i));
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('renders can\'t-find option when cantFindOption=true and query has no results', async () => {
+    // Override mock to return empty
+    const { supabase } = await import('@/lib/supabase');
+    (supabase.from as any).mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }));
+
+    const user = userEvent.setup();
+    const onCantFind = vi.fn();
+    render(
+      <LessonSearchPicker
+        selected={null}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        cantFindOption
+        onCantFind={onCantFind}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'nonsense');
+    await waitFor(() => screen.getByText(/can't find it/i));
+    await user.click(screen.getByText(/can't find it/i));
+    expect(onCantFind).toHaveBeenCalled();
+  });
+
+  it('does not render can\'t-find option when cantFindOption=false', async () => {
+    const user = userEvent.setup();
+    render(
+      <LessonSearchPicker
+        selected={null}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        cantFindOption={false}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'nonsense');
+    await waitFor(() => {}, { timeout: 500 });
+    expect(screen.queryByText(/can't find it/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run tests, verify they fail**
+
+Run: `npx vitest run src/components/__tests__/LessonSearchPicker.test.tsx`
+Expected: FAIL — module not found.
+
+**Step 3: Implement the component**
+
+```typescript
+// src/components/LessonSearchPicker.tsx
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, X, Loader2 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { logger } from '@/utils/logger';
+
+export interface LessonSearchResult {
+  lesson_id: string;
+  title: string;
+  grade_levels?: string[] | null;
+  season_timing?: string[] | null;
+}
+
+interface Props {
+  selected: LessonSearchResult | null;
+  // eslint-disable-next-line no-unused-vars
+  onSelect: (lesson: LessonSearchResult) => void;
+  onClear: () => void;
+  cantFindOption?: boolean;
+  onCantFind?: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+const MAX_RESULTS = 10;
+
+export function LessonSearchPicker({
+  selected,
+  onSelect,
+  onClear,
+  cantFindOption = false,
+  onCantFind,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<LessonSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasQueried, setHasQueried] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runSearch = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults([]);
+      setHasQueried(false);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('lessons')
+        .select('lesson_id, title, grade_levels, season_timing')
+        .ilike('title', `%${q}%`)
+        .order('title', { ascending: true })
+        .limit(MAX_RESULTS);
+      if (error) throw error;
+      setResults(data ?? []);
+      setHasQueried(true);
+    } catch (err) {
+      logger.debug('LessonSearchPicker query failed:', err);
+      setResults([]);
+      setHasQueried(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selected) return; // No live search when something is bound
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      runSearch(query);
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, selected, runSearch]);
+
+  if (selected) {
+    return (
+      <div className="flex items-center justify-between p-3 bg-emerald-50 border border-emerald-200 rounded-lg sticky top-0 z-10">
+        <div>
+          <span className="text-xs uppercase tracking-wide text-emerald-700 mr-2">Selected:</span>
+          <span className="font-medium text-emerald-900">{selected.title}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear selected lesson"
+          className="text-emerald-700 hover:text-emerald-900 p-1"
+        >
+          <X size={18} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="relative">
+        <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search by lesson title or topic"
+          className="w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        {isLoading && (
+          <Loader2
+            size={18}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 animate-spin"
+          />
+        )}
+      </div>
+      <p className="mt-1 text-xs text-gray-500">e.g., 'Three Sisters' or 'composting'</p>
+
+      {results.length > 0 && (
+        <ul className="mt-2 border border-gray-200 rounded-lg divide-y divide-gray-100">
+          {results.map((r) => (
+            <li key={r.lesson_id}>
+              <button
+                type="button"
+                onClick={() => onSelect(r)}
+                className="w-full text-left px-3 py-2 hover:bg-gray-50 focus:bg-gray-100 focus:outline-none"
+              >
+                <div className="font-medium text-gray-900">{r.title}</div>
+                {(r.grade_levels?.length || r.season_timing?.length) && (
+                  <div className="text-xs text-gray-500 mt-0.5">
+                    {r.grade_levels?.length ? `Grades ${r.grade_levels.join(', ')}` : ''}
+                    {r.grade_levels?.length && r.season_timing?.length ? ' · ' : ''}
+                    {r.season_timing?.join(', ')}
+                  </div>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {hasQueried && results.length === 0 && !isLoading && (
+        <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700">
+          No matches found.
+          {cantFindOption && onCantFind && (
+            <button
+              type="button"
+              onClick={onCantFind}
+              className="ml-2 text-blue-600 hover:text-blue-800 underline"
+            >
+              I'm updating but can't find it — let a reviewer help
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 4: Run tests, verify all pass**
+
+Run: `npx vitest run src/components/__tests__/LessonSearchPicker.test.tsx`
+Expected: 6/6 pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/components/LessonSearchPicker.tsx src/components/__tests__/LessonSearchPicker.test.tsx
+git commit -m "feat(components): add reusable LessonSearchPicker
+
+Used by Phase 8b submitter (revising branch) and reviewer (search
+escape hatch) flows. Debounced (300ms) ilike against the existing
+trigram index on lessons.title. Optional 'can't find it' affordance
+for the submitter side."
+```
+
+### Task 2.3: Add new routes to `App.tsx`
+
+**Files:**
+- Modify: `src/App.tsx`
+
+**Step 1: Read current routes section**
+
+Run: `grep -n "<Route path" src/App.tsx`
+Confirm `/submit` is the only existing submission route.
+
+**Step 2: Edit `App.tsx` to add the two new routes**
+
+Find:
+```tsx
+<Route path="/submit" element={<SubmissionPage />} />
+```
+
+Replace with:
+```tsx
+<Route path="/submit" element={<SubmissionPage />} />
+<Route path="/submit/new" element={<NewSubmissionForm />} />
+<Route path="/submit/revising" element={<RevisingSubmissionForm />} />
+```
+
+Add the imports near the top of `App.tsx` alongside the existing `SubmissionPage` lazy import:
+```tsx
+const NewSubmissionForm = lazy(() => import('./pages/NewSubmissionForm').then(m => ({ default: m.NewSubmissionForm })));
+const RevisingSubmissionForm = lazy(() => import('./pages/RevisingSubmissionForm').then(m => ({ default: m.RevisingSubmissionForm })));
+```
+(Match the existing lazy-import pattern; check `App.tsx` lines 1-30 for the existing `SubmissionPage` lazy import shape.)
+
+**Step 3: Verify type-check passes (will warn about missing files until next tasks)**
+
+Run: `npm run type-check 2>&1 | head -20`
+Expected: errors reference missing `NewSubmissionForm` and `RevisingSubmissionForm` modules. That's fine — they'll be created in Tasks 2.5 and 2.6. Do not commit yet.
+
+(Alternatively: stage the route additions but defer commit until after Task 2.6 so we never have a broken commit.)
+
+### Task 2.4: Rewrite `SubmissionPage.tsx` as the intent picker
+
+**Files:**
+- Modify: `src/pages/SubmissionPage.tsx` (full rewrite — currently 413 lines, will become ~80 lines)
+
+**Step 1: Replace the entire file contents**
+
+```typescript
+// src/pages/SubmissionPage.tsx
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FilePlus, Edit3 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { AuthModal } from '@/components/Auth/AuthModal';
+import { IntPageHeader } from '@/components/Internal';
+import { User } from '@supabase/supabase-js';
+
+type Intent = 'new' | 'revising';
+
+export function SubmissionPage() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState<User | null>(null);
+  const [pendingIntent, setPendingIntent] = useState<Intent | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setUser(user));
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleIntent = (intent: Intent) => {
+    if (!user) {
+      setPendingIntent(intent);
+      setShowAuthModal(true);
+      return;
+    }
+    navigate(`/submit/${intent}`);
+  };
+
+  const handleAuthSuccess = () => {
+    setShowAuthModal(false);
+    if (pendingIntent) {
+      navigate(`/submit/${pendingIntent}`);
+      setPendingIntent(null);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <IntPageHeader title="Submit a lesson" />
+      <p className="text-gray-600 mb-8">
+        Submit a Google Doc lesson plan for the ESYNYC library. A reviewer will check it and either
+        publish it or get back to you.
+      </p>
+
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">What are you submitting?</h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <button
+          type="button"
+          onClick={() => handleIntent('new')}
+          className="text-left p-6 border-2 border-gray-200 rounded-xl hover:border-blue-500 hover:bg-blue-50 focus:border-blue-500 focus:outline-none transition"
+        >
+          <FilePlus size={28} className="text-blue-600 mb-3" />
+          <div className="font-semibold text-lg text-gray-900 mb-1">
+            Add a new lesson to the library
+          </div>
+          <div className="text-sm text-gray-600">
+            Use this if no version of this lesson has been added yet.
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => handleIntent('revising')}
+          className="text-left p-6 border-2 border-gray-200 rounded-xl hover:border-emerald-500 hover:bg-emerald-50 focus:border-emerald-500 focus:outline-none transition"
+        >
+          <Edit3 size={28} className="text-emerald-600 mb-3" />
+          <div className="font-semibold text-lg text-gray-900 mb-1">
+            Update a lesson that's already in the library
+          </div>
+          <div className="text-sm text-gray-600">
+            Use this if a version of your lesson is already published.
+          </div>
+        </button>
+      </div>
+
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => {
+          setShowAuthModal(false);
+          setPendingIntent(null);
+        }}
+        onSuccess={handleAuthSuccess}
+      />
+    </div>
+  );
+}
+```
+
+**Step 2: Type-check**
+
+Run: `npm run type-check 2>&1 | head -20`
+Expected: still references missing `NewSubmissionForm` / `RevisingSubmissionForm` from `App.tsx`. The `SubmissionPage` itself should type-check.
+
+**Step 3: Defer commit until Task 2.6 (so we never have a broken commit on the branch).**
+
+### Task 2.5: Create `NewSubmissionForm`
+
+**Files:**
+- Create: `src/pages/NewSubmissionForm.tsx`
+
+**Step 1: Implement**
+
+This page handles the "brand new lesson" flow. Most of the heavy lifting (validation, edge function call, success/error rendering) is preserved from the original `SubmissionPage.tsx` lines 60-300 — but with `submissionType` hardcoded to `'new'` and `originalLessonId` hardcoded to `null`. The post-submit duplicates panel (originally lines 286-350) is dropped.
+
+```typescript
+// src/pages/NewSubmissionForm.tsx
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ChevronLeft, AlertCircle, CheckCircle2, Loader2, FileText } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { parseDbError } from '@/utils/errorHandling';
+import { AuthModal } from '@/components/Auth/AuthModal';
+import { IntButton, IntFormField, IntPageHeader, IntStatusBadge, type IntStatus } from '@/components/Internal';
+import { User } from '@supabase/supabase-js';
+import { logger } from '@/utils/logger';
+
+const SUBMISSION_STATUS_TO_BADGE: Record<string, IntStatus> = {
+  submitted: 'submitted',
+  in_review: 'review',
+  needs_revision: 'revision',
+  approved: 'approved',
+};
+
+export function NewSubmissionForm() {
+  const navigate = useNavigate();
+  const [googleDocUrl, setGoogleDocUrl] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submissionResult, setSubmissionResult] = useState<{
+    submissionId: string;
+    extractedTitle: string;
+    status: string;
+  } | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setUser(user));
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, s) => setUser(s?.user ?? null));
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) {
+      setShowAuthModal(true);
+      return;
+    }
+    if (!/\/document\/d\/([a-zA-Z0-9-_]+)/.test(googleDocUrl)) {
+      setError('Please paste a valid Google Doc URL.');
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const { data, error: invokeError } = await supabase.functions.invoke('process-submission', {
+        body: { googleDocUrl, submissionType: 'new', originalLessonId: null },
+      });
+      if (invokeError) throw invokeError;
+      if (!data?.success) throw new Error(data?.error ?? 'Submission failed.');
+      setSubmissionResult({
+        submissionId: data.submissionId,
+        extractedTitle: data.extractedTitle,
+        status: data.status,
+      });
+    } catch (err) {
+      logger.debug('NewSubmissionForm submit failed:', err);
+      setError(parseDbError(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (submissionResult) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="p-6 bg-green-50 border border-green-200 rounded-xl">
+          <CheckCircle2 className="text-green-600 mb-2" size={32} />
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Submitted!</h2>
+          <div className="text-gray-700 mb-4">
+            <FileText size={16} className="inline mr-1" />
+            <strong>{submissionResult.extractedTitle}</strong>
+          </div>
+          <IntStatusBadge status={SUBMISSION_STATUS_TO_BADGE[submissionResult.status] ?? 'submitted'} />
+          <p className="mt-4 text-sm text-gray-700">
+            We'll publish this once a reviewer approves.
+          </p>
+          <div className="mt-4 text-xs text-gray-500">Submission ID: {submissionResult.submissionId}</div>
+          <IntButton variant="primary" onClick={() => navigate('/')} className="mt-6">
+            Back to library
+          </IntButton>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <Link to="/submit" className="text-sm text-gray-600 hover:text-gray-900 inline-flex items-center mb-4">
+        <ChevronLeft size={14} className="mr-1" />
+        Adding a new lesson · Change
+      </Link>
+      <IntPageHeader title="Add a new lesson" />
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <IntFormField
+          label="Google Doc URL"
+          value={googleDocUrl}
+          onChange={setGoogleDocUrl}
+          placeholder="https://docs.google.com/document/d/..."
+          required
+        />
+        {error && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800 flex items-start">
+            <AlertCircle size={16} className="mr-2 mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+        <IntButton type="submit" variant="primary" disabled={isSubmitting || !googleDocUrl}>
+          {isSubmitting ? (<><Loader2 size={16} className="animate-spin mr-2 inline" />Submitting…</>) : 'Submit'}
+        </IntButton>
+      </form>
+
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        onSuccess={() => setShowAuthModal(false)}
+      />
+    </div>
+  );
+}
+```
+
+**Step 2: Type-check** — should now reference only `RevisingSubmissionForm` as missing.
+
+### Task 2.6: Create `RevisingSubmissionForm`
+
+**Files:**
+- Create: `src/pages/RevisingSubmissionForm.tsx`
+
+**Step 1: Implement**
+
+```typescript
+// src/pages/RevisingSubmissionForm.tsx
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ChevronLeft, AlertCircle, CheckCircle2, Loader2, FileText } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import { parseDbError } from '@/utils/errorHandling';
+import { AuthModal } from '@/components/Auth/AuthModal';
+import { IntButton, IntFormField, IntPageHeader, IntStatusBadge, type IntStatus } from '@/components/Internal';
+import { LessonSearchPicker, LessonSearchResult } from '@/components/LessonSearchPicker';
+import { User } from '@supabase/supabase-js';
+import { logger } from '@/utils/logger';
+
+const SUBMISSION_STATUS_TO_BADGE: Record<string, IntStatus> = {
+  submitted: 'submitted',
+  in_review: 'review',
+  needs_revision: 'revision',
+  approved: 'approved',
+};
+
+export function RevisingSubmissionForm() {
+  const navigate = useNavigate();
+  const [selectedLesson, setSelectedLesson] = useState<LessonSearchResult | null>(null);
+  const [cantFind, setCantFind] = useState(false);
+  const [googleDocUrl, setGoogleDocUrl] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submissionResult, setSubmissionResult] = useState<{
+    submissionId: string;
+    extractedTitle: string;
+    status: string;
+    targetTitle: string | null;
+  } | null>(null);
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setUser(user));
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, s) => setUser(s?.user ?? null));
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const targetReady = selectedLesson || cantFind;
+  const canSubmit = targetReady && /\/document\/d\/([a-zA-Z0-9-_]+)/.test(googleDocUrl) && !isSubmitting;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) {
+      setShowAuthModal(true);
+      return;
+    }
+    if (!targetReady) {
+      setError('Pick a lesson or use the "can\'t find it" option first.');
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const { data, error: invokeError } = await supabase.functions.invoke('process-submission', {
+        body: {
+          googleDocUrl,
+          submissionType: 'update',
+          originalLessonId: selectedLesson?.lesson_id ?? null,
+        },
+      });
+      if (invokeError) throw invokeError;
+      if (!data?.success) throw new Error(data?.error ?? 'Submission failed.');
+      setSubmissionResult({
+        submissionId: data.submissionId,
+        extractedTitle: data.extractedTitle,
+        status: data.status,
+        targetTitle: selectedLesson?.title ?? null,
+      });
+    } catch (err) {
+      logger.debug('RevisingSubmissionForm submit failed:', err);
+      setError(parseDbError(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (submissionResult) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <div className="p-6 bg-green-50 border border-green-200 rounded-xl">
+          <CheckCircle2 className="text-green-600 mb-2" size={32} />
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Submitted!</h2>
+          <div className="text-gray-700 mb-4">
+            <FileText size={16} className="inline mr-1" />
+            <strong>{submissionResult.extractedTitle}</strong>
+          </div>
+          <IntStatusBadge status={SUBMISSION_STATUS_TO_BADGE[submissionResult.status] ?? 'submitted'} />
+          <p className="mt-4 text-sm text-gray-700">
+            {submissionResult.targetTitle ? (
+              <>We'll merge this into <strong>"{submissionResult.targetTitle}"</strong> once a reviewer approves.</>
+            ) : (
+              <>A reviewer will identify which lesson this updates and either merge or publish as new.</>
+            )}
+          </p>
+          <div className="mt-4 text-xs text-gray-500">Submission ID: {submissionResult.submissionId}</div>
+          <IntButton variant="primary" onClick={() => navigate('/')} className="mt-6">
+            Back to library
+          </IntButton>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <Link to="/submit" className="text-sm text-gray-600 hover:text-gray-900 inline-flex items-center mb-4">
+        <ChevronLeft size={14} className="mr-1" />
+        Updating a lesson · Change
+      </Link>
+      <IntPageHeader title="Update an existing lesson" />
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-900 mb-2">
+            Step 1 · Find the lesson you're revising
+          </label>
+          {cantFind && !selectedLesson ? (
+            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center justify-between">
+              <span className="text-sm text-amber-900">
+                A reviewer will identify which lesson this updates.
+              </span>
+              <button
+                type="button"
+                onClick={() => setCantFind(false)}
+                className="text-sm text-amber-800 underline hover:text-amber-900"
+              >
+                Try search again
+              </button>
+            </div>
+          ) : (
+            <LessonSearchPicker
+              selected={selectedLesson}
+              onSelect={(l) => { setSelectedLesson(l); setCantFind(false); }}
+              onClear={() => setSelectedLesson(null)}
+              cantFindOption
+              onCantFind={() => setCantFind(true)}
+            />
+          )}
+        </div>
+
+        <div className={targetReady ? '' : 'opacity-50 pointer-events-none'}>
+          <label className="block text-sm font-medium text-gray-900 mb-2">
+            Step 2 · Paste your Google Doc link
+          </label>
+          <IntFormField
+            label=""
+            value={googleDocUrl}
+            onChange={setGoogleDocUrl}
+            placeholder="https://docs.google.com/document/d/..."
+            disabled={!targetReady}
+          />
+        </div>
+
+        {error && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800 flex items-start">
+            <AlertCircle size={16} className="mr-2 mt-0.5 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <IntButton type="submit" variant="primary" disabled={!canSubmit}>
+          {isSubmitting ? (
+            <><Loader2 size={16} className="animate-spin mr-2 inline" />Submitting…</>
+          ) : selectedLesson ? (
+            <>Submit as a revision of {selectedLesson.title}</>
+          ) : (
+            <>Submit for reviewer to match</>
+          )}
+        </IntButton>
+        <p className="text-xs text-gray-500">
+          {selectedLesson
+            ? 'A reviewer will replace the published lesson with this content.'
+            : 'A reviewer will identify which lesson this updates.'}
+        </p>
+      </form>
+
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        onSuccess={() => setShowAuthModal(false)}
+      />
+    </div>
+  );
+}
+```
+
+**Step 2: Type-check + lint**
+
+Run: `npm run type-check && npm run lint`
+Expected: passes.
+
+**Step 3: Commit (consolidates Tasks 2.3, 2.4, 2.5, 2.6 — first compilable state on this branch)**
+
+```bash
+git add src/App.tsx src/pages/SubmissionPage.tsx src/pages/NewSubmissionForm.tsx src/pages/RevisingSubmissionForm.tsx
+git commit -m "feat(submit): Phase 8b intent-first submitter flow
+
+Rewrites SubmissionPage as a two-button intent picker. Adds
+/submit/new (URL-paste only) and /submit/revising (search picker +
+URL paste) routes. The revising form supports a 'can't find it'
+escape that submits with original_lesson_id=null and binding intent
+'update' — the reviewer-side flow (PR 3) interprets this as
+'submitter is updating but couldn't find target.' Drops the post-submit
+duplicates panel; success copy now mentions the bound target lesson
+title (or the can't-find fallback message)."
+```
+
+### Task 2.7: Add pre-INSERT validation to `process-submission`
+
+**Sub-skill:** `superpowers:test-driven-development` (integration test)
+
+**Files:**
+- Modify: `supabase/functions/process-submission/index.ts` (insert before line 174)
+
+**Step 1: Read the current INSERT region** (line 173-187 confirmed earlier; verify line numbers haven't drifted)
+
+Run: `grep -n "Step 1: Create submission record" supabase/functions/process-submission/index.ts`
+Expected: line ~173.
+
+**Step 2: Insert the pre-INSERT validation block before line 174**
+
+Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMatch[1];`) and BEFORE line 173 (`// Step 1: Create submission record`):
+
+```typescript
+      // Phase 8b: validate originalLessonId BEFORE INSERT to avoid orphan
+      // rows on the error path. The DB-level FK serves as the TOCTOU
+      // backstop; this check provides fast user feedback.
+      if (submissionType === 'update' && originalLessonId) {
+        const { count: lessonCount, error: lessonCheckError } = await supabaseAdmin
+          .from('lessons')
+          .select('lesson_id', { count: 'exact', head: true })
+          .eq('lesson_id', originalLessonId);
+        if (lessonCheckError) {
+          throw lessonCheckError;
+        }
+        if ((lessonCount ?? 0) === 0) {
+          return new Response(
+            JSON.stringify({
+              success: false,
+              error: `Original lesson not found: ${originalLessonId}`,
+            }),
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          );
+        }
+      }
+```
+
+**Step 3: Local test**
+
+Start the function locally:
+```bash
+supabase functions serve process-submission --no-verify-jwt
+```
+
+Send a test request with an invalid `originalLessonId` from a separate terminal:
+```bash
+curl -X POST 'http://localhost:54321/functions/v1/process-submission' \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $(supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2 | tr -d '"')" \
+  -d '{"googleDocUrl":"https://docs.google.com/document/d/abc/edit","submissionType":"update","originalLessonId":"lesson_nonsense_uuid"}'
+```
+Expected: HTTP 400 with `{"success":false,"error":"Original lesson not found: lesson_nonsense_uuid"}`. Verify NO row was inserted:
+```bash
+psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c "
+  SELECT count(*) FROM lesson_submissions WHERE google_doc_url LIKE '%abc/edit%';
+"
+```
+Expected: `0`.
+
+**Step 4: Commit**
+
+```bash
+git add supabase/functions/process-submission/index.ts
+git commit -m "feat(edge-fn): Phase 8b — pre-INSERT validation of originalLessonId
+
+When submissionType='update' and originalLessonId is non-null, verify
+the target lesson exists BEFORE inserting the submission row. Returns
+400 on missing target without inserting; the existing FK constraint
+remains the TOCTOU backstop. Allows (update, null) — that's the
+'submitter said update but couldn't find target' state from PR 2."
+```
+
+### Task 2.8: E2E tests for the three submitter paths
+
+**Files:**
+- Modify or create: `e2e/submission-flow.spec.ts`
+
+**Step 1: Read the existing E2E setup**
+
+Run: `cat e2e/smoke.spec.ts && ls e2e/`
+Confirm Playwright config + how the existing test bootstraps a session.
+
+**Step 2: Implement the new spec**
+
+```typescript
+// e2e/submission-flow.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Phase 8b — submission flow (intent-first)', () => {
+  test('intent picker renders and routes to /submit/new on click', async ({ page }) => {
+    await page.goto('/submit');
+    await expect(page.getByRole('heading', { name: /Submit a lesson/i })).toBeVisible();
+    await expect(page.getByText(/Add a new lesson to the library/i)).toBeVisible();
+    await expect(page.getByText(/Update a lesson that's already in the library/i)).toBeVisible();
+  });
+
+  test('Add new branch shows URL paste form and a back-to-intent link', async ({ page }) => {
+    await page.goto('/submit/new');
+    await expect(page.getByText(/Add a new lesson/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/docs\.google\.com\/document/i)).toBeVisible();
+    await expect(page.getByText(/Adding a new lesson · Change/i)).toBeVisible();
+  });
+
+  test('Update branch shows search picker; URL field disabled until target picked or can\'t-find', async ({ page }) => {
+    await page.goto('/submit/revising');
+    await expect(page.getByText(/Find the lesson you're revising/i)).toBeVisible();
+    const urlInput = page.getByPlaceholder(/docs\.google\.com\/document/i);
+    await expect(urlInput).toBeDisabled();
+  });
+
+  // The login/submit happy paths require seeded credentials and TEST DB —
+  // run those in a dedicated authenticated suite separately. The structural
+  // tests above cover the route + initial state regression risk.
+});
+```
+
+**Step 3: Run E2E**
+
+Run: `npm run test:e2e -- submission-flow`
+Expected: 3/3 pass.
+
+**Step 4: Commit**
+
+```bash
+git add e2e/submission-flow.spec.ts
+git commit -m "test(e2e): Phase 8b submission flow structural smoke
+
+Covers: /submit renders intent picker; /submit/new shows URL form +
+breadcrumb; /submit/revising disables URL field until target picked.
+Authenticated happy-path flows deferred to a credentialed suite."
+```
+
+### Task 2.9: Push, dispatch own reviewer agent, investigate bot findings
+
+**Step 1: Mandatory pre-PR check**
+
+Run: `npm run type-check && npm run lint`
+Expected: both pass with no errors.
+
+**Step 2: Push**
+
+```bash
+git push -u origin feat/phase-8b-intent-first-submitter-flow
+```
+
+**Step 3: Open PR**
+
+```bash
+gh pr create --title "feat: Phase 8b — intent-first submitter flow + LessonSearchPicker" --body "$(cat <<'EOF'
+## Summary
+- Rewrites `SubmissionPage` as a two-button intent picker (Add new / Update existing)
+- Adds `/submit/new` and `/submit/revising` routes
+- New `LessonSearchPicker` component (reused by PR 3 reviewer flow)
+- New `titlesAreSimilar` utility (consumed by PR 3)
+- `process-submission` edge function pre-INSERT validation of `originalLessonId`
+- Drops the post-submit duplicates panel (per design)
+
+## Phase 8b context
+This is PR 2 of 3. PR 1 (the FK migration) is already merged. PR 3 (reviewer flow) lands after this. See `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md` for full context.
+
+## Test plan
+- [ ] Unit: `npx vitest run src/utils/__tests__/titleSimilarity.test.ts` (10/10 pass)
+- [ ] Unit: `npx vitest run src/components/__tests__/LessonSearchPicker.test.tsx` (6/6 pass)
+- [ ] E2E: `npm run test:e2e -- submission-flow` (3/3 pass)
+- [ ] Type: `npm run type-check` clean
+- [ ] Lint: `npm run lint` clean
+- [ ] Manual smoke on TEST DB after Netlify preview is up: submit via `/submit/new`, verify row in TEST DB has `submission_type='new'` and `original_lesson_id=NULL`
+- [ ] Manual smoke: submit via `/submit/revising` with target picked, verify row has `original_lesson_id` set
+- [ ] Manual smoke: submit via `/submit/revising` with "can't find it", verify row has `submission_type='update'` and `original_lesson_id=NULL`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 4: Dispatch own `feature-dev:code-reviewer` agent on the PR before bot reviews**
+
+Per `feedback_pr_bot_review_workflow.md`. Investigate every bot finding per `feedback_bot_review_investigation.md`. Round-cap after 2 rounds.
+
+**Step 5: Manual TEST DB smoke after Netlify preview is up**
+
+Use `mcp__supabase-test__execute_sql` to verify each of the three submission paths produces a correctly-shaped row. Required before merge per `feedback_data_safety_top_priority.md`.
+
+**Step 6: Merge**
+
+---
+
+## PR 3 — Reviewer flow
+
+**Branch:** `feat/phase-8b-reviewer-flow`
+
+**What ships:** `ReviewDetail.tsx` updates (binding-intent banner, pre-selection, fixed enable/disable, unified card list, search escape hatch, mismatch helper, off-list submitter target fetch); `ReviewDashboard.tsx` + `IntQueueRow.tsx` three-state queue badges.
+
+**Pre-flight: read these files first to internalize shape:**
+- `src/pages/ReviewDetail.tsx` (entire — 1016 lines; focus on `selectedDuplicate` state at line 122, `loadSubmission` near line 200-300, decision-bar at line 990-1010, duplicate cards at line 876-911, approve_update radio at line 938)
+- `src/pages/ReviewDashboard.tsx` (line 109 query; line 165 status cast; lines 257-266 `IntQueueRow` instantiation)
+- `src/components/IntQueueRow.tsx` (current props shape)
+- `src/components/IntDuplicateCard.tsx` (matchLabel prop; this is what powers the "Submitter's choice" badge)
+- `src/components/LessonSearchPicker.tsx` (created in PR 2)
+- `src/utils/titleSimilarity.ts` (created in PR 2)
+
+### Task 3.1: Extend `loadSubmission` to fetch off-list submitter target
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx` (in the `loadSubmission` function around line 200-300)
+
+**Why:** if the submitter bound to lesson X but X doesn't appear in `submission_similarities`, the unified card list (Task 3.5) needs X's metadata to render the "Submitter's choice" card.
+
+**Step 1: Find the spot in `loadSubmission` where similarities-with-lessons are assembled**
+
+Run: `grep -n "similaritiesWithLessons\|lessons_with_metadata" src/pages/ReviewDetail.tsx`
+Expected: a few lines around the join logic (likely 240-280).
+
+**Step 2: After the existing similarities-with-lessons assembly, add this block**
+
+```typescript
+// Phase 8b: if submitter bound to a lesson that's NOT in the dup list,
+// fetch it separately so the unified card list can render it as
+// "Submitter's choice."
+const submitterTargetId = submissionData?.original_lesson_id ?? null;
+const targetInDupList = submitterTargetId
+  ? similaritiesWithLessons.some((s) => s.lesson?.lesson_id === submitterTargetId)
+  : false;
+let submitterTargetLesson: any = null;
+if (submitterTargetId && !targetInDupList) {
+  const { data: targetData, error: targetErr } = await supabase
+    .from('lessons_with_metadata')
+    .select('lesson_id, title, summary, file_link, grade_levels, thematic_categories')
+    .eq('lesson_id', submitterTargetId)
+    .single();
+  if (!targetErr) {
+    submitterTargetLesson = targetData;
+  }
+}
+```
+
+Then attach `submitterTargetLesson` to the `setSubmission(...)` payload (extend the type as needed).
+
+**Step 3: Verify type-check passes**
+
+Run: `npm run type-check`
+Expected: passes (after extending the submission type).
+
+**Step 4: Commit (will be amended via fix-up commits in later tasks if needed)**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): fetch off-list submitter target lesson
+
+When submission.original_lesson_id is set but that lesson is not in
+the dup-detection list, fetch it from lessons_with_metadata so the
+upcoming unified card list can render it as 'Submitter's choice.'"
+```
+
+### Task 3.2: Add color-coded binding-intent banner
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx` (top of decision panel — find the wrapper around the decision radio set, likely around line 920-940; add a new block ABOVE the existing decision UI)
+
+**Step 1: Add the banner component logic**
+
+Inside the render function, near the top of the decision panel area, add:
+
+```tsx
+{/* Phase 8b: binding-intent banner */}
+{(() => {
+  const type = submission?.submission_type;
+  const targetId = submission?.original_lesson_id;
+  const targetTitle = submitterTargetLesson?.title
+    || topDuplicates.find((d) => d.id === targetId)?.title
+    || null;
+
+  if (type === 'update' && targetId && targetTitle) {
+    return (
+      <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm">
+        <span className="font-medium text-blue-900">Submitter says:</span>{' '}
+        <span className="text-blue-900">Updating <strong>{targetTitle}</strong></span>
+      </div>
+    );
+  }
+  if (type === 'update' && !targetId) {
+    return (
+      <div className="mb-4 p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm flex items-start">
+        <AlertTriangle size={16} className="text-amber-700 mr-2 mt-0.5 flex-shrink-0" />
+        <div>
+          <span className="font-medium text-amber-900">Submitter says:</span>{' '}
+          <span className="text-amber-900">Updating, but couldn't find target — please search to identify.</span>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="mb-4 p-3 bg-emerald-50 border border-emerald-200 rounded-lg text-sm">
+      <span className="font-medium text-emerald-900">Submitter says:</span>{' '}
+      <span className="text-emerald-900">New lesson</span>
+    </div>
+  );
+})()}
+```
+
+(Make sure `AlertTriangle` is imported from `lucide-react` if it isn't already.)
+
+**Step 2: Type-check + visual smoke**
+
+Run: `npm run type-check`
+Then `npm run dev` and open a sample submission to confirm the banner renders. Verify all three states by manually editing `lesson_submissions` rows in local DB to flip `submission_type` and `original_lesson_id`.
+
+**Step 3: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): Phase 8b binding-intent banner with three colored states
+
+Green (new), blue (update with target), yellow ⚠ (update without target).
+Color is load-bearing for muscle memory."
+```
+
+### Task 3.3 + 3.4: Pre-selection logic + fixed enable/disable
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx`
+
+These are tightly coupled — do them in one step.
+
+**Step 1: Pre-select decision and target after `loadSubmission` resolves**
+
+Inside `loadSubmission`, after `setSubmission(...)`, add:
+
+```typescript
+// Phase 8b: pre-select decision + target based on submitter intent.
+// Both setState calls batch in React 19 so the radio renders enabled
+// on first paint when target is set.
+if (submissionData?.submission_type === 'update') {
+  setDecision('approve_update');
+  if (submissionData.original_lesson_id) {
+    setSelectedDuplicate(submissionData.original_lesson_id);
+  }
+} else {
+  setDecision('approve_new');
+}
+```
+
+(Confirm `setDecision` is the existing setter; if not, name-match to whatever the file calls it.)
+
+**Step 2: Find the existing `disabled={!selectedDuplicate}` on the approve_update radio (line 938)**
+
+Replace it with `disabled={false}` (or remove the `disabled` prop entirely on the radio). The radio should always be selectable; it's the SUBMIT button that gets the constraint.
+
+**Step 3: Find the submit button (around line 990-1010)**
+
+Add this disabled condition (combining with whatever existing disabled logic is there):
+
+```typescript
+disabled={
+  /* existing conditions */
+  || (decision === 'approve_update' && !selectedDuplicate)
+}
+```
+
+And adjacent to the button, add inline guidance text rendered when the condition is met:
+
+```tsx
+{decision === 'approve_update' && !selectedDuplicate && (
+  <p className="text-sm text-gray-600 mt-2">
+    Pick a target lesson to merge into, or change to Approve as new.
+  </p>
+)}
+```
+
+**Step 4: Manual smoke**
+
+Run dev server. Open a submission with `(submission_type='update', original_lesson_id=null)`. Verify:
+- Yellow banner shows
+- `approve_update` radio is selected by default
+- Submit button is disabled with the inline guidance text visible
+
+Open one with `(update, valid_id)`. Verify:
+- Blue banner shows
+- `approve_update` radio is selected
+- Target is pre-selected (look for visual ring on the matching dup card)
+- Submit button is enabled
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): Phase 8b pre-selection + fixed submit-disabled logic
+
+Decision + target pre-selected from submission.submission_type and
+.original_lesson_id. All decision radios always selectable; submit
+button disabled when approve_update is chosen with no target, with
+inline guidance: 'Pick a target lesson to merge into, or change to
+Approve as new.' Closes the silent-degrade-to-approve_new failure
+mode for the (update, null) state."
+```
+
+### Task 3.5: Unified candidate matches list with "Submitter's choice" badge
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx`
+- (Possibly) modify: `src/components/IntDuplicateCard.tsx` if it doesn't already accept a custom `matchLabel`
+
+**Step 1: Verify `IntDuplicateCard` supports `matchLabel`**
+
+Run: `grep -n "matchLabel" src/components/IntDuplicateCard.tsx`
+Expected: prop already exists per agent verification.
+
+**Step 2: Build a unified `candidateMatches` array**
+
+Around the existing `topDuplicates` derivation (line ~412-415), add:
+
+```typescript
+// Phase 8b: unified candidate-matches list — submitter's pick at top
+// (with "Submitter's choice" badge), then dup-detection results.
+const candidateMatches = useMemo(() => {
+  if (!submission) return [];
+  const dupList = topDuplicates ?? [];
+  const submitterTargetId = submission.original_lesson_id ?? null;
+  if (!submitterTargetId) return dupList;
+
+  // If submitter target is in the dup list, hoist it to the top and label.
+  const inListIdx = dupList.findIndex((d) => d.id === submitterTargetId);
+  if (inListIdx >= 0) {
+    const hoisted = { ...dupList[inListIdx], matchLabel: 'Submitter\'s choice' };
+    return [hoisted, ...dupList.filter((_, i) => i !== inListIdx)];
+  }
+  // Otherwise prepend the off-list submitter target as a synthetic card.
+  if (submitterTargetLesson) {
+    const synthetic = {
+      id: submitterTargetLesson.lesson_id,
+      title: submitterTargetLesson.title,
+      summary: submitterTargetLesson.summary ?? '',
+      similarityScore: 0,
+      matchType: 'submitter',
+      matchLabel: 'Submitter\'s choice',
+    };
+    return [synthetic, ...dupList];
+  }
+  return dupList;
+}, [submission, topDuplicates, submitterTargetLesson]);
+```
+
+**Step 3: Replace the rendering of `topDuplicates` with `candidateMatches`** in the duplicate cards section (around line 876-911).
+
+**Step 4: Type-check + visual smoke**
+
+Verify on three test submissions: (new), (update, X-in-dup-list), (update, X-not-in-dup-list). Confirm "Submitter's choice" badge appears on the right card and stays anchored when reviewer selects a different card.
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): unified candidate-matches list with Submitter's choice badge
+
+One card list instead of two (dup-detection results + separate
+submitter-pick card). Submitter's pick is hoisted to top with
+'Submitter's choice' badge whether or not it's in the dup list. Badge
+stays anchored to that card regardless of which card the reviewer
+selects."
+```
+
+### Task 3.6: Search escape hatch (collapsed by default, auto-expand for needs-search)
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx`
+
+**Step 1: Add disclosure UI below the candidate-matches list**
+
+Find the spot just below the cards (still within the decision panel). Add:
+
+```tsx
+{/* Phase 8b: search escape hatch */}
+{(() => {
+  const needsSearch = submission?.submission_type === 'update' && !submission?.original_lesson_id;
+  const noDups = candidateMatches.length === 0;
+  const [showSearch, setShowSearch] = React.useState(needsSearch || noDups);
+  // When intent changes (rare), keep the toggle in sync
+  React.useEffect(() => {
+    setShowSearch(needsSearch || noDups);
+  }, [needsSearch, noDups]);
+
+  const helpText =
+    needsSearch
+      ? "Use this to find the lesson the submitter couldn't"
+      : submission?.original_lesson_id
+        ? "Use this if you disagree with the submitter's pick"
+        : "Use this when no card above is the right match";
+
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        onClick={() => setShowSearch((v) => !v)}
+        className="text-sm text-blue-600 hover:text-blue-800 underline"
+      >
+        {showSearch ? '− Hide library search' : '+ Search the library for a different lesson'}
+      </button>
+      {showSearch && (
+        <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
+          <p className="text-xs text-gray-600 mb-2">{helpText}</p>
+          <LessonSearchPicker
+            selected={null}
+            onSelect={(l) => setSelectedDuplicate(l.lesson_id)}
+            onClear={() => {}}
+            cantFindOption={false}
+          />
+        </div>
+      )}
+    </div>
+  );
+})()}
+```
+
+(Hoist the `useState` and `useEffect` to the component body if linting rejects them inside the IIFE; the IIFE is just for readability of the design spec.)
+
+**Step 2: Add the import**
+
+Add `import { LessonSearchPicker } from '@/components/LessonSearchPicker';` at the top of `ReviewDetail.tsx`.
+
+**Step 3: Manual smoke**
+
+Verify auto-expansion fires for (update, null) and zero-dup-match cases; confirm contextual help text matches state.
+
+**Step 4: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): collapsed search escape hatch with contextual help
+
+Auto-expanded for (update, null) and no-dup-matches cases. Reuses
+LessonSearchPicker built in PR 2. Help text varies by state:
+update-no-target, override mode, or generic 'no match above.'"
+```
+
+### Task 3.7: Title mismatch helper
+
+**Files:**
+- Modify: `src/pages/ReviewDetail.tsx`
+
+**Step 1: Add the import**
+
+`import { titlesAreSimilar } from '@/utils/titleSimilarity';`
+
+**Step 2: Track which targets are "auto-picked" vs "manual"**
+
+The mismatch warning only fires on auto-picks (submitter binding or dup detector). Reviewer manual picks are deliberate.
+
+Add a `manualPickRef = useRef(false)` near the top of the component. Set `manualPickRef.current = true` inside the `LessonSearchPicker.onSelect` handler and inside any dup-card click handler. Reset to `false` on `loadSubmission`.
+
+(Or simpler: derive from `selectedDuplicate` vs `submission.original_lesson_id`: if they match, it's a binding pick; if `selectedDuplicate` matches a top-N dup card, it's a dup-detector pick; otherwise manual. Pick whichever is cleaner against the existing state machine.)
+
+**Step 3: Render the mismatch warning when applicable**
+
+Below the candidate-matches list, before the search escape hatch:
+
+```tsx
+{(() => {
+  if (!selectedDuplicate || manualPickRef.current) return null;
+  const targetTitle =
+    candidateMatches.find((c) => c.id === selectedDuplicate)?.title ?? '';
+  const submissionTitle = submission?.extracted_title ?? '';
+  if (!targetTitle || !submissionTitle) return null;
+  if (titlesAreSimilar(targetTitle, submissionTitle)) return null;
+  return (
+    <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded text-xs text-amber-900">
+      Heads up: submitter linked to <strong>"{targetTitle}"</strong> but submission's extracted
+      title is <strong>"{submissionTitle}"</strong> — confirm this is the right merge target.
+    </div>
+  );
+})()}
+```
+
+**Step 4: Manual smoke** with a contrived case (submitter target = "Apple Crisp", extracted title = "Solar Eclipse") to confirm the warning fires; with target = "Spring Planting", extracted title = "Spring Planting Updated for 2026" to confirm it does NOT fire.
+
+**Step 5: Commit**
+
+```bash
+git add src/pages/ReviewDetail.tsx
+git commit -m "feat(review): title mismatch helper using titlesAreSimilar
+
+Yellow inline warning when an auto-picked merge target's title
+diverges from the submission's extracted title. Word-set Jaccard at
+0.3 threshold. Only fires on auto-picks (submitter binding or dup
+detector); reviewer manual picks are deliberate confirmations and
+suppress the warning."
+```
+
+### Task 3.8: Three-state queue badge in `ReviewDashboard.tsx` + `IntQueueRow.tsx`
+
+**Files:**
+- Modify: `src/pages/ReviewDashboard.tsx` (around the `IntQueueRow` instantiation at lines 257-266)
+- Modify: `src/components/IntQueueRow.tsx` (extend props + render the badge)
+
+**Step 1: Extend `IntQueueRow` props**
+
+Add to the `IntQueueRowSubmission` interface:
+```typescript
+originalLessonId?: string | null;
+originalLessonTitle?: string | null;
+```
+
+Inside the row render, add badge logic (replacing or supplementing the existing `type` chip rendering at line 65 of `IntQueueRow`):
+
+```tsx
+{(() => {
+  if (submission.type === 'new') {
+    return <span className="px-2 py-0.5 text-xs bg-green-100 text-green-800 rounded">NEW</span>;
+  }
+  if (submission.originalLessonId) {
+    return (
+      <span
+        className="px-2 py-0.5 text-xs bg-blue-100 text-blue-800 rounded"
+        title={submission.originalLessonTitle ?? ''}
+      >
+        UPDATE
+      </span>
+    );
+  }
+  return (
+    <span
+      className="px-2 py-0.5 text-xs bg-amber-100 text-amber-800 rounded"
+      title="Submitter is updating but couldn't find target — needs reviewer search"
+    >
+      UPDATE?
+    </span>
+  );
+})()}
+```
+
+**Step 2: Pass new props from `ReviewDashboard.tsx`**
+
+Around line 257-266, extend the `<IntQueueRow ...>` call:
+```tsx
+<IntQueueRow
+  ... existing props ...
+  submission={{
+    ...existingSubmission,
+    originalLessonId: submission.original_lesson_id,
+    originalLessonTitle: lessonTitleMap[submission.original_lesson_id ?? ''] ?? null,
+  }}
+/>
+```
+
+If `lessonTitleMap` doesn't already exist, add a small batched fetch in `loadSubmissions`: collect `original_lesson_id` values, fetch their titles in one query, build a map. (Keep this lean — N is small.)
+
+**Step 3: Type-check + visual smoke**
+
+Verify the queue shows three different badge colors for the three states.
+
+**Step 4: Commit**
+
+```bash
+git add src/pages/ReviewDashboard.tsx src/components/IntQueueRow.tsx
+git commit -m "feat(review): three-state queue badge (NEW / UPDATE / UPDATE?)
+
+Green NEW for submission_type='new', blue UPDATE for type='update'
+with a bound target (target title in tooltip), yellow UPDATE? for
+type='update' with no target (tooltip explains needs reviewer
+search). Lets reviewers triage the queue — UPDATE? rows need the
+extra work."
+```
+
+### Task 3.9: Add tests for pre-selection + mismatch helper
+
+**Files:**
+- Create: `src/pages/__tests__/ReviewDetail.preselect.test.tsx`
+
+**Step 1: Write a focused test** (mocking `loadSubmission` is tricky given the file size; consider testing a hypothetical pure helper or extracting the pre-selection logic to a small function for testability)
+
+If extraction is appropriate, create:
+```typescript
+// src/pages/__tests__/reviewPreselect.test.ts
+import { describe, it, expect } from 'vitest';
+import { computePreselection } from '@/pages/reviewPreselect';
+
+describe('computePreselection', () => {
+  it('new → approve_new, no target', () => {
+    expect(computePreselection({ submission_type: 'new', original_lesson_id: null }))
+      .toEqual({ decision: 'approve_new', target: null });
+  });
+  it('update with target → approve_update + target', () => {
+    expect(computePreselection({ submission_type: 'update', original_lesson_id: 'lesson_1' }))
+      .toEqual({ decision: 'approve_update', target: 'lesson_1' });
+  });
+  it('update without target → approve_update, no target', () => {
+    expect(computePreselection({ submission_type: 'update', original_lesson_id: null }))
+      .toEqual({ decision: 'approve_update', target: null });
+  });
+  it('legacy unknown type → approve_new fallback', () => {
+    expect(computePreselection({ submission_type: undefined as any, original_lesson_id: null }))
+      .toEqual({ decision: 'approve_new', target: null });
+  });
+});
+```
+
+Then extract `computePreselection` to its own file `src/pages/reviewPreselect.ts` and import it from `ReviewDetail.tsx`.
+
+**Step 2: Run tests, verify pass**
+
+Run: `npx vitest run src/pages/__tests__/reviewPreselect.test.ts`
+Expected: 4/4 pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/pages/reviewPreselect.ts src/pages/__tests__/reviewPreselect.test.ts src/pages/ReviewDetail.tsx
+git commit -m "test(review): unit tests for pre-selection logic
+
+Extract computePreselection to its own file for testability. Covers
+all three intent states + legacy/undefined fallback."
+```
+
+### Task 3.10: E2E tests for reviewer flows
+
+**Files:**
+- Create: `e2e/review-flow.spec.ts`
+
+These need authenticated sessions with TEST DB. Match whatever credential pattern the existing project uses (per project memory `reference_test_credentials.md`: `admin@test.com` / `password123`).
+
+**Step 1: Implement smoke tests for the three intent states**
+
+```typescript
+// e2e/review-flow.spec.ts
+import { test, expect } from '@playwright/test';
+
+// These tests assume seeded TEST DB rows. If the seed doesn't include
+// the three (intent, target) shapes, mark them .skip or seed via a
+// fixture before running.
+
+test.describe('Phase 8b reviewer flow — intent banner + pre-selection', () => {
+  test.skip('green banner + approve_new pre-selected for (new) submission', async () => {
+    // Login as admin@test.com, navigate to a known (new) submission, assert.
+  });
+
+  test.skip('blue banner + target pre-selected for (update, X) submission', async () => {
+    // Login, navigate to known (update, X) submission, assert.
+  });
+
+  test.skip('yellow banner + search auto-expanded for (update, null) submission', async () => {
+    // Login, navigate to known (update, null) submission, assert.
+  });
+});
+```
+
+Mark `.skip` for now if seeded fixtures aren't in place — log as a follow-up. The unit tests in Task 3.9 cover the logic; E2E for reviewer is best done manually for v1 if the auth fixture isn't already established.
+
+**Step 2: Commit**
+
+```bash
+git add e2e/review-flow.spec.ts
+git commit -m "test(e2e): scaffolding for reviewer flow E2E (currently .skip)
+
+Three tests sketched for the three intent states. Skipped pending
+seeded fixtures or test-credential automation. Unit coverage in
+src/pages/__tests__/reviewPreselect.test.ts is the primary regression
+guard for now."
+```
+
+### Task 3.11: Final type-check, lint, push, PR
+
+**Step 1: Mandatory pre-PR check**
+
+Run: `npm run type-check && npm run lint`
+Expected: passes.
+
+**Step 2: Push**
+
+```bash
+git push -u origin feat/phase-8b-reviewer-flow
+```
+
+**Step 3: Open PR**
+
+```bash
+gh pr create --title "feat: Phase 8b — reviewer flow (binding-intent banner, pre-selection, search escape, mismatch helper, queue badges)" --body "$(cat <<'EOF'
+## Summary
+- Color-coded binding-intent banner at top of decision panel (green NEW / blue UPDATE / yellow ⚠ UPDATE-no-target)
+- Pre-selection of decision + target from submitter intent
+- Fixed enable/disable: all decision radios always selectable; submit disabled when approve_update has no target with inline guidance
+- Unified candidate-matches list with "Submitter's choice" badge
+- Collapsed search escape hatch (auto-expand for update-no-target / no-dup-matches)
+- Title mismatch helper (word-set Jaccard, only on auto-picks)
+- Three-state queue badge (NEW / UPDATE / UPDATE?)
+
+## Phase 8b context
+This is PR 3 of 3 — the reviewer-side consumer of the binding intent that PR 2's submitter flow now produces. PR 1 (FK migration) and PR 2 (submitter flow) are already merged. See `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md`.
+
+## Test plan
+- [ ] Unit: `npx vitest run src/pages/__tests__/reviewPreselect.test.ts` (4/4)
+- [ ] Type: `npm run type-check` clean
+- [ ] Lint: `npm run lint` clean
+- [ ] Manual smoke on TEST DB: open submissions in each of the three intent states, verify banner color, pre-selection, search-escape auto-expand, queue badges
+- [ ] Manual smoke: override pre-selection, verify save still succeeds with overridden value
+- [ ] Manual smoke: contrived mismatch case (target Apple Crisp + extracted Solar Eclipse) — verify warning fires; legitimate revision (Spring Planting + Spring Planting 2026) — verify warning does NOT fire
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 4: Per-PR ritual** — own reviewer first; investigate every bot finding; round-cap after 2 rounds.
+
+**Step 5: Manual TEST DB smoke after Netlify preview is up** (mandatory per `feedback_data_safety_top_priority.md`).
+
+**Step 6: Merge.** No production migration needed for PR 3 (no schema changes). Netlify auto-deploy.
+
+---
+
+## Done
+
+After PR 3 merges + smoke-passes on PROD:
+
+1. **Update auto-memory** `project_lesson_submission_tier1.md` with the Phase 8b ship status.
+2. **Verify on PROD**: open a real submission (any intent) and confirm the banner + pre-selection render correctly.
+3. **Capture follow-ups in beads** (when fixed) or in a markdown TODO list:
+   - Override-tracking admin view (compare `original_lesson_id` to `published_lesson_id`)
+   - Extraction-failure recovery
+   - Repeated-submission detection
+   - Past-submissions-first revising flow
+   - Brand-new-branch safety check
+   - Submission claim mechanism
+   - Lesson title snapshot at picker-time
+   - DB-trigram fallback for title mismatch (if in-browser proves insufficient)
+   - Separate queue lane for UPDATE-NO-TARGET
+
+## References
+
+- **Design doc:** `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md`
+- **Original investigation:** `~/.claude/plans/i-want-you-to-pure-iverson.md`
+- **Tier-1 plan:** `~/.claude/plans/lesson-submission-tier1-implementation.md`
+- **Mid-brainstorm handoff (now superseded by design doc):** `~/.claude/plans/2026-04-27-phase-8b-workflow-redesign-handoff.md`

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
@@ -527,7 +527,7 @@ export function LessonSearchPicker({
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by lesson title or topic"
+          placeholder="Search by lesson title"
           className="w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         {isLoading && (
@@ -537,7 +537,7 @@ export function LessonSearchPicker({
           />
         )}
       </div>
-      <p className="mt-1 text-xs text-gray-500">e.g., 'Three Sisters' or 'composting'</p>
+      <p className="mt-1 text-xs text-gray-500">e.g., 'Three Sisters' or 'Apple Crisp'</p>
 
       {results.length > 0 && (
         <ul className="mt-2 border border-gray-200 rounded-lg divide-y divide-gray-100">
@@ -1427,7 +1427,29 @@ interface SimilarityWithLesson {
 Run: `grep -n "similaritiesWithLessons\|lessons_with_metadata" src/pages/ReviewDetail.tsx`
 Expected: a few lines around the join logic (likely 240-280).
 
-**Step 3: After the existing similarities-with-lessons assembly, add this block**
+**Step 3: First, define a named `SubmitterTargetLesson` interface near `SimilarityWithLesson` (around line 33-44 of `ReviewDetail.tsx`)**
+
+```typescript
+// Phase 8b: shape of the off-list submitter-target lookup. Used both
+// as the local-variable type in loadSubmission and as the optional
+// field on SubmissionDetail so the rendering code (banner + unified
+// card list) can read it.
+interface SubmitterTargetLesson {
+  lesson_id: string;
+  title: string;
+  summary?: string | null;
+  file_link?: string | null;
+  grade_levels?: string[] | null;
+  thematic_categories?: string[] | null;
+}
+```
+
+Then extend `SubmissionDetail` with:
+```typescript
+submitterTargetLesson?: SubmitterTargetLesson | null;
+```
+
+**Step 4: After the existing similarities-with-lessons assembly, add this block**
 
 ```typescript
 // Phase 8b: if submitter bound to a lesson that's NOT in the dup list,
@@ -1438,7 +1460,7 @@ const submitterTargetId = submissionData?.original_lesson_id ?? null;
 const targetInDupList = submitterTargetId
   ? similaritiesWithLessons.some((s) => s.lesson_id === submitterTargetId)
   : false;
-let submitterTargetLesson: { lesson_id: string; title: string; summary?: string; grade_levels?: string[] | null; thematic_categories?: string[] | null } | null = null;
+let submitterTargetLesson: SubmitterTargetLesson | null = null;
 if (submitterTargetId && !targetInDupList) {
   const { data: targetData, error: targetErr } = await supabase
     .from('lessons_with_metadata')
@@ -1451,7 +1473,7 @@ if (submitterTargetId && !targetInDupList) {
 }
 ```
 
-Then attach `submitterTargetLesson` to the `setSubmission(...)` payload (extend the `SubmissionDetail` interface to include `submitterTargetLesson?: typeof submitterTargetLesson` so consumers downstream can read it).
+Then attach `submitterTargetLesson` to the `setSubmission(...)` payload — the typed field on `SubmissionDetail` (defined in Step 3) is what consumers downstream read.
 
 **Step 3: Verify type-check passes**
 
@@ -1789,33 +1811,43 @@ selects."
 **Files:**
 - Modify: `src/pages/ReviewDetail.tsx`
 
-**Step 1: Add hook state at the TOP of the `ReviewDetail` component (with the other `useState` calls, NOT inside an IIFE — React rules of hooks)**
+**Step 1: Add hook state in the correct order — `selectedSearchLesson` MUST be declared BEFORE `candidateCards` (Task 3.5) because `candidateCards` consumes `selectedSearchLesson` in its `useMemo` deps.**
+
+The correct ordering inside the `ReviewDetail` component body, top to bottom:
 
 ```typescript
 import type { LessonSearchResult } from '@/components/LessonSearchPicker';
 
-// Phase 8b: search escape hatch. Two pieces of state:
-//   - showSearch: disclosure open/closed
-//   - selectedSearchLesson: the lesson the reviewer picked via search
-//     (kept as a separate state so the picker shows a chip and the
-//     candidate-cards list can render a "Reviewer searched" entry; without
-//     this, picking a search result quietly sets selectedDuplicate but
-//     leaves the reviewer with no visible confirmation of what they chose)
+// 1. State hooks (with the other useState calls, near the top of the component)
+const [selectedSearchLesson, setSelectedSearchLesson] = useState<LessonSearchResult | null>(null);
+const [showSearch, setShowSearch] = useState<boolean>(false);
+//    ... other existing useState declarations ...
+
+// 2. Memoized derivations (the candidateCards useMemo from Task 3.5 reads
+//    selectedSearchLesson from above; safe because the value is captured
+//    at render time)
+const candidateCards = useMemo(() => {
+  // ... see Task 3.5 for full body ...
+  // deps: [submission, topDuplicates, selectedSearchLesson]
+}, [submission, topDuplicates, selectedSearchLesson]);
+
+// 3. Derived plain values (computed during render — not hooks)
 const needsSearch =
   submission?.submission_type === 'update' && !submission?.original_lesson_id;
 const noDups = candidateCards.length === 0;
-const [showSearch, setShowSearch] = useState<boolean>(false);
-const [selectedSearchLesson, setSelectedSearchLesson] = useState<LessonSearchResult | null>(null);
+
+// 4. Effects that depend on (3)
 useEffect(() => {
   setShowSearch(needsSearch || noDups);
 }, [needsSearch, noDups]);
+
 // Reset search picker when navigating to a different submission.
 useEffect(() => {
   setSelectedSearchLesson(null);
 }, [submission?.id]);
 ```
 
-(Order these AFTER `submission` state and AFTER `candidateCards` `useMemo`.)
+**Why ordering matters:** React's "rules of hooks" forbid conditional/looped hook calls but don't forbid this kind of dependency between hooks (later hooks can read values produced by earlier hooks). The risk is purely *referential* — if `candidateCards` is declared before `selectedSearchLesson`, you get `ReferenceError: Cannot access 'selectedSearchLesson' before initialization` at runtime. Declaring state hooks first, then memoized derivations, then effects keeps everything in dependency-correct order.
 
 **Step 2: Compute `helpText` as a derived value (not a hook)**
 

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
@@ -372,7 +372,7 @@ describe('LessonSearchPicker', () => {
     expect(onClear).toHaveBeenCalled();
   });
 
-  it('renders can\'t-find option when cantFindOption=true and query has no results', async () => {
+  it('renders can\'t-find affordance after any query when cantFindOption=true (zero-results case)', async () => {
     // Override mock to return empty
     const { supabase } = await import('@/lib/supabase');
     (supabase.from as any).mockImplementation(() => ({
@@ -398,6 +398,44 @@ describe('LessonSearchPicker', () => {
     await waitFor(() => screen.getByText(/can't find it/i));
     await user.click(screen.getByText(/can't find it/i));
     expect(onCantFind).toHaveBeenCalled();
+  });
+
+  it('renders can\'t-find affordance after a query that returns irrelevant matches (non-zero results)', async () => {
+    // Default mock returns Apple Crisp + Pumpkin Pie — irrelevant to "soil"
+    const user = userEvent.setup();
+    const onCantFind = vi.fn();
+    render(
+      <LessonSearchPicker
+        selected={null}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        cantFindOption
+        onCantFind={onCantFind}
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'soil');
+    // Wait for results to render
+    await waitFor(() => screen.getByText('Apple Crisp Lesson'));
+    // Can't-find link should be available even with non-empty results
+    await waitFor(() => screen.getByText(/can't find it/i));
+    await user.click(screen.getByText(/can't find it/i));
+    expect(onCantFind).toHaveBeenCalled();
+  });
+
+  it('does not render can\'t-find affordance before any query (initial state)', async () => {
+    const onCantFind = vi.fn();
+    render(
+      <LessonSearchPicker
+        selected={null}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        cantFindOption
+        onCantFind={onCantFind}
+      />
+    );
+    // Without any query typed, the affordance should not show
+    expect(screen.queryByText(/can't find it/i)).not.toBeInTheDocument();
   });
 
   it('does not render can\'t-find option when cantFindOption=false', async () => {
@@ -565,15 +603,23 @@ export function LessonSearchPicker({
       {hasQueried && results.length === 0 && !isLoading && (
         <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-700">
           No matches found.
-          {cantFindOption && onCantFind && (
-            <button
-              type="button"
-              onClick={onCantFind}
-              className="ml-2 text-blue-600 hover:text-blue-800 underline"
-            >
-              I'm updating but can't find it — let a reviewer help
-            </button>
-          )}
+        </div>
+      )}
+
+      {/* Phase 8b: can't-find affordance is available whenever the
+          submitter has queried (even with irrelevant results), not
+          only on zero-results. Otherwise a teacher with title-similar
+          but content-different matches has no escape into the
+          binding-intent-no-target state. */}
+      {cantFindOption && onCantFind && hasQueried && (
+        <div className="mt-2 text-sm text-gray-700">
+          <button
+            type="button"
+            onClick={onCantFind}
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            None of these is right — I'm updating but can't find it
+          </button>
         </div>
       )}
     </div>
@@ -1117,10 +1163,89 @@ title (or the can't-find fallback message)."
 
 ### Task 2.7: Add pre-INSERT validation to `process-submission`
 
-**Sub-skill:** `superpowers:test-driven-development` (integration test)
+**Sub-skill:** `superpowers:test-driven-development` (real unit test on the extracted helper)
 
 **Files:**
-- Modify: `supabase/functions/process-submission/index.ts` (insert before line 174)
+- Create: `supabase/functions/process-submission/normalizeSubmissionInputs.ts`
+- Create: `supabase/functions/process-submission/__tests__/normalizeSubmissionInputs.test.ts`
+- Modify: `supabase/functions/process-submission/index.ts` (import + call the helper before line 174)
+
+**Step 0: Extract normalization helper for testability**
+
+The validation logic is the data-safety boundary. It deserves a real automated test, not just manual UI verification. Extract the pure normalization into its own file:
+
+```typescript
+// supabase/functions/process-submission/normalizeSubmissionInputs.ts
+export interface RawSubmissionInputs {
+  submissionType?: 'new' | 'update' | string | undefined;
+  originalLessonId?: string | null | undefined;
+}
+
+export interface NormalizedSubmissionInputs {
+  normalizedSubmissionType: 'new' | 'update';
+  normalizedOriginalLessonId: string | null;
+}
+
+/**
+ * Normalize submission_type and original_lesson_id together so the
+ * persisted row is always internally consistent:
+ *   - type='new' → original_lesson_id is always NULL
+ *   - type='update' → original_lesson_id is either non-empty trimmed
+ *     string or NULL ("submitter said update but couldn't find target")
+ *
+ * Empty strings, whitespace-only strings, undefined, and null all
+ * collapse to NULL — so a sloppy caller that sends '' instead of null
+ * doesn't trip a downstream FK violation with a less-helpful error.
+ */
+export function normalizeSubmissionInputs(input: RawSubmissionInputs): NormalizedSubmissionInputs {
+  const normalizedSubmissionType: 'new' | 'update' =
+    input.submissionType === 'update' ? 'update' : 'new';
+  const normalizedOriginalLessonId =
+    normalizedSubmissionType === 'update' &&
+    typeof input.originalLessonId === 'string' &&
+    input.originalLessonId.trim().length > 0
+      ? input.originalLessonId.trim()
+      : null;
+  return { normalizedSubmissionType, normalizedOriginalLessonId };
+}
+```
+
+Test it (Vitest):
+
+```typescript
+// supabase/functions/process-submission/__tests__/normalizeSubmissionInputs.test.ts
+import { describe, it, expect } from 'vitest';
+import { normalizeSubmissionInputs } from '../normalizeSubmissionInputs';
+
+describe('normalizeSubmissionInputs', () => {
+  it.each([
+    // [input, expected]
+    [{ submissionType: 'new', originalLessonId: null },
+     { normalizedSubmissionType: 'new', normalizedOriginalLessonId: null }],
+    [{ submissionType: 'new', originalLessonId: 'lesson_abc' }, // inconsistent input
+     { normalizedSubmissionType: 'new', normalizedOriginalLessonId: null }], // dropped
+    [{ submissionType: 'update', originalLessonId: 'lesson_abc' },
+     { normalizedSubmissionType: 'update', normalizedOriginalLessonId: 'lesson_abc' }],
+    [{ submissionType: 'update', originalLessonId: '  lesson_abc  ' }, // whitespace
+     { normalizedSubmissionType: 'update', normalizedOriginalLessonId: 'lesson_abc' }],
+    [{ submissionType: 'update', originalLessonId: '' }, // empty string
+     { normalizedSubmissionType: 'update', normalizedOriginalLessonId: null }],
+    [{ submissionType: 'update', originalLessonId: '   ' }, // whitespace-only
+     { normalizedSubmissionType: 'update', normalizedOriginalLessonId: null }],
+    [{ submissionType: 'update', originalLessonId: undefined }, // undefined
+     { normalizedSubmissionType: 'update', normalizedOriginalLessonId: null }],
+    [{ submissionType: undefined, originalLessonId: 'lesson_abc' }, // type missing
+     { normalizedSubmissionType: 'new', normalizedOriginalLessonId: null }],
+    [{ submissionType: 'bogus' as any, originalLessonId: 'lesson_abc' }, // unknown type
+     { normalizedSubmissionType: 'new', normalizedOriginalLessonId: null }],
+  ])('normalizeSubmissionInputs(%j) === %j', (input, expected) => {
+    expect(normalizeSubmissionInputs(input)).toEqual(expected);
+  });
+});
+```
+
+Run: `npx vitest run supabase/functions/process-submission/__tests__/normalizeSubmissionInputs.test.ts`
+Expected: 9/9 pass.
 
 **Step 1: Read the current INSERT region** (line 173-187 confirmed earlier; verify line numbers haven't drifted)
 
@@ -1129,24 +1254,23 @@ Expected: line ~173.
 
 **Step 2: Insert the pre-INSERT validation block before line 174**
 
+Add the import at the top of `process-submission/index.ts`:
+```typescript
+import { normalizeSubmissionInputs } from './normalizeSubmissionInputs.ts';
+```
+
 Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMatch[1];`) and BEFORE line 173 (`// Step 1: Create submission record`):
 
 ```typescript
       // Phase 8b: normalize BOTH submissionType and originalLessonId
-      // together. Without coupled normalization, a caller sending
-      // submissionType='new' with a non-empty originalLessonId would
-      // persist an internally-inconsistent row (new lesson with a
-      // pointer to an "updated" lesson). Defense in depth — the legitimate
-      // PR 2 UI never sends this combination, but other callers (future
-      // edge functions, scripts, manual API calls) might.
-      const normalizedSubmissionType =
-        submissionType === 'update' ? 'update' : 'new';
-      const normalizedOriginalLessonId =
-        normalizedSubmissionType === 'update' &&
-        typeof originalLessonId === 'string' &&
-        originalLessonId.trim().length > 0
-          ? originalLessonId.trim()
-          : null;
+      // together (extracted helper, unit-tested in Step 0). Without
+      // coupled normalization, a caller sending submissionType='new'
+      // with a non-empty originalLessonId would persist an
+      // internally-inconsistent row. Defense in depth — the legitimate
+      // PR 2 UI never sends this combination, but other callers
+      // (future edge functions, scripts, manual API calls) might.
+      const { normalizedSubmissionType, normalizedOriginalLessonId } =
+        normalizeSubmissionInputs({ submissionType, originalLessonId });
 
       // Phase 8b: validate originalLessonId BEFORE INSERT to avoid orphan
       // rows on the error path. The DB-level FK serves as the TOCTOU
@@ -1199,14 +1323,24 @@ Optional: write a Vitest integration test against the edge function module — s
 **Step 4: Commit**
 
 ```bash
-git add supabase/functions/process-submission/index.ts
-git commit -m "feat(edge-fn): Phase 8b — pre-INSERT validation of originalLessonId
+git add supabase/functions/process-submission/index.ts \
+        supabase/functions/process-submission/normalizeSubmissionInputs.ts \
+        supabase/functions/process-submission/__tests__/normalizeSubmissionInputs.test.ts
+git commit -m "feat(edge-fn): Phase 8b — normalize + pre-INSERT validation of submission inputs
 
-When submissionType='update' and originalLessonId is non-null, verify
-the target lesson exists BEFORE inserting the submission row. Returns
-400 on missing target without inserting; the existing FK constraint
-remains the TOCTOU backstop. Allows (update, null) — that's the
-'submitter said update but couldn't find target' state from PR 2."
+Extracts coupled-normalization of submissionType + originalLessonId
+into a pure helper with 9 unit tests covering:
+- type='new' coerces originalLessonId to NULL even if caller sent one
+- type='update' with valid id passes through (trimmed)
+- type='update' with empty/whitespace/null/undefined → NULL
+- unknown/missing type → 'new'
+
+Validation runs BEFORE the INSERT — when type='update' AND
+originalLessonId is non-null after normalization, verify the target
+lesson exists; return 400 on missing without inserting. The existing
+FK constraint remains the TOCTOU backstop. Allows (update, null) —
+that's the 'submitter said update but couldn't find target' state
+from PR 2."
 ```
 
 ### Task 2.7.5: Minimal reviewer safety banner (gap-window mitigation)
@@ -1391,8 +1525,8 @@ Use `mcp__supabase-test__execute_sql` to verify each of the three submission pat
 **Pre-flight: read these files first to internalize shape:**
 - `src/pages/ReviewDetail.tsx` (entire — 1016 lines; focus on `selectedDuplicate` state at line 122, `loadSubmission` near line 200-300, decision-bar at line 990-1010, duplicate cards at line 876-911, approve_update radio at line 938)
 - `src/pages/ReviewDashboard.tsx` (line 109 query; line 165 status cast; lines 257-266 `IntQueueRow` instantiation)
-- `src/components/IntQueueRow.tsx` (current props shape)
-- `src/components/IntDuplicateCard.tsx` (matchLabel prop; this is what powers the "Submitter's choice" badge)
+- `src/components/Internal/IntQueueRow.tsx` (current props shape)
+- `src/components/Internal/IntDuplicateCard.tsx` (matchLabel prop; this is what powers the "Submitter's choice" badge)
 - `src/components/LessonSearchPicker.tsx` (created in PR 2)
 - `src/utils/titleSimilarity.ts` (created in PR 2)
 
@@ -1433,7 +1567,13 @@ Expected: a few lines around the join logic (likely 240-280).
 // Phase 8b: shape of the off-list submitter-target lookup. Used both
 // as the local-variable type in loadSubmission and as the optional
 // field on SubmissionDetail so the rendering code (banner + unified
-// card list) can read it.
+// card list) can read it. lesson_id and title are non-null here
+// because we coalesce/guard at the construction site (loadSubmission)
+// before assigning — even though the underlying lessons_with_metadata
+// view types both as nullable. If either is null in the row, the
+// off-list lookup is treated as failed (submitterTargetLesson stays
+// null) and the banner falls into the "update with id but title
+// couldn't be loaded" yellow state.
 interface SubmitterTargetLesson {
   lesson_id: string;
   title: string;
@@ -1452,23 +1592,40 @@ submitterTargetLesson?: SubmitterTargetLesson | null;
 **Step 4: After the existing similarities-with-lessons assembly, add this block**
 
 ```typescript
-// Phase 8b: if submitter bound to a lesson that's NOT in the dup list,
-// fetch it separately so the unified card list can render it as
-// "Submitter's choice." Note: SimilarityWithLesson has lesson_id at TOP
-// level, not nested under .lesson — see type definition above.
+// Phase 8b: if submitter bound to a lesson that's NOT in the rendered
+// top-5 dup cards, fetch it separately so the unified card list can
+// render it as "Submitter's choice." CRITICAL: check against the SLICED
+// top-5 (not the full similarities array). The render path uses
+// `topDuplicates = submission.similarities.slice(0, 5)` (line 412), so
+// if the submitter target sits at rank 6+ of dup detection results, it
+// is NOT visible in the cards UI — same effective state as off-list.
+// Without this slice, we'd silently skip the off-list fetch for those
+// rank-6+ targets and the reviewer would see selectedDuplicate set to
+// an invisible target with no card showing it.
 const submitterTargetId = submissionData?.original_lesson_id ?? null;
-const targetInDupList = submitterTargetId
-  ? similaritiesWithLessons.some((s) => s.lesson_id === submitterTargetId)
+const renderedTopFive = (similaritiesWithLessons ?? []).slice(0, 5);
+const targetInRenderedTopFive = submitterTargetId
+  ? renderedTopFive.some((s) => s.lesson_id === submitterTargetId)
   : false;
 let submitterTargetLesson: SubmitterTargetLesson | null = null;
-if (submitterTargetId && !targetInDupList) {
+if (submitterTargetId && !targetInRenderedTopFive) {
   const { data: targetData, error: targetErr } = await supabase
     .from('lessons_with_metadata')
     .select('lesson_id, title, summary, file_link, grade_levels, thematic_categories')
     .eq('lesson_id', submitterTargetId)
     .single();
-  if (!targetErr && targetData) {
-    submitterTargetLesson = targetData;
+  // Coalesce nullable view fields. lessons_with_metadata is typed with
+  // nullable lesson_id and title (Supabase view nullability) — guard
+  // before constructing the SubmitterTargetLesson which requires both.
+  if (!targetErr && targetData && targetData.lesson_id && targetData.title) {
+    submitterTargetLesson = {
+      lesson_id: targetData.lesson_id,
+      title: targetData.title,
+      summary: targetData.summary,
+      file_link: targetData.file_link,
+      grade_levels: targetData.grade_levels,
+      thematic_categories: targetData.thematic_categories,
+    };
   }
 }
 ```
@@ -1676,11 +1833,11 @@ mode for the (update, null) state."
 
 **Files:**
 - Modify: `src/pages/ReviewDetail.tsx`
-- (Possibly) modify: `src/components/IntDuplicateCard.tsx` if it doesn't already accept a custom `matchLabel`
+- (Possibly) modify: `src/components/Internal/IntDuplicateCard.tsx` if it doesn't already accept a custom `matchLabel`
 
 **Step 1: Verify `IntDuplicateCard` supports `matchLabel`**
 
-Run: `grep -n "matchLabel\|export interface\|export type" src/components/IntDuplicateCard.tsx`
+Run: `grep -n "matchLabel\|export interface\|export type" src/components/Internal/IntDuplicateCard.tsx`
 Confirm the prop name (the prior agent review reported it exists; double-check the actual prop name — it might be `matchLabel`, `badge`, or similar).
 
 **Step 2: Re-read the existing `topDuplicates.map` rendering at `src/pages/ReviewDetail.tsx:885-908`**
@@ -1777,7 +1934,14 @@ The existing wrapper at line 878 reads `{topDuplicates.length > 0 && (...)}`. Un
           }}
           selected={selectedDuplicate === c.id}
           onSelect={() => {
-            setSelectedDuplicate(selectedDuplicate === c.id ? null : c.id);
+            const next = selectedDuplicate === c.id ? null : c.id;
+            setSelectedDuplicate(next);
+            // Phase 8b: keep selectedSearchLesson in sync. If reviewer
+            // picks a non-search card, the picker chip should not show
+            // the previously-searched lesson as still selected.
+            if (selectedSearchLesson && next !== selectedSearchLesson.lesson_id) {
+              setSelectedSearchLesson(null);
+            }
             setSaveError(null);
           }}
         />
@@ -2014,7 +2178,7 @@ suppress the warning."
 
 **Files:**
 - Modify: `src/pages/ReviewDashboard.tsx` (around the `IntQueueRow` instantiation at lines 257-266)
-- Modify: `src/components/IntQueueRow.tsx` (extend props + render the badge)
+- Modify: `src/components/Internal/IntQueueRow.tsx` (extend props + render the badge)
 
 **Step 1: Extend `IntQueueRow` props**
 
@@ -2088,7 +2252,7 @@ Verify the queue shows three different badge colors for the three states.
 **Step 4: Commit**
 
 ```bash
-git add src/pages/ReviewDashboard.tsx src/components/IntQueueRow.tsx
+git add src/pages/ReviewDashboard.tsx src/components/Internal/IntQueueRow.tsx
 git commit -m "feat(review): three-state queue badge (NEW / UPDATE / UPDATE?)
 
 Green NEW for submission_type='new', blue UPDATE for type='update'

--- a/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+++ b/docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
@@ -1132,19 +1132,26 @@ Expected: line ~173.
 Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMatch[1];`) and BEFORE line 173 (`// Step 1: Create submission record`):
 
 ```typescript
-      // Phase 8b: normalize originalLessonId — treat undefined/null/empty
-      // string/whitespace-only as NULL. Without this, an empty string
-      // would skip the truthy check below but then fail the FK at INSERT
-      // with a less-helpful error than a clean 400.
+      // Phase 8b: normalize BOTH submissionType and originalLessonId
+      // together. Without coupled normalization, a caller sending
+      // submissionType='new' with a non-empty originalLessonId would
+      // persist an internally-inconsistent row (new lesson with a
+      // pointer to an "updated" lesson). Defense in depth — the legitimate
+      // PR 2 UI never sends this combination, but other callers (future
+      // edge functions, scripts, manual API calls) might.
+      const normalizedSubmissionType =
+        submissionType === 'update' ? 'update' : 'new';
       const normalizedOriginalLessonId =
-        typeof originalLessonId === 'string' && originalLessonId.trim().length > 0
+        normalizedSubmissionType === 'update' &&
+        typeof originalLessonId === 'string' &&
+        originalLessonId.trim().length > 0
           ? originalLessonId.trim()
           : null;
 
       // Phase 8b: validate originalLessonId BEFORE INSERT to avoid orphan
       // rows on the error path. The DB-level FK serves as the TOCTOU
       // backstop; this check provides fast user feedback.
-      if (submissionType === 'update' && normalizedOriginalLessonId) {
+      if (normalizedSubmissionType === 'update' && normalizedOriginalLessonId) {
         const { count: lessonCount, error: lessonCheckError } = await supabaseAdmin
           .from('lessons')
           .select('lesson_id', { count: 'exact', head: true })
@@ -1164,7 +1171,11 @@ Insert this code block immediately AFTER line 171 (`const googleDocId = docIdMat
       }
 ```
 
-Then in the existing INSERT (line 174-185), replace `original_lesson_id: originalLessonId` with `original_lesson_id: normalizedOriginalLessonId` so the normalized value is what's persisted.
+Then in the existing INSERT (line 174-185), replace BOTH:
+- `submission_type: submissionType || 'new'` → `submission_type: normalizedSubmissionType`
+- `original_lesson_id: originalLessonId` → `original_lesson_id: normalizedOriginalLessonId`
+
+so the normalized values are what's persisted. This guarantees the row's `submission_type` and `original_lesson_id` are always internally consistent: if type is `'new'`, original_lesson_id is always NULL; if type is `'update'`, original_lesson_id is either a validated existing lesson_id or NULL (the can't-find-it state).
 
 **Step 3: Local verification (via UI, not curl)**
 
@@ -1478,6 +1489,7 @@ Find and delete the Task 2.7.5 banner block (the `submission?.submission_type ==
     || topDuplicates.find((d) => d.lesson_id === targetId)?.lesson?.title
     || null;
 
+  // (update, X, title-known) — happy path
   if (type === 'update' && targetId && targetTitle) {
     return (
       <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg text-sm">
@@ -1486,6 +1498,25 @@ Find and delete the Task 2.7.5 banner block (the `submission?.submission_type ==
       </div>
     );
   }
+  // (update, X, title lookup FAILED) — degraded but still update intent.
+  // CRITICAL: must NOT fall through to the green "new" banner; that's the
+  // worst-possible misrender (reviewer thinks it's new when submitter
+  // declared an update). Render yellow with the raw lesson_id and a
+  // "verify before approving" prompt.
+  if (type === 'update' && targetId && !targetTitle) {
+    return (
+      <div className="mb-4 p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm flex items-start">
+        <AlertTriangle size={16} className="text-amber-700 mr-2 mt-0.5 flex-shrink-0" />
+        <div>
+          <span className="font-medium text-amber-900">Submitter says:</span>{' '}
+          <span className="text-amber-900">
+            Updating lesson <code>{targetId}</code> — but its title couldn't be loaded. Please search the library to confirm the right merge target before approving.
+          </span>
+        </div>
+      </div>
+    );
+  }
+  // (update, null) — explicit can't-find-it
   if (type === 'update' && !targetId) {
     return (
       <div className="mb-4 p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm flex items-start">
@@ -1497,6 +1528,7 @@ Find and delete the Task 2.7.5 banner block (the `submission?.submission_type ==
       </div>
     );
   }
+  // (new) — only fall here when type is genuinely 'new'
   return (
     <div className="mb-4 p-3 bg-emerald-50 border border-emerald-200 rounded-lg text-sm">
       <span className="font-medium text-emerald-900">Submitter says:</span>{' '}
@@ -1535,17 +1567,22 @@ These are tightly coupled — do them in one step.
 
 **Step 1: Pre-select decision and target after `loadSubmission` resolves — but ONLY when no existing reviewer state exists**
 
-Inside `loadSubmission`, after `setSubmission(...)`, add:
+The existing prior-review restoration logic lives at `ReviewDetail.tsx:302-325` and uses the **separately-fetched `reviews` array**, not the assembled `fullSubmission` object. The raw `submissionData` row from the DB query has no `.review` field. So the guard MUST check `reviews?.length`, not `submissionData?.review`.
+
+What the existing code already restores from `reviews?.[0]`:
+- `decision` (via `setDecision`)
+- `notes` (via `setNotes`)
+- `metadata` (via `setMetadata`)
+- **NOT `selectedDuplicate`** — the prior merge target is *not* restored from the prior review (pre-existing gap; the `submission_reviews` table doesn't store the chosen lesson_id in a column the RPC writes — it lives in `lessons.original_submission_id` for `approve_new` or `lesson_versions.archived_from_submission_id` for `approve_update`). **Restoring the prior target is OUT OF 8B SCOPE** — this is a known pre-existing limitation, captured as a follow-up. Phase 8b's pre-selection just needs to not clobber the existing decision restoration.
+
+Inside `loadSubmission`, after the existing block at `ReviewDetail.tsx:302-325` (the `if (reviews && reviews.length > 0) { ... }` that restores decision/notes/metadata), add an `else` branch:
 
 ```typescript
-// Phase 8b: pre-select decision + target based on submitter intent.
-// CRITICAL: only fire when there's no existing review row. Otherwise we'd
-// clobber a reviewer's in-progress decision (e.g., they flipped from
-// needs_revision back to submitted, or they refreshed mid-edit). The
-// banner still renders for these cases — only the auto-pre-select
-// fires conditionally.
-const hasExistingReview = !!submissionData?.review;
-if (!hasExistingReview) {
+// Phase 8b: pre-select decision + target from submitter intent — but
+// ONLY when no existing review row. The existing block above already
+// restored decision/notes/metadata from reviews?.[0] when present;
+// pre-selecting from submitter intent now would clobber that.
+if (!reviews || reviews.length === 0) {
   if (submissionData?.submission_type === 'update') {
     setDecision('approve_update');
     if (submissionData.original_lesson_id) {
@@ -1555,13 +1592,11 @@ if (!hasExistingReview) {
     setDecision('approve_new');
   }
 }
-// If hasExistingReview is true, the existing setSubmission(...) call
-// already restored decision/notes/metadata from submissionData.review
-// (verify this in the existing loadSubmission flow; if not, ensure it
-// does — pre-existing behavior, not new in 8b).
 ```
 
-(Confirm `setDecision` is the existing setter; if not, name-match to whatever the file calls it.)
+(`setDecision` and `setSelectedDuplicate` are the existing setters — verify against current code.)
+
+**Note for the implementation agent:** if the existing prior-review block at lines 302-325 doesn't already restore `setSelectedDuplicate` from any source (and per pre-flight reading it does NOT), the prior-target gap remains. That's fine — Phase 8b is not introducing the gap and is not on the hook to fix it. A future task can JOIN through `lesson_versions.archived_from_submission_id` to restore the prior target.
 
 **Step 2: Find the existing `disabled={!selectedDuplicate}` on the approve_update radio (line 938)**
 
@@ -1690,27 +1725,44 @@ const candidateCards = useMemo(() => {
 }, [submission, topDuplicates]);
 ```
 
-**Step 4: Replace the existing `topDuplicates.map(...)` block at `src/pages/ReviewDetail.tsx:885-908` with a `candidateCards.map(...)` block**
+**Step 4: Replace the existing `topDuplicates.map(...)` block at `src/pages/ReviewDetail.tsx:885-908` with a `candidateCards.map(...)` block — AND update the wrapper condition**
+
+The existing wrapper at line 878 reads `{topDuplicates.length > 0 && (...)}`. Under Phase 8b, an `(update, X)` submission where X is off-list AND zero dup-detection results would have `topDuplicates.length === 0` but `candidateCards.length === 1` (the prepended off-list submitter target). The existing wrapper would hide the entire section — reviewer sees no card and can't pick a target via the cards UI.
+
+**Update both the wrapper condition AND the section header copy:**
 
 ```tsx
-{candidateCards.map((c) => (
-  <IntDuplicateCard
-    key={c.id}
-    dup={{
-      id: c.id,
-      title: c.title,
-      meta: c.meta,
-      similarity: c.similarity,
-      matchType: c.matchType,
-      matchLabel: c.matchLabel,
-    }}
-    selected={selectedDuplicate === c.id}
-    onSelect={() => {
-      setSelectedDuplicate(selectedDuplicate === c.id ? null : c.id);
-      setSaveError(null);
-    }}
-  />
-))}
+{candidateCards.length > 0 && (
+  <div className="adm-card">
+    <div className="adm-section-eyebrow">
+      {/* Header copy adapts to whether we have submitter's choice, dup matches, or both */}
+      {candidateCards[0]?.matchLabel === "Submitter's choice"
+        ? "Candidate matches"
+        : "Possible duplicates"}
+    </div>
+    <p className="adm-section-desc">Select one to merge into instead of publishing new.</p>
+    <div className="adm-dup-list">
+      {candidateCards.map((c) => (
+        <IntDuplicateCard
+          key={c.id}
+          dup={{
+            id: c.id,
+            title: c.title,
+            meta: c.meta,
+            similarity: c.similarity,
+            matchType: c.matchType,
+            matchLabel: c.matchLabel,
+          }}
+          selected={selectedDuplicate === c.id}
+          onSelect={() => {
+            setSelectedDuplicate(selectedDuplicate === c.id ? null : c.id);
+            setSaveError(null);
+          }}
+        />
+      ))}
+    </div>
+  </div>
+)}
 ```
 
 (If the actual `IntDuplicateCard` prop name for the badge isn't `matchLabel`, update accordingly per Step 1's verification.)
@@ -1740,18 +1792,30 @@ selects."
 **Step 1: Add hook state at the TOP of the `ReviewDetail` component (with the other `useState` calls, NOT inside an IIFE — React rules of hooks)**
 
 ```typescript
-// Phase 8b: search escape hatch toggle. Default-open when reviewer must
-// search (update with no target) or when there are no dup matches at all.
+import type { LessonSearchResult } from '@/components/LessonSearchPicker';
+
+// Phase 8b: search escape hatch. Two pieces of state:
+//   - showSearch: disclosure open/closed
+//   - selectedSearchLesson: the lesson the reviewer picked via search
+//     (kept as a separate state so the picker shows a chip and the
+//     candidate-cards list can render a "Reviewer searched" entry; without
+//     this, picking a search result quietly sets selectedDuplicate but
+//     leaves the reviewer with no visible confirmation of what they chose)
 const needsSearch =
   submission?.submission_type === 'update' && !submission?.original_lesson_id;
 const noDups = candidateCards.length === 0;
 const [showSearch, setShowSearch] = useState<boolean>(false);
+const [selectedSearchLesson, setSelectedSearchLesson] = useState<LessonSearchResult | null>(null);
 useEffect(() => {
   setShowSearch(needsSearch || noDups);
 }, [needsSearch, noDups]);
+// Reset search picker when navigating to a different submission.
+useEffect(() => {
+  setSelectedSearchLesson(null);
+}, [submission?.id]);
 ```
 
-(Order these AFTER `submission` state and AFTER `candidateCards` `useMemo` so they read fresh values. Note: `candidateCards` from Task 3.5 is a derived `useMemo`, so it can be referenced in this `useEffect`'s deps.)
+(Order these AFTER `submission` state and AFTER `candidateCards` `useMemo`.)
 
 **Step 2: Compute `helpText` as a derived value (not a hook)**
 
@@ -1765,7 +1829,32 @@ const searchHelpText = needsSearch
     : "Use this when no card above is the right match";
 ```
 
-**Step 3: Render the disclosure JSX**
+**Step 3: Extend `candidateCards` to include the search-picked target (so it appears as a card with a "Reviewer searched" badge)**
+
+Update the `candidateCards` `useMemo` from Task 3.5 to also append the search-picked lesson when present and not already in the list:
+
+```typescript
+const candidateCards = useMemo(() => {
+  // ... existing logic from Task 3.5 ...
+  // After computing the dup-list-with-submitter-pick result (call it `base`):
+  if (selectedSearchLesson && !base.some((c) => c.id === selectedSearchLesson.lesson_id)) {
+    return [
+      ...base,
+      {
+        id: selectedSearchLesson.lesson_id,
+        title: selectedSearchLesson.title,
+        meta: '(found via library search)',
+        similarity: 0,
+        matchType: null,
+        matchLabel: 'Reviewer searched',
+      },
+    ];
+  }
+  return base;
+}, [submission, topDuplicates, selectedSearchLesson]);
+```
+
+**Step 4: Render the disclosure JSX**
 
 Place this in the decision-panel render below the candidate-matches list:
 
@@ -1783,9 +1872,19 @@ Place this in the decision-panel render below the candidate-matches list:
     <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
       <p className="text-xs text-gray-600 mb-2">{searchHelpText}</p>
       <LessonSearchPicker
-        selected={null}
-        onSelect={(l) => setSelectedDuplicate(l.lesson_id)}
-        onClear={() => {}}
+        selected={selectedSearchLesson}
+        onSelect={(l) => {
+          setSelectedSearchLesson(l);
+          setSelectedDuplicate(l.lesson_id);
+          setSaveError(null);
+        }}
+        onClear={() => {
+          setSelectedSearchLesson(null);
+          // Also clear selectedDuplicate if it was the search-picked one
+          if (selectedDuplicate === selectedSearchLesson?.lesson_id) {
+            setSelectedDuplicate(null);
+          }
+        }}
         cantFindOption={false}
       />
     </div>
@@ -1793,7 +1892,7 @@ Place this in the decision-panel render below the candidate-matches list:
 </div>
 ```
 
-No IIFE, no hooks-in-callback. JSX uses values computed by hooks at the top of the component.
+No IIFE, no hooks-in-callback. The search-picked lesson appears both as a chip inside the picker AND as a card with "Reviewer searched" badge in the candidate-matches list — so reviewer always sees what's selected.
 
 **Step 2: Add the import**
 
@@ -1823,13 +1922,25 @@ update-no-target, override mode, or generic 'no match above.'"
 
 `import { titlesAreSimilar } from '@/utils/titleSimilarity';`
 
-**Step 2: Track which targets are "auto-picked" vs "manual"**
+**Step 2: Determine "auto-pick vs manual" via state derivation (no ref needed)**
 
-The mismatch warning only fires on auto-picks (submitter binding or dup detector). Reviewer manual picks are deliberate.
+The mismatch warning only fires on auto-picks (submitter binding or dup-detector pick). Reviewer manual picks via the search escape hatch are deliberate confirmations and suppress the warning.
 
-Add a `manualPickRef = useRef(false)` near the top of the component. Set `manualPickRef.current = true` inside the `LessonSearchPicker.onSelect` handler and inside any dup-card click handler. Reset to `false` on `loadSubmission`.
+Use the testable helper from Task 3.9:
 
-(Or simpler: derive from `selectedDuplicate` vs `submission.original_lesson_id`: if they match, it's a binding pick; if `selectedDuplicate` matches a top-N dup card, it's a dup-detector pick; otherwise manual. Pick whichever is cleaner against the existing state machine.)
+```typescript
+import { shouldShowMismatchWarning } from '@/pages/reviewMismatch';
+
+// Derived in render — no extra state.
+const showMismatch = shouldShowMismatchWarning({
+  selectedTarget: selectedDuplicate,
+  submitterTargetId: submission?.original_lesson_id ?? null,
+  topDuplicateIds: topDuplicates.map((d) => d.lesson_id),
+  searchPickedId: selectedSearchLesson?.lesson_id ?? null,
+});
+```
+
+This is cleaner than a `useRef`-based "manualPickRef" approach because it's pure (testable as a function), survives re-renders without race conditions, and consistently classifies the search-picked target as "manual" via the `selectedSearchLesson` state from Task 3.6.
 
 **Step 3: Render the mismatch warning when applicable**
 
@@ -1837,7 +1948,7 @@ Below the candidate-matches list, before the search escape hatch:
 
 ```tsx
 {(() => {
-  if (!selectedDuplicate || manualPickRef.current) return null;
+  if (!showMismatch) return null;
   const targetTitle =
     candidateCards.find((c) => c.id === selectedDuplicate)?.title ?? '';
   const submissionTitle = submission?.extracted_title ?? '';
@@ -1955,14 +2066,15 @@ search). Lets reviewers triage the queue — UPDATE? rows need the
 extra work."
 ```
 
-### Task 3.9: Add tests for pre-selection + mismatch helper
+### Task 3.9: Add tests for pre-selection + mismatch-helper integration
 
 **Files:**
-- Create: `src/pages/__tests__/ReviewDetail.preselect.test.tsx`
+- Create: `src/pages/reviewPreselect.ts`
+- Create: `src/pages/__tests__/reviewPreselect.test.ts`
+- Create: `src/pages/__tests__/reviewMismatch.test.ts`
 
-**Step 1: Write a focused test** (mocking `loadSubmission` is tricky given the file size; consider testing a hypothetical pure helper or extracting the pre-selection logic to a small function for testability)
+**Step 1: Pre-selection tests (extracting `computePreselection` for testability)**
 
-If extraction is appropriate, create:
 ```typescript
 // src/pages/__tests__/reviewPreselect.test.ts
 import { describe, it, expect } from 'vitest';
@@ -1988,21 +2100,85 @@ describe('computePreselection', () => {
 });
 ```
 
-Then extract `computePreselection` to its own file `src/pages/reviewPreselect.ts` and import it from `ReviewDetail.tsx`.
+Then extract `computePreselection` to its own file and import it from `ReviewDetail.tsx`.
 
-**Step 2: Run tests, verify pass**
+**Step 2: Mismatch-helper integration tests** (tests that the helper from Task 3.7 is consumed correctly — fires only on auto-picks, suppressed on reviewer manual picks)
 
-Run: `npx vitest run src/pages/__tests__/reviewPreselect.test.ts`
-Expected: 4/4 pass.
+The `manualPickRef` (or equivalent state-derivation) logic from Task 3.7 should be tested independently. Extract that decision into a pure helper for testability:
 
-**Step 3: Commit**
+```typescript
+// src/pages/reviewMismatch.ts
+export function shouldShowMismatchWarning(args: {
+  selectedTarget: string | null;
+  submitterTargetId: string | null;
+  topDuplicateIds: string[];
+  searchPickedId: string | null;
+}): boolean {
+  const { selectedTarget, submitterTargetId, topDuplicateIds, searchPickedId } = args;
+  if (!selectedTarget) return false;
+  // Auto-pick: target was bound by submitter or surfaced by dup detector.
+  const isSubmitterPick = selectedTarget === submitterTargetId;
+  const isDupDetectorPick = topDuplicateIds.includes(selectedTarget);
+  // Manual: target was picked via the search escape hatch.
+  const isManualPick = selectedTarget === searchPickedId;
+  // Manual picks are deliberate confirmations — suppress.
+  if (isManualPick) return false;
+  // Otherwise, if it's an auto-pick, signal the caller to compute Jaccard.
+  return isSubmitterPick || isDupDetectorPick;
+}
+```
+
+```typescript
+// src/pages/__tests__/reviewMismatch.test.ts
+import { describe, it, expect } from 'vitest';
+import { shouldShowMismatchWarning } from '@/pages/reviewMismatch';
+
+describe('shouldShowMismatchWarning', () => {
+  it('returns false when nothing selected', () => {
+    expect(shouldShowMismatchWarning({
+      selectedTarget: null, submitterTargetId: 'lesson_1', topDuplicateIds: [], searchPickedId: null,
+    })).toBe(false);
+  });
+  it('returns true when submitter-bound target is selected', () => {
+    expect(shouldShowMismatchWarning({
+      selectedTarget: 'lesson_1', submitterTargetId: 'lesson_1', topDuplicateIds: [], searchPickedId: null,
+    })).toBe(true);
+  });
+  it('returns true when dup-detector target is selected', () => {
+    expect(shouldShowMismatchWarning({
+      selectedTarget: 'lesson_2', submitterTargetId: null, topDuplicateIds: ['lesson_2', 'lesson_3'], searchPickedId: null,
+    })).toBe(true);
+  });
+  it('returns false when reviewer manually search-picked the target', () => {
+    expect(shouldShowMismatchWarning({
+      selectedTarget: 'lesson_5', submitterTargetId: null, topDuplicateIds: [], searchPickedId: 'lesson_5',
+    })).toBe(false);
+  });
+  it('returns false when reviewer search-picked AND that lesson happens to also be a dup-detector hit (defer to deliberate confirmation)', () => {
+    expect(shouldShowMismatchWarning({
+      selectedTarget: 'lesson_5', submitterTargetId: null, topDuplicateIds: ['lesson_5'], searchPickedId: 'lesson_5',
+    })).toBe(false);
+  });
+});
+```
+
+Then in Task 3.7's render code, gate the actual mismatch banner on `shouldShowMismatchWarning(...) && !titlesAreSimilar(targetTitle, submissionTitle)`.
+
+**Step 3: Run tests, verify pass**
+
+Run: `npx vitest run src/pages/__tests__/reviewPreselect.test.ts src/pages/__tests__/reviewMismatch.test.ts`
+Expected: 4 + 5 = 9/9 pass.
+
+**Step 4: Commit**
 
 ```bash
-git add src/pages/reviewPreselect.ts src/pages/__tests__/reviewPreselect.test.ts src/pages/ReviewDetail.tsx
-git commit -m "test(review): unit tests for pre-selection logic
+git add src/pages/reviewPreselect.ts src/pages/reviewMismatch.ts src/pages/__tests__/reviewPreselect.test.ts src/pages/__tests__/reviewMismatch.test.ts src/pages/ReviewDetail.tsx
+git commit -m "test(review): unit tests for pre-selection + mismatch-helper logic
 
-Extract computePreselection to its own file for testability. Covers
-all three intent states + legacy/undefined fallback."
+Extract computePreselection and shouldShowMismatchWarning to their own
+files for testability. Covers all three intent states for preselect
+and the four trigger states for mismatch (no selection, submitter-bound,
+dup-detector, reviewer-manual)."
 ```
 
 ### Task 3.10: E2E tests for reviewer flows

--- a/docs/plans/2026-04-27-phase-8b-execution-kickoff.md
+++ b/docs/plans/2026-04-27-phase-8b-execution-kickoff.md
@@ -35,7 +35,12 @@ Lesson Search v2. Three sequential PRs:
 
 - docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
   The WHAT. Source of truth for the next task: exact file paths, code snippets,
-  test commands, commit messages. Follow it. Don't improvise.
+  test commands, commit messages. Follow it for product scope and task order.
+  Verify every snippet against the current code before applying it — line
+  numbers, imports, types, prop names, and APIs may have drifted since the
+  plan was written. Small repo-conformance adaptations are allowed; product
+  or design changes are not. If a needed adaptation changes behavior or
+  scope, stop and ask.
 
 - docs/plans/2026-04-27-phase-8b-execution-status.md
   Source of truth for WHERE we are. Survives /clear because it's on disk +
@@ -50,11 +55,18 @@ Lesson Search v2. Three sequential PRs:
    (see "LOCKED" below).
 4. Read the implementation plan from the task you're about to start through
    the next 1-2 tasks (don't read it all unless useful).
-5. `git status && git log --oneline -10` — confirm git matches the status
-   file. If they diverge, trust git.
-6. `npm run type-check && npm run lint` — confirm a clean baseline. If
-   either fails, the first task is to fix that, not to push forward.
-7. Tell me where you are and what task is next. Don't start coding until
+5. `git status --short --branch && git branch --show-current && git log --oneline -10`
+   — confirm git matches the status file. If they diverge, trust git, then
+   update the status file to match reality before proceeding.
+6. If the worktree is dirty, identify whether the changes are part of
+   Phase 8b before touching them. Never revert or overwrite unrelated user
+   changes. If unsure, ask.
+7. `npm run type-check && npm run lint` — confirm a clean baseline.
+   If either fails, diagnose first. If the failure is unrelated to the
+   current Phase 8b branch/task, report it and ask before changing
+   unrelated files. If it is caused by current branch work, fix it before
+   proceeding.
+8. Tell me where you are and what task is next. Don't start coding until
    I confirm orientation.
 
 # LOCKED DECISIONS — do NOT re-debate
@@ -175,8 +187,8 @@ might cover.
 
 # EXECUTION STATUS FILE TEMPLATE (create on Session 1)
 
-If docs/plans/2026-04-27-phase-8b-execution-status.md doesn't exist, create
-it with this content:
+If docs/plans/2026-04-27-phase-8b-execution-status.md does not exist yet,
+create it with the content shown below:
 
 ---
 # Phase 8b Execution Status

--- a/docs/plans/2026-04-27-phase-8b-execution-kickoff.md
+++ b/docs/plans/2026-04-27-phase-8b-execution-kickoff.md
@@ -1,0 +1,214 @@
+# Phase 8b — Execution Kickoff Prompt
+
+**Purpose:** paste the contents of the code block below verbatim at the start of each new Claude Code session that's executing Phase 8b. Each session bootstraps from this prompt with no prior conversation context — the design doc, implementation plan, status file, and git history are the only source of truth across sessions.
+
+**How to use:**
+1. Open a fresh Claude Code session in `/Users/danfeder/cCode/esynyc-lessonsearch-v2`.
+2. Copy everything inside the triple-backtick block below.
+3. Paste as the first message.
+4. Wait for the agent to orient and report — don't tell it to start coding until it confirms what task is next.
+5. At session end, the agent updates `docs/plans/2026-04-27-phase-8b-execution-status.md` so the next session knows where to pick up.
+
+**When to update this kickoff:** if a hard rule changes (e.g., a new "never do X" emerges from a session) or a locked decision is genuinely re-opened. Don't edit casually — the rules' stability is what makes the across-session pattern work.
+
+---
+
+```
+You are continuing execution of the Phase 8b approve_update workflow redesign.
+This prompt will be pasted at the start of every session in this work — assume
+no prior conversation context. Treat what's on disk + git history + the
+execution status file as your only source of truth.
+
+# WHAT YOU'RE BUILDING
+
+The intent-first redesign of the lesson submission + reviewer flow for ESYNYC
+Lesson Search v2. Three sequential PRs:
+  PR 1: Schema (single FK migration)
+  PR 2: Submitter flow + LessonSearchPicker + reviewer-side safety banner
+  PR 3: Reviewer flow (full state-aware UX)
+
+# WHERE THINGS LIVE
+
+- docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md
+  The WHY behind every decision. Read once at session start. Return when a
+  "why are we doing it this way" question comes up.
+
+- docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md
+  The WHAT. Source of truth for the next task: exact file paths, code snippets,
+  test commands, commit messages. Follow it. Don't improvise.
+
+- docs/plans/2026-04-27-phase-8b-execution-status.md
+  Source of truth for WHERE we are. Survives /clear because it's on disk +
+  in git. If it doesn't exist, you're starting Session 1 — create it using
+  the template at the bottom of this prompt.
+
+# SESSION-START RITUAL (do this FIRST, every session)
+
+1. Read this whole prompt.
+2. Read the execution status file (or note it needs creating).
+3. Read the design doc end-to-end. Settled decisions are NOT debatable
+   (see "LOCKED" below).
+4. Read the implementation plan from the task you're about to start through
+   the next 1-2 tasks (don't read it all unless useful).
+5. `git status && git log --oneline -10` — confirm git matches the status
+   file. If they diverge, trust git.
+6. `npm run type-check && npm run lint` — confirm a clean baseline. If
+   either fails, the first task is to fix that, not to push forward.
+7. Tell me where you are and what task is next. Don't start coding until
+   I confirm orientation.
+
+# LOCKED DECISIONS — do NOT re-debate
+
+These were settled across multi-session brainstorming + 4 rounds of bot
+review. New concrete evidence can re-open them; generic "this could be
+better" arguments cannot.
+
+- Submission shape: intent-first (two-button picker → /submit/new or
+  /submit/revising). NOT hybrid gate, search-first, or original Option C.
+- Section 1 schema: ONLY the FK alter migration. The Phase-4 status guard
+  already exists at 20260428000008_phase_4_status_guard.sql; verify it,
+  don't modify it. No CHECK constraint.
+- Three sequential PRs in the order above. NOT a mega-PR.
+- PR2→PR3 gap mitigation: minimal yellow banner. NOT a confirmation modal,
+  NOT a feature flag, NOT a disable-radio.
+- Out of scope (captured as follow-ups in the design doc, do NOT scope-creep
+  into 8b): override-tracking admin view, extraction-failure recovery,
+  repeated-submission detection, prior-target restoration on review reload,
+  past-submissions-first picker, claim mechanism for concurrent reviewers.
+
+If you find yourself wanting to "improve" the design or plan mid-execution,
+STOP and surface it to the user. Don't unilaterally rewrite the spec.
+
+# HARD RULES (enforce every action)
+
+DATA SAFETY (top priority — supersedes velocity):
+- Schema changes ONLY through migration files. Never
+  mcp__supabase-remote__apply_migration for schema.
+- Before merging any DB-touching PR: wait for CI to apply migration to TEST,
+  then verify with mcp__supabase-test__execute_sql.
+- After PROD migration applies: verify with mcp__supabase-remote__execute_sql.
+  Mandatory — the migrate-production.yml Verify step has known SASL flakes,
+  so MCP verification is the source of truth.
+- When in doubt about touching prod data, ask first.
+
+MIGRATION DISCIPLINE:
+- Before touching any file in supabase/migrations/, invoke the
+  `database-migrations` skill via the Skill tool.
+- Verify the new migration's date prefix sorts AFTER the latest existing one.
+  Run `ls supabase/migrations/ | sort | tail -3` first. ASCII gotcha:
+  digits < underscore, so `20260504000000_x` sorts BEFORE `20260504_x`.
+
+PER-PR RITUAL (every PR, every time):
+1. Pre-push self-review: read every line of `git diff main...HEAD`.
+2. Run `npm run type-check && npm run lint` (mandatory pre-PR per CLAUDE.md).
+3. Push the feature branch.
+4. Open the PR with `gh pr create`.
+5. Dispatch your own feature-dev:code-reviewer agent on the PR BEFORE bot
+   reviews arrive. Investigate findings; verify each against actual code
+   before fixing. Push back where the bot is wrong (per
+   feedback_bot_review_investigation.md).
+6. Consolidated fix-up commits (do NOT amend pushed commits).
+7. ROUND-CAP AFTER 2 ROUNDS of bot review. If a 3rd round comes in, fix
+   only critical bugs, document the rest, ship. Diminishing returns hits
+   fast on iteration.
+
+WHAT NEVER TO DO WITHOUT EXPLICIT USER INSTRUCTION:
+- `git push` to main (commits go through PRs only)
+- Merge a PR
+- Approve a PROD migration in GitHub Actions
+- `bd` commands (beads is broken — use TaskCreate)
+- `git push --force` on any branch
+- Modify .beads/ files (leave them alone)
+- Re-write design doc or implementation plan to "improve" mid-execution
+
+WHAT'S OK without asking:
+- `git push -u origin feat/...` for the current feature branch
+- `git commit` on the feature branch (often, small)
+- `gh pr create` for the current branch
+- Reading anything, running tests, running type-check/lint
+- Dispatching review agents via the Agent tool
+
+VERIFICATION BEFORE COMPLETION:
+- Before claiming a task done, run the verification commands in that task's
+  spec. Evidence before assertions. Invoke the
+  `superpowers:verification-before-completion` skill if unclear.
+- "Tests pass" requires that you ran them and saw the green output, not
+  that the diff looks like it should pass.
+
+TDD WHERE APPROPRIATE:
+- The implementation plan flags TDD tasks explicitly. Follow the
+  failing-test-first → implement → green → commit loop. Don't skip the
+  failing-test step (it proves the test actually exercises the new code).
+- Invoke `superpowers:test-driven-development` for these tasks.
+
+# SESSION SCOPE
+
+Default: ONE task per session, or a small group of trivially-related tasks
+(e.g., create file + run test + commit = one task; that's fine). Stop at
+natural commit boundaries. Don't try to ship an entire PR in one session
+unless it's tiny (PR 1 might fit).
+
+If you finish a task with cycles to spare and the next task is small +
+independent, do it. If the next task is substantive, end the session.
+
+# SESSION-END RITUAL (do this LAST, every session)
+
+1. `npm run type-check && npm run lint` — both must pass.
+2. `git status && git log --oneline -5 origin/main..HEAD` — confirm what
+   landed.
+3. Update the execution status file:
+   - What got done this session (commit hashes + task IDs)
+   - Where the next session picks up (specific task ID + any setup needed)
+   - Any blockers, surprises, or decisions made
+   - Current branch + what's pushed vs. local
+4. Commit the status file.
+5. Tell me in 2-3 sentences what got done and what the next session picks
+   up. End there.
+
+# AUTO-LOADED MEMORY (already in your context, don't duplicate)
+
+Your auto-loaded MEMORY.md references include the per-PR-ritual, data-safety,
+bot-review-investigation, workflows-not-sacred, user-relearning,
+beads-broken, test-credentials, and database-pipeline reference memories.
+They apply throughout. Re-read them if a question comes up that they
+might cover.
+
+# EXECUTION STATUS FILE TEMPLATE (create on Session 1)
+
+If docs/plans/2026-04-27-phase-8b-execution-status.md doesn't exist, create
+it with this content:
+
+---
+# Phase 8b Execution Status
+
+**Last updated:** YYYY-MM-DD HH:MM by Session N
+**Current PR:** PR 1 — Schema (single FK migration)
+**Current task:** Task 1.1 (not yet started)
+**Branch:** main (not yet branched for PR 1)
+**Last commit on branch:** (none)
+
+## Done
+(empty)
+
+## In flight
+(none yet)
+
+## Blocked
+(none)
+
+## Decisions made during execution
+(things that came up that weren't in the design doc — e.g., "IntDuplicateCard's
+badge prop turned out to be named `badgeLabel` not `matchLabel`; fixed in
+commit abc1234")
+
+## Out-of-scope follow-ups captured here
+(things you noticed but did NOT do, because they're out of 8b scope; for
+the project status memory after 8b ships)
+---
+
+# RIGHT NOW
+
+Read this prompt → read design doc → read implementation plan from current
+task → read status file → run baseline checks → tell me where you are and
+what's next. Don't start coding until I confirm.
+```

--- a/supabase/migrations/20260504000000_phase_8b_fk_on_delete_set_null.sql
+++ b/supabase/migrations/20260504000000_phase_8b_fk_on_delete_set_null.sql
@@ -1,0 +1,37 @@
+-- =====================================================
+-- Migration: 20260504000000_phase_8b_fk_on_delete_set_null.sql
+-- =====================================================
+-- Description: Phase 8b Section 1 — re-create the FK on
+-- lesson_submissions.original_lesson_id with ON DELETE SET NULL.
+--
+-- Rationale: Phase 8b makes the submitter's binding intent ("updating
+-- lesson X") a first-class signal. If a reviewer or admin later
+-- deletes lesson X, the submission row should survive with its intent
+-- neutralized (original_lesson_id = NULL) rather than cascade-deleting
+-- the submission. The original FK had no ON DELETE clause (defaults to
+-- NO ACTION), which would block the lesson delete — also wrong, since
+-- a delete shouldn't be vetoed by an old submission's reference.
+--
+-- Section 1 of the design doc had a second item (RPC status guard) but
+-- that already exists from Phase 4 (see 20260428000008_phase_4_status_guard.sql),
+-- which refuses re-entry on terminal statuses ('approved', 'rejected').
+-- This file is the only schema migration needed for Phase 8b.
+
+ALTER TABLE public.lesson_submissions
+  DROP CONSTRAINT IF EXISTS lesson_submissions_original_lesson_id_fkey;
+
+ALTER TABLE public.lesson_submissions
+  ADD CONSTRAINT lesson_submissions_original_lesson_id_fkey
+    FOREIGN KEY (original_lesson_id)
+    REFERENCES public.lessons(lesson_id)
+    ON DELETE SET NULL;
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- ALTER TABLE public.lesson_submissions
+--   DROP CONSTRAINT IF EXISTS lesson_submissions_original_lesson_id_fkey;
+-- ALTER TABLE public.lesson_submissions
+--   ADD CONSTRAINT lesson_submissions_original_lesson_id_fkey
+--     FOREIGN KEY (original_lesson_id)
+--     REFERENCES public.lessons(lesson_id);


### PR DESCRIPTION
## Summary
- Re-creates `lesson_submissions_original_lesson_id_fkey` with `ON DELETE SET NULL`
- First of three Phase 8b PRs (schema → submitter flow → reviewer flow)
- Section 1's second item (RPC status guard) is already in production from Phase 4 (`20260428000008_phase_4_status_guard.sql`); no migration needed for it

## Why this matters
Phase 8b makes the submitter's binding intent ("updating lesson X") a first-class signal. The current FK has no `ON DELETE` clause (defaults to NO ACTION), which would veto a lesson delete with a vague constraint error if any submission references that lesson. `ON DELETE SET NULL` keeps the submission row intact (with intent neutralized) AND lets the lesson delete succeed.

See design doc: `docs/plans/2026-04-27-phase-8b-approve-update-redesign-design.md` §4. Implementation plan: `docs/plans/2026-04-27-phase-8b-approve-update-redesign-implementation.md` PR 1.

## Test plan
- [x] Local `supabase db reset` succeeds — migration applied cleanly
- [x] `pg_constraint.confdeltype = 'n'` and constraint def shows `ON DELETE SET NULL` (verified locally via MCP)
- [x] `npm run test:rls` shows no NEW failures (the 2 failing scenarios — `archive_duplicate_lesson` checks — are pre-existing on `main`)
- [x] `npm run type-check && npm run lint` clean
- [x] Pre-push code-reviewer agent dispatched (no critical findings)
- [ ] After CI applies migration to TEST DB, verify via `mcp__supabase-test__execute_sql` that the FK shows `ON DELETE SET NULL`

## Note for reviewers — extra commits in this PR
Local `main` is currently 9 commits ahead of `origin/main` — those are the Phase 8b kickoff/design/implementation-plan doc commits from prior sessions. Branched off local `main`, so this PR currently shows those 10 commits (9 docs + 1 migration). When this PR merges, the docs land on `origin/main` along with the migration, which is the intended state. The single SQL migration is the only schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)