### PR TITLE
feat(metadata-foundation): PR 4 — corpus cleanup (21 imports retired)

### DIFF
--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status-archive.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status-archive.md
@@ -1591,3 +1591,420 @@ Source: round-5 bot finding (long-form formal F2 + line `lessonToReviewMapper.ts
 - **PR 2 rebase plan.** `git checkout feat/metadata-foundation-llm-tagging && git rebase main` (main at `bd9d6e4`). Conflict on `complete_review_atomic` — PR 2's `20260517000000_*` `CREATE OR REPLACE` collides with PR 1b's `20260518100000_*` `CREATE OR REPLACE`. Resolution: keep PR 1b's body (array passthrough for `activity_type`) AND re-fold PR 2's `tags` side-channel (write surface for the LLM-drafted `tags` array) into the same body. Verify via `mcp__supabase-test__execute_sql pg_get_functiondef('complete_review_atomic'::regproc)` post-rebase to confirm BOTH code paths survive. Then continue PR 2 work (Tasks 2.4+2.5 eval gates, etc.).
 
 - **PR-cycle archival.** At start of PR 2 work, move Sessions 28-36 from active file into archive file. Per kickoff: "Audit each entry as you move it for any process learnings worth promoting to `~/.claude/projects/.../memory/feedback_*.md` files OR hygiene follow-ups worth promoting to MEMORY.md." Candidates this cycle (collected during Session 36): stale-doc-header pattern (3-occurrence confirmation; possibly worth a `feedback_*.md`), empirical-evidence-escalates-low-confidence-finding pattern (Session 34 Codex P2 #1 → 113 rows actually crashing; good `feedback_pr_bot_review_workflow.md` candidate addition), type-coupled cluster impl-plan flaw (Session 30 — when schema-shape changes touch multiple consumer files, decompose-by-file impl plans break tsc invariants mid-session; worth a feedback note about cluster framing).
+
+---
+
+# Sessions 37-46 — PR 2 ritual cycle (CRF + activity_type LLM auto-tag)
+
+Archived 2026-05-08 (Session 47, start of PR 4 cycle). PR 2 lifecycle covered:
+- Session 37: PR-cycle archival of Sessions 28-36 + 2 feedback promotions to `feedback_pr_bot_review_workflow.md`
+- Session 38: PR 2 rebase onto PR 1b via cherry-pick (vanilla rebase would have hit ~13 docs conflicts; cherry-pick of 7 code commits + bundled Sessions 36/37 docs)
+- Session 39: Task 2.4 step 1 — activity_type prompt + worksheet v2 stub + harness `maxPredictionRateForAbsentValues` guardrail
+- Session 40: Task 2.4 step 2 — worksheet labels parsed; activity-type-samples.json built (113 entries)
+- Session 41: Task 2.4 step 3 — activity_type eval gate cleared at macroF1=0.887 with Rule Y hybrid garden semantics (3 canonical runs + 1 smoke)
+- Session 42: Task 2.4 step 4 — activity_type wired into process-submission/index.ts with RMW merge into ai_draft_metadata
+- Session 43: PR 2 OPENED as #477 — pre-push reviewer agent dispatched (0 P0/P1 + 2 P2 fix-ups + 4 rejects); Tasks 2.4 + 2.5 deferred
+- Session 44: Round 1 fix-ups — migration rename (back-sort fix `20260516000000` → `20260518200000`) + CodeQL regex slice
+- Session 45: Round 2 fix-ups — 1 accept (CRF test coverage in reviewMetadataInit.test.ts) + 6 rejects + round-cap activated
+- Session 46: PR 2 SHIPPED — squash commit `cf2aad4` on main 2026-05-07T21:34:06Z; PROD migrations applied + edge fn deployed; 4/4 PROD MCP probes confirmed substrate
+
+Process learnings collected during the cycle that stayed as watch-patterns in the active file's "Recent decisions worth carrying forward" (single-occurrence; promote to `feedback_*.md` if they recur):
+- Cherry-pick approach over `git rebase` when stale-docs would generate multi-commit conflicts (Session 38)
+- Rebase-rename-sweep: rename ALL stale-timestamp migration files post-rebase, not just body-conflicting ones (Session 38, surfaced via Session 44 round 1 back-sort fix)
+- `database-migrations` skill rule has a documented exception class for filename/timestamp bugs when no remote DB has the migration applied (Session 44)
+
+Promotion candidate flagged but deferred to Session 47:
+- Pre-PROD-apply MCP probe pattern (Session 46) as distinct from per-round TEST DB verification — both axes apply independently. Worth appending to `feedback_per_round_test_db_verification.md`.
+
+Cost actuals from PR 2's eval-gate work (Session 41):
+- Console API direct billing ~$2 per 113-sample canonical activity_type run (vs ~$30 via CLIProxyAPI proxy with `cache_read=0` cost gotcha; ~15× ratio confirmed). Future eval runs with budget pressure should use direct Console API.
+
+### Session 37 — 2026-05-07 — PR-cycle archival + 2 feedback promotions
+
+**Done (1 docs commit on `docs/session-36-pr1b-shipped`, accumulating with Session 36's `c6b68f7`):**
+
+- **Moved Sessions 28-36 from active file into archive** per kickoff session-end ritual step 5 ("PR-cycle archival, do at the START of each new PR cycle"). Active file shrunk from 392 lines to ~95 lines (Current State + decisions + out-of-scope + pointers + this single session entry). Archive grew by 9 sessions (PR 1b cycle: Tasks 1b.1-1b.8 implementation Sessions 28-32 + PR push/round-1/round-2/ship Sessions 33-36).
+
+- **Reconstructed missing Session 34 header.** During the move the source file was missing `### Session 34 — 2026-05-06 — PR 1b round 1 bot triage + fix-up shipped (commit \`131168b\`)` between Sessions 33 and 35 (3 blank lines where the header should have been; body started at "**Done (1 commit + 1 docs commit pending):**"). Fix-up reconstructed from cross-references in surrounding sessions: Session 35's "Round-cap-of-2 rule activated for round 3+" + Session 36's "round-2 fix-up's CI completion" + Out-of-scope follow-up's `131168b` reference all triangulate to Session 34 = round-1-fix-up. Committed the reconstruction as part of the archive append.
+
+- **Promoted 2 patterns to `feedback_pr_bot_review_workflow.md`** per Session 36's process notes (which explicitly flagged them as candidates for promotion):
+  1. **Empirical evidence can escalate a single-voice low-confidence finding to P0.** From Session 34 (PR 1b round 1): Codex P2 #1 framed as "2 historical rows"; TEST + PROD MCP probe revealed all 113 historical scalar `tagged_metadata.activityType` rows had the bad shape, every reviewer reopen crashing to error boundary. Reachable via 'approved'/'all' filter — mainline. The pattern: for any single-voice finding citing a small row count, run the corresponding MCP probe before triage; the escalation can be load-bearing.
+  2. **Active-PR session-orientation rule (always check PR review state at session-start).** From the 4-occurrence pattern across Sessions 33→34→35→36: when a session opens and the prior session's status doc claims "N commits unpushed" or "awaiting round N", that's stale because the prior session's docs commit didn't push (per `feedback_no_docs_push_during_pr.md` they bundle with next fix-up), CI ran on the pushed fix-up, bots reviewed it, round N+1 fired between sessions. Mitigation: at session-start, run `git log @{u}..HEAD` AND `gh pr view <PR> --json reviews,comments` for any active PR. Trust git + live PR state; refresh Current State header inline before proceeding.
+
+- **Type-coupled cluster impl-plan flaw NOT promoted (single occurrence).** Session 30 surfaced this in PR 1b — schema-shape change cascaded through Tasks 1b.3 + 1b.4 + 1b.5 type-couplings, breaking tsc invariants if shipped piecemeal. The note explicitly self-described as "candidate for `feedback_*` if it recurs"; PR 1b's later sessions (31, etc.) had truly independent tasks (Session 31 explicitly noted the contrast) so no recurrence yet. Stays in the active file's Recent decisions section as a watch-pattern for PR 2+; promote if it recurs.
+
+- **Audit pass on Out-of-scope follow-ups** — no new resolutions to remove, no new entries to add. Current 12 entries all carry forward.
+
+**Decisions made:**
+
+- **`docs/session-36-pr1b-shipped` accumulates Session 37's commit too** rather than branching for the archival. Per kickoff session-end ritual step 4 ("Commit the status file"), this session's docs work commits on the current branch. The carrier choice (bundle into rebased PR 2 OR open standalone docs PR) was already deferred from Session 36; deferring it again to Session 38 is the cleanest call. The branch now holds 2 commits ahead of main: Session 36's status update + Session 37's archival.
+
+- **Did NOT delete the merged feature branches** (`feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema`). Per past PR 1 + PR 1b precedent ("deletable at convenience"), branch retention is user-side cleanup. Keeping them avoids any risk of deleting work that hasn't fully replicated forward; user can run `git branch -D` at any time.
+
+- **Did NOT touch `feat/metadata-foundation-llm-tagging`** (PR 2 branch). Rebase work is the substantive next-session task; archival session stays scoped to docs-only changes per kickoff "ONE task per session" guidance.
+
+**Process notes for Session 38+:**
+
+- **Order on next session:** PR 2 rebase first (substantive), then carrier choice (small follow-up). The PR 2 rebase is non-trivial (`complete_review_atomic` `CREATE OR REPLACE` collision + tags side-channel re-fold + migration timestamp rename to sort after `20260518100000_*`). Plan: `git checkout feat/metadata-foundation-llm-tagging && git rebase main`, work the conflict via Edit, verify via `mcp__supabase-test__execute_sql pg_get_functiondef(...)` post-rebase, commit-amend the rename + body merge as one logical fix-up.
+
+- **Carrier choice options for the docs commits.** Bundle into rebased PR 2: simplest, no extra PR overhead, but the docs commits land in PR 2's history under PR 2's title. Open a standalone docs PR: cleaner separation, but adds PR overhead for what's effectively just session-end housekeeping. The bundle path matches `feedback_no_docs_push_during_pr.md` spirit (don't burn CI cycles on docs-only pushes).
+
+- **Watch the type-coupled cluster pattern.** PR 2's Task 2.4-2.5 will write to columns + Zod + mappers + edge function (LLM auto-tag wires across all four surfaces). If the impl plan has decompose-by-file ordering and any task introduces a type-shape change, expect tsc-break invariants to require cluster shipping like Session 30. Better to plan cluster commits up front than rediscover the pattern.
+
+### Session 38 — 2026-05-08 — PR 2 rebase onto PR 1b (main `bd9d6e4`) + Sessions 36+37 docs bundled
+
+**Done (10 commits on `feat/metadata-foundation-llm-tagging` after rebase, accumulating with this session-end docs commit):**
+
+- **Rebased PR 2 onto `bd9d6e4`** (main with PR 1b shipped) via cherry-pick approach. `git reset --hard main` + cherry-picked 7 code commits in chronological order (the 13 stale docs commits from PR 2 dropped). New SHAs: `66ad77d` (Task 2.2a — ai_draft_metadata columns) → `97c35ab` (Task 2.2b — ReviewDetail reads draft, autosquashed test fix-up included) → `1e9fa8a` (Task 2.2c — tags side-channel migration RENAMED + body merged) → `7cd2a3f` (Task 2.2 — eval-gate harness) → `5eeaf47` (Task 2.3 partial — CRF eval inputs) → `efefcff` (Task 2.3 ship — CRF canonical run) → `67a3cd7` (Task 2.3 step 5 — CRF auto-tag in process-submission edge fn).
+
+- **Migration rename + body merge** (commit `1e9fa8a`). Renamed `20260517000000_complete_review_atomic_tags_side_channel.sql` → `20260519000000_*` so it sorts AFTER PR 1b's `20260518100000_complete_review_atomic_activity_type_multi.sql`. Body re-folded to carry both: PR 1b's array-passthrough for `activityType` (INSERT site uses `_phase4_jsonb_text_array(v_meta->'activityType')`; UPDATE site uses `_phase4_jsonb_text_array_or_null(v_meta->'activityType')` + COALESCE chain) AND PR 2's tags side-channel (declare `v_ai_draft jsonb`, pluck from `v_submission.ai_draft_metadata`, write `tags` column in INSERT, carry-forward `tags` in UPDATE). Header comment documents the rebase + rename context for future readers; rollback comment updated to point at PR 1b's body as the revert target. ROUND of CREATE OR REPLACE preserved grants; signature unchanged.
+
+- **Test fix-up for `reviewMetadataInit.test.ts`** (autosquashed into `97c35ab`). PR 2's original test expected `activityType: 'cooking'` (scalar) per merge-base `lessonToReview` mapper signature; PR 1b changed `lessonToReview` to return arrays, so the test had to update to `activityType: ['cooking']`. Auto-squashed via `git commit --fixup=<sha>` + `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash bd9d6e4` so the per-commit invariant "every commit's tests pass" holds for git bisect. Other 5 tests in `reviewMetadataInit.test.ts` (null/undefined inputs, schema-failure cases, empty draft) all unchanged.
+
+- **Bundled Sessions 36 + 37 docs into PR 2.** Cherry-picked `c6b68f7` (Session 36 — PR 1b SHIPPED + PROD-applied + verified) + `af431f8` (Session 37 — PR-cycle archival + 2 feedback promotions) onto rebased PR 2 branch. Both applied cleanly (status doc + archive only; no code overlap). Carrier choice resolved per Session 37's deferred decision: bundle into PR 2 over standalone docs PR.
+
+- **Local DB rebuild verified.** `supabase db reset` ran cleanly (all migrations applied; seed complete: 5 lessons + 3 users). Final `complete_review_atomic` body inspected via `mcp__supabase__execute_sql pg_get_functiondef` — 6/6 verification signals YES (declare + pluck + INSERT array passthrough + UPDATE array passthrough + INSERT tags from draft + UPDATE tags carry-forward). Schema check confirms `lesson_submissions.ai_draft_metadata jsonb` / `lessons.tags ARRAY` / `lessons.activity_type ARRAY` / `lessons.lesson_format` dropped. Migration list shows `20260516000000` → `20260518000000` → `20260518100000` → `20260519000000` (correct order; orphan `20260517000000_*` is gone). 569/569 tests passing.
+
+- **Backup branch `backup/feat-metadata-foundation-llm-tagging-pre-rebase` created** before `git reset --hard main`. Allows recovery of the original 20-commit PR 2 branch if rebase needs to be undone. Deletable after PR 2 ships.
+
+**Decisions made:**
+
+- **Cherry-pick approach instead of `git rebase main`** (captured as new bullet in "Recent decisions worth carrying forward"). Vanilla rebase would have hit ~13 separate docs conflicts (one per docs commit since main's docs are now PR 1b's Session 37 archival state vs PR 2's older Session 17-27 layout). Cherry-picking only the 7 code commits bypassed all docs conflicts; docs re-bundled cleanly via fresh cherry-picks + this session-end docs commit.
+
+- **Migration sort-key `20260519000000`** chosen to sort cleanly after PR 1b's `20260518100000_*`. Convention: when same-day or adjacent migrations conflict, advance one full UTC day to dodge the digits-vs-underscore ASCII gotcha (per MEMORY.md migration-naming note). Today's actual date is 2026-05-08; `20260519` is purely a sort key.
+
+- **Bundle Sessions 36 + 37 docs into PR 2** (carrier choice resolved per Session 37's deferred decision). Cherry-picked into rebased PR 2 branch directly; standalone docs PR rejected as overhead-heavy for what was effectively PR 1b's session-end housekeeping. Matches `feedback_no_docs_push_during_pr.md` spirit — no separate CI cycle for docs-only changes.
+
+- **Test fix-up auto-squashed instead of standalone fix-up commit.** Per-commit "tests pass" invariant matters for git bisect; the test was correct vs the merge-base mapper but wrong against the rebased mapper, so it semantically belongs IN the cherry-picked Task 2.2b commit, not as a follow-up.
+
+- **Did NOT delete merged feature branches or `docs/session-36-pr1b-shipped` this session.** Per past PR 1 + PR 1b precedent ("deletable at convenience"), branch retention is user-side cleanup. Leaving them in place avoids any risk of deleting work that hasn't fully replicated forward; user can `git branch -D` at any time.
+
+**Process notes for Session 39+:**
+
+- **Vanilla `git rebase` is rarely the right primitive when stale-docs commits are involved.** The cherry-pick approach generalizes: identify the substantive (code/feature) commits vs the housekeeping (docs/status) commits; cherry-pick only the substantive set; re-run docs work fresh at the end. Watch for recurrence of this pattern; promote to feedback memory if it happens again on a future rebase.
+
+- **Watch the type-coupled cluster pattern in Task 2.4.** PR 1b's Session 30 learning: when a task's schema-shape change touches Zod + mappers + consumer files + tests, ship as one cluster commit, not decomposed by file. Task 2.4 (activity_type prompt) is more contained than PR 1b's Task 1b.3-1b.5 cluster, but if it adds new vocab keys or field shapes, watch for the pattern.
+
+- **TEST DB verification deferred until PR 2 push.** Rebase substrate work is local-only this session; TEST DB will get the new migrations + edge fn updates when PR 2 opens (CI applies). Per-round verification rule applies to PR rounds (round 0 = initial open), not pre-PR sessions. The 6/6 RPC body signals + schema check via local MCP at session-end give high confidence that TEST will be clean on first apply.
+
+### Session 39 — 2026-05-06 — PR 2 Task 2.4 step 1: activity_type prompt + worksheet v2 stub + harness absent-values guardrail
+
+**Done (1 code commit `fccd05e` + this session-end docs commit pending):**
+
+- **Activity_type prompt** at `supabase/functions/process-submission/prompts/activity-type.md` (47 lines). Mirrors CRF prompt structure: role intro → 4 canonical values with example agenda blocks → selection rules with substantial-block bar + tie-breakers → input format (priority order: agenda timed blocks > summary > skills lists > title) → output via `submit_tags` tool, multi-label.
+- **Vocab + thresholds + samples README** scaffolded under `scripts/eval-data/activity-type-{vocab,thresholds,samples.README}.{json,md}`. Vocab matches `ACTIVITY_TYPE_VALUES` from `_shared/metadataSchemas.ts` (4 values, multi-label). Thresholds carry CRF baseline (macroF1=0.7 + minRecallPerValue=0.5) plus the new `maxPredictionRateForAbsentValues=0.10` guardrail. README documents methodology + regeneration SQL + harness invocation + the craft-zero-truth caveat.
+- **Worksheet v2** at `scripts/eval-data/activity-type-relabel-worksheet-v2.md` (2331 lines, 113 entries). Pulled all 113 reviewer-tagged submissions from TEST DB via 4 chunked MCP queries (offset 0/30/60/90, limit 30 each). Each entry: numbered header with title, submission_id + old single-label + body length, summary excerpt (350 chars via SQL `SUBSTRING ... FOR 350` from `position('summary' IN lower(content))`) + agenda excerpt (500 chars from `position('agenda' IN lower(content))`) in `<details>` blocks, empty `**New labels (multi-label):**` line. SQL extracts already replaced newlines with spaces via `REGEXP_REPLACE` so excerpts are single-line; titles with stray `` (vertical tab) characters cleaned during formatting. Two duplicate-title rows (entries 104 + 105: "Welcome and Exploration: How humans work in the garden") flagged inline as "duplicate submission" with byte-identical bodies.
+- **Harness `maxPredictionRateForAbsentValues` threshold** added to `scripts/lib/evalMetrics.ts` (~12 LOC). When a vocabulary value has `truthCount === 0` AND `sampleCount > 0`, computes `predictionCount / sampleCount` and fails if > ceiling. Failure message names the value + the rate + the absent-from-truth context: `prediction rate X.XXX for "<value>" exceeds ceiling Y when value is absent from truth (N of M samples)`. Threshold schema mirror in `scripts/eval-llm-tagging-prompt.ts` updated; help text extended with the new flag. 4 new unit tests added (above-ceiling fail; at-ceiling pass; truthCount>0 no-op; empty-input no-op); 21/21 evalMetrics tests passing.
+- **Comment block on the new threshold key** documents the WHY: CRF's reference set has truth coverage for all 7 features (truthCount ≥ 48 per feature on 353 rows); activity_type's reference set may have zero craft labels under old vocab so per-value craft recall is undefined, but a runaway false-positive rate is still a fail. Generalizes to any vocabulary value missing from truth; not craft-specific.
+
+**Decisions made:**
+
+- **Worksheet body excerpts use `<details>` blocks rather than blockquotes or markdown tables.** v1 used `<details>` and the format read cleanly during reviewer triage. Blockquotes would force line-by-line `>` prefixing on multi-line excerpts; tables would break on the `|` characters embedded in Google-Docs-table-extracted bodies. `<details>` keeps the worksheet visually compact when scrolling and lets the reviewer expand only the rows where summary alone is ambiguous.
+- **Single SQL substring window per excerpt section, not full-body context.** Pulled 350 chars of summary + 500 chars of agenda per row. Tried full-body excerpts in the first sample query (~5K-17K chars/row) — would have hit MCP's 25K-token output cap inside 5 rows. Trimmed to the structurally-meaningful sections (Summary cell + Agenda cell) where body content has predictable shape. If reviewer needs longer context for any row, regeneration SQL is documented in the samples README + the worksheet footer offers per-row pull on request.
+- **Pre-formatted markdown via SQL string concatenation considered, rejected.** Could have built the row markdown inside the SQL `SELECT` and pasted output verbatim; would have saved ~20% of the formatting cost client-side. Tradeoff: harder to debug if format glitches; tighter coupling between query + worksheet structure. Decided client-side formatting is more flexible for the one-off worksheet build (per-row tweaks easier).
+- **No "Reviewer's Distilled" line per row.** v1 had Claude-pre-summarized 1-sentence synopses per row. v2 omits — the summary excerpt + agenda excerpt are already pulled from the body, and reviewer-side reasoning is more grounded when working from raw body excerpts than from Claude's pre-judgment. Cuts ~$30 in API cost (113 reads × Opus body summarization) + ~30 min of session-side processing time. Worth it.
+- **maxPredictionRateForAbsentValues uses `>` not `>=`** for the ceiling comparison. A rate exactly at the ceiling passes, mirroring `minRecallPerValue` semantics where the floor compares with `<`. The unit test "passes when an absent-from-truth value is predicted at or below the ceiling" exercises the edge case at rate=0.1, ceiling=0.1.
+- **Threshold key named for the general principle, not the specific use case.** `maxPredictionRateForAbsentValues` rather than `maxCraftRate` or `craftGuardrail`. Future eval gates may have other vocabulary values absent from a given truth set (e.g., a tags eval where neither orientation nor bilingual_handouts shows up in the user's labeling); this rule fires for all of them automatically.
+
+**Process notes for Session 40+:**
+
+- **User labeling is the bottleneck.** Worksheet v2 stub stops at the empty `**New labels (multi-label):**` lines; user fills 113 rows over ~2-3 hrs. Resume after user signals done. Parser to write Session 40 will be similar shape to whatever ad-hoc parsing CRF samples used; if no formal parser exists, build a small `scripts/build-activity-type-samples.mjs` that reads worksheet markdown + writes samples.json.
+- **Watch for the CLIProxyAPI cache_read=0 cost gotcha at canonical eval time.** Per Session 25 + MEMORY.md, every harness call through the proxy shows `cache_read=0` even with explicit `cache_control: ephemeral`. Per-call cost ~3-4× direct Console API rates. Activity_type canonical run on 113 samples expected ~$30 via proxy vs ~$7 direct. User has $200 Max extra-usage budget; ~6 prompts at proxy rates fits, but if running tight, drop the `--base-url` flag and bill against Console API instead.
+- **No type-coupled cluster pattern fired this session.** Per Session 30 PR 1b learning, schema-shape changes touching Zod + mappers + edge fn + tests need to ship as one cluster commit. Task 2.4 step 1 added a new threshold key to one file (evalMetrics.ts) + threshold-schema mirror in one file (eval-llm-tagging-prompt.ts) + threshold-config JSON + unit tests; no schema-shape change. Watch for the pattern at Task 2.4 step 4 (wire into process-submission/index.ts) — should mostly be additive (one more `loadX()` + one more Anthropic call + one more Zod validation), no type narrowing across consumers.
+
+### Session 40 — 2026-05-06 — PR 2 Task 2.4 step 2: worksheet labels + samples.json built
+
+**Done (1 code commit `a426114` + this session-end docs commit pending):**
+
+- **User completed worksheet labels** between sessions: 113/113 entries filled in, 0 invalid labels (all in canonical 4-value vocab `cooking / garden / academic / craft`), 0 empty lines. Local pre-build parse confirmed parseability before any DB work. Per-label distribution: garden 68 / cooking 34 / craft 13 / academic 11; 12 multi-label rows (10.6%, range 2-2 labels per multi row). Old-vs-new shifts: garden 67→68, cooking 33→34, academic 11→11 (unchanged), `both` 2→0 (retired; expressed as `cooking, garden`), craft 0→13 (new value; reviewers were forced to mis-classify these in the old vocab).
+
+- **Bodies pulled from TEST DB via `mcp__supabase-test__execute_sql`** in a single query (id + extracted_content for the 113 reviewer-tagged submissions, ordered `extracted_title NULLS LAST, ls.id` matching worksheet order). 113-row payload was 696,399 chars (~700KB) and exceeded the inline MCP cap; the persisted-output file path was returned in the error message. Extracted the JSON-wrapped result via small `extract-bodies.mjs` helper that parses outer JSON → inner JSON → regex match between `<untrusted-data-XXX>` markers → bodies array. Written to `/tmp/activity-type-bodies.json` (intermediate, not committed). 113 unique IDs; perfect overlap with worksheet IDs (0 missing, 0 extra).
+
+- **Built `scripts/build-activity-type-samples.ts`** (200 LOC, npx tsx). Mirrors harness style (zod schema validation, similar argv parsing, similar logging output). Reads worksheet via regex split on `^---$` then per-chunk extraction of `- **ID:** \`uuid\`` and `**New labels (multi-label):** values` (strip inline `<!-- -->` comments before split-by-comma + trim + lowercase). Reads bodies dump + vocab JSON. Validates: every worksheet ID has a body in the bodies dump; every truth label is in vocab; no entry has an empty/missing label line. Exits 0 on success / 1 + per-error report on validation failure. De-duplicates within a single label list with a warn log if duplicates collapsed (none triggered).
+
+- **Ran build → emitted `scripts/eval-data/activity-type-samples.json`** (805 lines, 664KB, 113 entries). Schema matches harness's `sampleSchema = z.object({id, body, truth: string[]})`. Total body chars 652,580 matches MCP sanity query.
+
+- **Verified end-to-end via perfect-prediction dry-run** (no API spend): generated truth-as-predicted from samples.json via 1-line node helper, ran `--dry-run-with-predictions` against full 113-row sample set with all thresholds active. Result: `samples=113`, all per-value P=R=F1=1.000, macroF1=microF1=1.000, exit 0. Confirmed: harness's zod sampleSchema parses; truth-in-vocab validation passes; metrics math runs across all 4 values; threshold logic evaluates; output file format intact.
+
+- **Updated `activity-type-samples.README.md`**: replaced "Eval-gate caveat — `craft` may have zero truth labels" section with "Eval-gate guardrails — actual state after relabeling" reflecting craft truth count = 13 (guardrail dormant, per-value P/R applies); expanded distribution table with both pre- and post-relabel columns; added "How samples.json was built" pipeline section documenting the bodies-pull → build-script invocation. Total body chars + min/max/avg added so future readers can size their MCP pulls.
+
+**Decisions made:**
+
+- **Single full-pull MCP query over chunked batches.** Initial plan was 12 batches of 10 rows (113 rows / 100K-char inline cap = ~12 batches at avg row size). After running batch 0/12 and seeing the persisted-output mechanism fire on the very first batch, realized persistence already bypasses the inline cap — switched to a single 113-row query. Saved 11 round-trips. The `Error: result (696,399 characters) exceeds maximum allowed tokens` is not a failure mode; the persisted file path is fully usable.
+
+- **Build script committed (not ad-hoc).** CRF samples were assembled ad-hoc with no committed build script (verified via `git show 5eeaf47 --stat`); v2 of activity_type takes a different path because (a) Session 39's process notes explicitly called for a build script, (b) Task 2.5 (tags) and any future Gate-C-classified vocab-locked prompts will need similar parser infrastructure, (c) the worksheet → samples.json reproduction is high-leverage to keep machine-driven (avoids manual JSON crafting + paste mistakes). 200 LOC TS file mirrors the harness's style for maintainer continuity.
+
+- **`/tmp/activity-type-bodies.json` intermediate not committed.** Same rationale as CRF's pull (no committed bodies dump): the bodies are already in samples.json once merged, and the regeneration recipe in README + the build-script invocation cover reproducibility. Avoids duplicating ~700KB of body text across two committed files.
+
+- **Worksheet labels committed in the same commit as samples.json + build script.** Worksheet labels are the source-of-truth that drove samples.json; bundling them keeps the data lineage visible in one commit. Matches the way Session 39 bundled prompt + worksheet stub + harness extension into a single Task 2.4 step 1 commit.
+
+- **README distribution table given both pre- and post-relabel columns.** Earlier README had only pre-relabel (single-label) distribution; post-relabel (multi-label) adds a "count truth-occurrences" framing that's cleaner than trying to express multi-label in row-counts. The split also visually shows the `both` retirement and the craft surfacing.
+
+**Process notes for Session 41+:**
+
+- **CLIProxyAPI vs Console API decision required before Task 2.4 step 3.** Per MEMORY.md, proxy adds cache_read=0 → ~3-4× cost vs direct Console API. Activity_type canonical run on 113 samples: ~$30 proxy / ~$7 direct. User's $200 Max extra-usage budget covers ~6 prompts at proxy rates, but if running tight on budget, drop the `--base-url` flag and bill against Console API. CRF run (Session 25) used proxy at $30.23. The decision should surface to the user before the run, not be silently chosen.
+
+- **Most-likely-fail values on canonical run: craft (over-prediction) or academic (small denominator).** Craft: prompt biases toward conservative tagging (substantial-block bar) but `academic, craft` and `craft` are easy to over-recall on lessons with substantial closing art segments. Per-value floor 0.5 recall on 13-row truth = need ≥ 7/13 craft TPs and per-value precision floor not in thresholds. Academic: 11-row truth means each missed academic = 0.091 recall drop; LLM probably tags more conservatively than reviewers on subtle academic-discussion frames. If gate fails, study the per-value confusion in the JSON output before iterating prompt.
+
+- **Watch for the type-coupled cluster pattern at step 4.** Wiring activity_type into `process-submission/index.ts` should be structurally parallel to CRF's wire-up (Task 2.3 step 5, commit `67a3cd7`): one new prompt-load helper, one new Anthropic call, one new Zod-validate-into-`ai_draft_metadata`. Likely additive, no type narrowing — but if a shared interface like `AiDraftPayload` needs widening, ship as one cluster commit covering edge fn + Zod schema + any consumer reads.
+
+- **No PR 2 push this session.** Branch is now 13 commits ahead of main. PR 2 push waits on Tasks 2.4 (3-5) + 2.5 closure. Bundle session-end docs commits with the next code push (`feedback_no_docs_push_during_pr.md` spirit: don't burn CI cycles on docs-only changes).
+
+### Session 41 — 2026-05-07 — PR 2 Task 2.4 step 3: activity_type eval gate cleared + Rule Y hybrid garden
+
+**Done (1 code commit `5e25431` + this session-end docs commit pending):**
+
+- **Canonical eval gate cleared at macroF1=0.887** (gate floor 0.700) on the post-Rule-Y truth set. Per-value F1: cooking 0.889 / garden 0.809 / academic 1.000 / craft 0.852. Macro recall 0.956 / macro precision 0.836. Result file `/tmp/activity-type-eval-result-v3.json` (not committed; CRF pattern doesn't commit eval results).
+
+- **Rule Y design call (mid-session)**: user introduced `garden` as a hybrid tag firing for both hands-on garden activity AND food/agriculture/garden topical content. `academic` becomes mode-exclusive and narrow. The user authored this rule mid-session after seeing v2's failure mode (garden→craft confusion) revealed the reviewers had been using "garden" both topically (lesson is about pollinators / food systems / etc.) and activity-based (students do hands-on garden work) inconsistently across samples. Rule Y disambiguates: garden is hybrid by design; academic is the rare narrow fallback for non-food/non-garden conceptual content (e.g., The Lorax Debate).
+
+- **17 truth retags applied** via one-off helper `/tmp/apply-retags.mjs` (not committed; intentional — script reads `/tmp/retag-pairs.json` and edits worksheet markdown by ID-matching regex):
+  - 7 `[academic]` → `[garden]` or `[garden, craft]` (food/agriculture topical lessons that previously got academic by reviewer judgment): Meet The Food System; African American Food Traditions; Foods From Around the World; How Food Moves (Food Miles); School Lunch Heroes (added craft); The Apple Story (added craft); The Ugly Vegetables (added craft).
+  - 10 `[garden]` → `[garden, craft]` (lessons that already had garden topical truth but had substantial craft activity reviewers didn't tag): All About Birds, Anthotype, Bug Camouflage, Butterflies, Exquisite Plants, Ladybugs, Garden Community, Tea Bags, Honey Bee Pollinators, What Gardeners Wear.
+  - The Lorax Debate stays as the sole `[academic]` entry — deforestation/environmentalism, not food/agriculture.
+
+- **Iteration trajectory** (3 full canonical runs + 1 smoke):
+  - Smoke (5 samples, original prompt): macroF1=0.756 on tiny denominator; passed gate but unrepresentative — only 1 of 5 samples exhibited the academic FP problem.
+  - v1 full (113 samples, original prompt): macroF1=0.605 — failed. Academic FPs 72 of 113 (LLM tagged academic on 73% of lessons; reviewers tagged it on 11). Confusion matrix revealed dominant pattern: opening rituals + closing reflections triggering academic across hands-on lessons.
+  - v2 full (113 samples, mode-exclusive academic prompt + 3 academic-handson outlier retags): macroF1=0.670 — failed (improved by 0.065 but didn't clear). Academic FPs dropped 72→6 (massive precision improvement); but garden FNs grew 19→23 via new garden→craft confusion pattern (LLM read garden-themed-craft lessons as `[craft]` instead of `[garden]`). User's analysis: reviewers were using "garden" both topically and activity-based; the v2 prompt forced activity-based interpretation, dropping topical garden tags.
+  - **v3 full (113 samples, Rule Y prompt + 17 retags): macroF1=0.887 — passed.** Garden recall now 1.000 (was 0.667 in v2); garden precision 0.679 (LLM aggressive on topical tag, fits draft-validate use case where reviewers easily remove extras).
+
+- **README updated** (`scripts/eval-data/activity-type-samples.README.md`):
+  - Distribution table extended to three columns: pre-relabel old vocab / post-v2-relabel / post-Rule-Y retag.
+  - Added "Canonical run result (Session 41)" block with full per-value metrics + actual cost.
+  - Updated cost note: Console API direct ~$2 per 113-sample run (was $7 projection; ~3-4× cheaper than CLIProxyAPI proxy as expected).
+
+- **Cost actuals**: Console API direct billing ~$2 per full canonical run (vs my $5.43 estimate; vs $30 via CLIProxyAPI proxy with `cache_read=0` cost gotcha). User tracked actuals from Anthropic console; my pricing estimates were ~3× over. Total session spend: ~$6 of $9 budget (smoke $0.13 + v1 $2 + v2 $2 + v3 $2). ~$3 budget margin remaining.
+
+**Decisions made:**
+
+- **Direct Console API over CLIProxyAPI proxy** for this run. User had $9 in console credits; proxy would have cost ~$30 via Max billing (cache_read=0 gotcha). Decision: swap `ANTHROPIC_API_KEY` in `.env.local` for a Console key (`sk-ant-api03-...`), keep proxy key under separate name `ANTHROPIC_CONSOLE_API_KEY`, use shell prefix `ANTHROPIC_API_KEY="$(grep ... .env.local | cut -d= -f2)"` to inject at runtime without polluting shell history. dotenv's `override: false` default keeps shell env winning over `.env.local`. Both keys coexist; future runs can pick which billing path.
+
+- **Smoke-then-full vs straight-to-full**: did smoke first ($0.13) to verify Console key works + measure per-call cost. Smoke passed (macroF1=0.756 on 5) but had unreliable signal on academic FPs (only 1 of 5 samples exhibited the problem). For subsequent iterations (v2, v3), went straight to full instead of smoking — v1's full data showed smoke was too small to predict full-run behavior.
+
+- **Rule Y design over alternatives**: when v2 failed, considered three paths — (A) retag the 14 garden→craft outlier truths to `[craft]`, (B) loosen prompt to read garden-themed-craft as `[garden, craft]`, (C) accept v2 as close-to-pass + adjust gate threshold. User picked B with caveat: "garden tag fires for anything plant/agriculture-related, including food systems, food culture, agricultural history" — which became Rule Y (hybrid tag). Strong design call that simplified the entire mental model; reviewer truth was using `garden` inconsistently both topically and activity-based.
+
+- **Retag scope**: 17 lessons total, not the broader cooking-lessons-with-food-discussion. User's intent reading: garden topical fires when the lesson's CONTENT is about food/garden/agriculture (discussion topic, summary, objectives), not just because cooking lessons "involve food." 31 `[cooking]`-only truth labels left untouched — those represent the user's earlier judgment that the cooking activity was the dominant frame, not garden topical.
+
+- **Ship v3 without further iteration**: macroF1=0.887 cleared by 0.187. Garden precision 0.679 (36 garden FPs) is the only soft spot; LLM is being slightly aggressive on the topical tag, applying it where reviewers didn't. For the draft-validate use case, this is the right direction (reviewers easily remove extras; missed tags harder to catch). Pattern across iterations showed each tightening introduced new failure modes; further iteration likely diminishing returns.
+
+- **Don't commit eval result JSON**: CRF pattern doesn't commit `/tmp/*-eval-result.json`; canonical run is regeneratable from prompt + samples + thresholds. Headline numbers captured in commit message + README + this status entry.
+
+- **Don't commit one-off retag scripts**: `/tmp/apply-retags.mjs` and `/tmp/retag-pairs.json` are one-off helpers. Session log + README documents the retag intent; the helper script regex pattern (`(- \\*\\*ID:\\*\\* \`<id>\`[^\\n]*\\n[\\s\\S]*?\\n)\\*\\*New labels \\(multi-label\\):\\*\\*[^\\n]+`) is the reusable bit and is captured here.
+
+**Process notes for Session 42+:**
+
+- **Task 2.4 step 4 should be structurally parallel to CRF wire-up.** Activity_type adds one more prompt loader + one more Anthropic call + one more Zod validation in `process-submission/index.ts`. Key differences from CRF: multi-label tool call (`submit_tags` not `submit_tag`); array shape return (`activityType: string[]`); merge-not-overwrite into `ai_draft_metadata` (CRF writes `cultural_responsiveness_features` key; activity_type adds `activityType` key without dropping CRF's). Verify CRF's pattern handles read-modify-write of `ai_draft_metadata` cleanly before adding the second writer.
+
+- **Watch for the type-coupled cluster pattern at step 4 (per Session 30 PR 1b learning)** — wiring activity_type into the edge function should be additive (one new prompt + one new call site + one new Zod validate). No type narrowing across consumers expected. But if a shared interface like `AiDraftPayload` needs widening, ship as one cluster commit.
+
+- **CLIProxyAPI cost gotcha confirmed**: actual proxy cost was ~$30 (Session 25 CRF) vs ~$2 direct (Session 41 activity_type). The 15× ratio mostly comes from the prompt-cache miss (proxy adds Claude Code's session prompt per call, breaks cache). For future eval runs with budget pressure, direct Console API is dramatically cheaper. The proxy still has a place when burning Max credits is preferred over Console balance.
+
+- **My API cost estimates were ~3× over actuals.** Across smoke + v1 + v2 + v3, my projected cost per call was 2.7-3.5× the actual. Likely my chars-per-token assumption (3.5) was too low, OR Anthropic's billing has a discount I'm unaware of, OR there's a workspace-credit subsidy. For future projections, anchor on user-observed actuals not my pricing math; my math is consistently overestimating.
+
+- **Single-truth-row eval values are stringent.** Academic now has 1 truth row in the 113-sample set. Per-value academic recall is binary: 1.000 if the LLM correctly tags Lorax, 0.000 if it doesn't. Future canonical re-runs need to keep producing this 1/1 to maintain the per-value floor. If the 1-row category becomes a flake risk, options: (a) add 2-3 more academic-only lessons to the sample set (would need to find/invent), (b) drop the per-value floor for academic only via threshold-config exemption, (c) accept the binary signal as load-bearing — a regression on Lorax tells us the prompt has shifted academic interpretation away from the rule.
+
+### Session 46 — 2026-05-07 — PR 2 SHIPPED + PROD-applied + verified (CRF + activity_type LLM auto-tag)
+
+**Done (1 squash-merge to main + this session-end docs commit on the merged feature branch):**
+
+- **Active-PR session-orientation correction** (6th occurrence of the "stale unpushed claim" pattern; rule already captured in `feedback_pr_bot_review_workflow.md`): status doc claimed "1 code commit ahead of origin + docs commit pending" but `git log @{u}..HEAD` was empty at session start — Session 45's CRF test fix-up `c92b94c` AND Session 45's docs commit `8d645c0` had both already pushed. CI ran on `8d645c0` between Session 45 and Session 46.
+
+- **Round-3 bot voice triaged (4-surface query per `feedback_pr_comment_surfaces.md`).** Round-3 fired on `8d645c0`: claude formal review COMMENTED ("No P0/P1 findings. Four P3 observations inline; none block merge") + claude long-form issue comment + 4 inline P3 comments + Codex round-3 reviewer pass at 21:20 UTC ("**No new blocking P1/P2 findings**"; recommends ship). **Both bot voices converged on ship.** Triage shape: 1 P1 (no Anthropic call timeout — already in OOS follow-ups), 2 P2 (`ai_draft_model` last-writer-wins — already in OOS follow-ups; missing test for "existing review row" — `!existingReview` guard at `ReviewDetail.tsx:460` is correct by construction), 5 P3 nits (4 carry-overs from rounds 1-2 + 1 new `evalMetrics.averageDefined` NaN typing nit — callers handle correctly per claude's own admission). Per round-cap rule "fix only critical bugs" — no critical bugs surfaced.
+
+- **Pre-PROD-apply MCP body-signal probe on TEST DB** (added belt-and-braces hygiene step prompted by user mid-session: "did we already do that?"). Status doc claim was that Session 45's commit was test-only so no fresh per-round verification needed; that's true at the round level. But the *pre-PROD-apply* TEST DB body-signal probe via MCP had not been run for PR 2 specifically (only via CI auto-apply + E2E green). Ran the probe; 6/6 green — all 3 ai_draft_* columns present + both PR 2 migrations (`20260518200000`, `20260519000000`) applied + `complete_review_atomic` body has `v_ai_draft` + reads `ai_draft_metadata` + INSERT writes tags from draft + UPDATE has 3-tier COALESCE chain reading `v_ai_draft` (`tags = COALESCE(NULLIF(v_existing.tags, ARRAY[]::text[]), _phase4_jsonb_text_array_or_null(v_ai_draft->'tags'), v_existing.tags)`) + edge fn TEST version 9 has Anthropic SDK + CRF prompt + activity_type prompt with RMW merge. False alarm on initial regex (looked for `_phase4_..(v_ai_draft` as the FIRST arg of COALESCE, but it's the SECOND arg behind `NULLIF(v_existing.tags...)` — chain order is "existing wins, then LLM draft, then preserve NULL").
+
+- **PR #477 squash-merged via `gh pr merge 477 --squash`** at 2026-05-07T21:34:06Z. Squash commit `cf2aad4` on main. PR was MERGEABLE (UNSTABLE mergeStateStatus only because of pre-existing Security Audit failure on `@lhci/cli` chain, not blocking).
+
+- **PROD migrate + edge-function deploy approved by user; both succeeded on first approval.** `migrate-production.yml` run `25523339957` + `deploy-edge-functions.yml` run `25523339945` — no SASL handshake flake on Apply step, no esm.sh CDN 522 flake on edge fn deploy. Order followed kickoff Recent decisions ("migrations-first, edge-functions-second when both PROD workflows queue together").
+
+- **Post-PROD-apply MCP verification ALL GREEN (4 surfaces, 3-signal pattern):**
+  - `lesson_submissions.ai_draft_*` columns: 3/3 present (jsonb + timestamptz + text, all nullable)
+  - `schema_migrations`: both PR 2 migrations applied (`20260518200000` + `20260519000000`)
+  - `complete_review_atomic` body: 4/4 signals (`v_ai_draft` declared, reads `ai_draft_metadata`, array passthrough for v_ai_draft, `tags = COALESCE(NULLIF(v_existing.tags...` chain present); body_length 14,900 == TEST exactly
+  - `process-submission` edge fn: version 30 → **31** (signal 1: version increment ✓); ezbr_sha256 `94e8bb71...` IDENTICAL to TEST's deploy of same merge commit (signal 2: cross-environment match ✓); source has `import Anthropic`, CRF prompt block, activity_type prompt block with RMW merge into `ai_draft_metadata` (signal 3: source-content grep for new code ✓).
+
+- **PR 2 SHIPPED.** Foundation-phase substrate now includes submission-time Opus 4.7 LLM auto-tag for two fields: cultural_responsiveness_features (gated on body containing "cultural responsiveness" header text — older legacy template ~45% of corpus skipped) + activity_type (always-on, multi-label per Rule Y hybrid garden semantics).
+
+**Decisions made:**
+
+- **User-mid-session intercept on TEST DB verification surfaced an axis gap.** Per-round verification covers the "round changed DB-applied state?" axis, but pre-PROD-apply verification covers the "is TEST DB confirmed in expected post-merge state via MCP?" axis. Both axes apply. Session 45's status-doc claim "no fresh verification needed" was correct at the per-round axis but didn't trip the pre-PROD-apply axis. The 2-min MCP body-signal probe is high-leverage and should fire pre-PROD-apply regardless of per-round-verification status. Worth promoting to the per-round verification feedback memory or kickoff PER-PR RITUAL — see Process notes for Session 47+.
+
+- **`gh pr merge --squash` without `--delete-branch`.** Per past PR 1 + PR 1b precedent, branch retention is user-side cleanup ("deletable at convenience"). Auto-deletion would foreclose any need to recover the per-task hashes from the feature branch.
+
+- **Stay on the merged feature branch for this session's docs commit** (vs. checkout main + create `docs/session-46-pr2-shipped`). Session 36's pattern was the latter, but Session 46's docs are short (~150 lines append + Current State refresh) and the next-PR session can cherry-pick from any branch. Lower-friction path: commit on `feat/metadata-foundation-llm-tagging` (already deletable). If user prefers the dedicated docs branch, easy to recreate later.
+
+- **No new out-of-scope follow-ups added this session.** Session 45's three (any-types cleanup, per-field models provenance, Anthropic call timeout) cover the round-3 substantive findings; round-3's only NEW item was the `evalMetrics.averageDefined` NaN typing nit which is too minor to track.
+
+**Process notes for Session 47+:**
+
+- **PR-cycle archival fires at the START of the next PR (Session 47 if it opens a fresh branch).** Sessions 37-46 in the active file move to the archive at that time per kickoff session-end ritual step 5.
+
+- **Branch cleanup deferrable.** All 5 metadata-foundation feature/backup/docs branches are deletable at user convenience. No urgency.
+
+- **Foundation-phase next-PR options.** Three branches the user can pick (see Current State for command-line first steps). PR 3a (search infra) and PR 4 (corpus drops) are independent of Stage 1; the post-PR-2 tags-LLM follow-up needs its sample-set methodology decision before any code work begins.
+
+- **No v-tag yet.** Per Recent decisions "v-tag deferred to end-of-foundation-phase" — PR 2 is the third foundation-phase PR; tagging mid-phase is premature.
+
+- **Pre-PROD-apply MCP probe pattern is high-leverage — promote to feedback memory.** This session's user-prompted "did we already do that?" check turned a routine 2-min step into a confirmed-green pre-flight check that would have caught any TEST-DB-not-actually-applied case before PROD apply triggered. Candidate: append a bullet to `feedback_per_round_test_db_verification.md` distinguishing "per-round verification" (round changed DB-state?) from "pre-PROD-apply verification" (TEST DB confirmed in expected post-merge state?), making both fire independently. Or fold into kickoff PER-PR RITUAL step 9 explicitly. Decide on Session 47.
+
+### Session 45 — 2026-05-07 — PR 2 round 2 triage + 1 accept (CRF test coverage); round-cap activated
+
+**Done (1 code commit `c92b94c` + this session-end docs commit pending):**
+
+- **Active-PR session-orientation correction**: Session 44 status doc claimed "4 commits ahead of origin awaiting push" but `git log @{u}..HEAD` was empty at session start — push happened post-Session 44 docs commit (likely as part of Session 44's session-end ritual after the doc was written). Origin now at `6596782`. CI ran on push; E2E + CodeQL turned green (Session 44's fix-ups landed correctly); only Security Audit remains red (pre-existing `@lhci/cli` chain per MEMORY hygiene-follow-ups). This is the 5th occurrence of the "stale unpushed claim" pattern (Sessions 33, 34, 35, 36, 45) — already captured in `feedback_pr_bot_review_workflow.md`'s active-PR session-orientation rule.
+
+- **Round-2 bot review triaged (4-surface query per `feedback_pr_comment_surfaces.md`).** New review on `6596782` from `claude` at 16:14 UTC: `CHANGES_REQUESTED` with 7 findings (3 P2 + 4 P3). User's Codex round-2 pass at 19:18 UTC recommended 1 accept + round-cap. My rebuttal pass converged with Codex on the same shape: 1 accept, 6 reject.
+
+  - **ACCEPT (1)**: P2 — Missing `culturalResponsivenessFeatures` test in `reviewMetadataInit.test.ts`. Real coverage gap; CRF is the *other* field this PR auto-tags but only `activityType` was tested end-to-end. Two tests added: (a) valid CRF passthrough using actual master-list value `'Communicates high expectations'`, (b) invalid CRF returns null (mirrors existing `activityType` invalid-enum test). 8/8 tests passing (was 6).
+
+  - **REJECT (6)**: P2 `any` types at lines 136-137 — `git blame` proves pre-existing from `2c14ff04` 2025-08-06, ~9 months pre-PR-2; out of scope per kickoff. P2 TOCTOU race on `ai_draft_metadata` SELECT→merge→UPDATE — no realistic concurrent-write path (both LLM steps run sequentially in one edge invocation; `regenerateEmbedding` skips both); atomic JSONB merge is hypothetical-future-proofing. P3 `as ReviewMetadata` cast — load-bearing because `lessonToReview` returns `ReviewFormPayloadValidated` (Zod-inferred), not `ReviewMetadata` (legacy hand-written interface); removing it would couple the new mapper to legacy interface, wrong direction per Gate B architecture. P3 CRF Select `label: v` — verified all 7 master-list features have `value === label` in `filterDefinitions.ts:67-86`, byte-identical output; the cookingSkills/gardenSkills config-lookup pattern exists because *those* fields have slug-vs-label divergence which CRF doesn't. P3 no content truncation — production must match eval harness; `eval-llm-tagging-prompt.ts:191` sends full `body` with no cap. Truncating in production but not eval would cause production to underperform eval (eval-gated metrics CRF macroF1=0.937 / activity_type macroF1=0.887 reflect full-content behavior). Embedding's 8K cap is OpenAI hard limit; Opus is 200K. P3 `evalMetrics.ts` Array.includes — ~10K ops per metric run at current 113-353 sample sizes, harness is one-shot project-internal infra, not a hot path.
+
+  - **Round-1 inline carry-overs all rebutted in same pass:** `ai_draft_model` last-writer-wins (both prompts use same model; logged as out-of-scope); merged JSONB not re-validated (existingDraft was written by *the same function* with prior Zod validation; no untrusted source); two Anthropic clients (code-style nit); no Anthropic call timeout (SDK default 600s, edge-fn cap ~150s is binding constraint; logged as out-of-scope); ReviewDetail form-init guard (verified at `ReviewDetail.tsx:460` — AI draft block lines 470-473 IS inside `if (!reviews || reviews.length === 0)`; bot's "guard isn't visible in diff" claim was wrong).
+
+- **Fix-up commit `c92b94c`** — added 2 tests to `src/pages/reviewMetadataInit.test.ts`. vitest 8/8 green; type-check + lint clean. Test value `'Communicates high expectations'` chosen from actual Brown CR master list per Codex round-2 guidance — Claude's sample `'Windows-mirrors-and-sliding-doors'` is not a real CR feature.
+
+- **3 new out-of-scope follow-ups added** to status doc: (1) pre-PR-2 `any` types cleanup PR; (2) per-field `_models` provenance inside `ai_draft_metadata` for future model divergence; (3) explicit 30s Anthropic call timeout for resilience hardening.
+
+- **Round-cap activated** per kickoff PER-PR RITUAL ("round-cap after 2 rounds"). Round 1 = Session 44 fix-ups (back-sort migration rename + CodeQL regex). Round 2 = Session 45 fix-up (CRF test coverage). Any round-3 bot voice triages to "fix critical bugs only, document the rest, ship" — design preferences, perf nits, and pre-existing issues all auto-defer.
+
+**Decisions made:**
+
+- **Skipped fresh TEST DB verification this session.** Session 45's commit is test-only (no DB-applied state changed). The 6/6 RPC body signal probe + edge-function 3-signal verification can wait until pre-PROD-deploy. Per `feedback_per_round_test_db_verification.md` the rule is "every round that touches DB-applied state needs its own evidence" — test-only round doesn't trigger it. Session 44's push (which CI applied) is the most recent DB-affecting verification, and Codex round-2 confirmed via E2E logs the apply step ran and listed both renamed migrations correctly.
+
+- **Bot voice convergence as round-cap signal: Codex round-2 + my rebuttal pass aligned independently on 1 accept (CRF test). The convergence between independent analyses on the same accept choice — and on the same rejection rationales — is the signal that no real bug is being missed. Single-voice from claude on the rejected findings is the absence-of-convergence pattern that justifies the round-cap.
+
+**Process notes for Session 46+:**
+
+- **Push timing.** Per `feedback_no_docs_push_during_pr.md` bundle the docs commit with the next code push. Session 46 picks up with `git push` to send Session 45's code fix-up + this docs commit together. Watch CI for ~10 min to confirm checks remain green.
+
+- **Round-3 watchpoint.** If a third claude review fires, follow round-cap protocol: only fix findings that show convergence with another bot voice OR represent real production bugs. Use the same 4-surface query + rebuttal pass shape — but compress the report (kickoff "ROUND-CAP AFTER 2 ROUNDS — fix only critical bugs, document the rest, ship").
+
+- **Ready-to-ship boundary.** Once CI is green and no round-3 bot voice arrives within ~1 hour of CI completing, the PR is ready for user-decision merge. `c92b94c` + Session 45 docs is the last fix-up; pre-PROD-deploy verification (3-signal edge fn + 6/6 RPC body) fires after squash-merge but before approving the production migration in CI.
+
+### Session 44 — 2026-05-07 — PR 2 round 1 fix-ups: migration rename for back-sort + CodeQL regex slice
+
+**Done (2 code commits + this session-end docs commit pending — local only per `feedback_no_docs_push_during_pr.md` until next push):**
+
+- **Active-PR session-orientation per Session 43's process note**: ran `git log @{u}..HEAD` + `gh pr view 477 --json reviews,comments,state,mergeable` + `gh pr checks 477` + four-surface comment query (issue-comments + reviews + line-comments + failing-job logs). Findings: bots have all completed reviews (claude-review + GHAS CodeQL + user's own Codex pass at 15:45); 3 failing checks (E2E Tests, Security Audit, CodeQL); zero P1 from bot voice convergence — bot voice is single-voice `claude` on substance + single-voice `GHAS` on the regex; Security Audit is the pre-existing `@lhci/cli` chain (already in MEMORY hygiene-follow-ups, not introduced by this PR).
+
+- **Migration back-sort root cause investigated** via `mcp__supabase-test__execute_sql` + `mcp__supabase-remote__execute_sql` against `supabase_migrations.schema_migrations`. Both TEST and PROD are at `20260518100000` (PR 1b's tip) — neither PR 2 migration is recorded on either DB, and `lesson_submissions.ai_draft_metadata` columns do NOT exist on TEST (column probe returned `[]`). **Codex review's claim ("TEST has 20260516000000 and 20260519000000 recorded") was WRONG** per fresh probe — likely Codex hallucinated or read against a different DB. Rule learning: single-source MCP claims in review comments can be stale; always re-probe at the time of action, not at the time of review.
+
+- **CI behavior chain confirmed**: `supabase db push --dry-run` (line 59 of `.github/workflows/e2e.yml`) exits 1 on the back-sort detection ("Found local migration files to be inserted before the last migration on remote database"); `set -o pipefail` propagates the exit code; GHA's default fail-fast skips the subsequent `supabase db push` step (line 121) because its `if:` check doesn't override the implicit `success()`. The migration genuinely never applied. The bug is the FILENAME (timestamp), not the body.
+
+- **Fix-up commit 1 (`fff430d`) — migration rename via `git mv`**: `20260516000000_lesson_submissions_ai_draft_metadata.sql` → `20260518200000_lesson_submissions_ai_draft_metadata.sql`. New timestamp sorts cleanly post-PR-1b (`> 20260518100000`) and before PR 2's RPC migration that reads these columns (`< 20260519000000`). Body unchanged (additive `ADD COLUMN IF NOT EXISTS` + comments). Header gets a context block explaining the rename + rationale for the rule exception (mirrors `20260519000000_*`'s own rename header pattern).
+
+- **Fix-up commit 2 (`4ea642b`) — CodeQL regex slice**: replaced `replace(/<!--.*?-->/g, '')` on `scripts/build-activity-type-samples.ts:90` with `indexOf('<!--')` + `slice` approach. Clears 2 CodeQL alerts (alerts #23 "Incomplete multi-character sanitization" + #24 "Bad HTML filtering regexp"). Behavior-equivalent on real worksheet input — only 1 occurrence of `<!--` in the entire current worksheet, in the intro section, not in any label line. Inline comment documents the intent: treat `<!--` as a line-comment terminator, not as one half of an HTML tag pair.
+
+- **Local verification clean**: `supabase db reset` (all 15 migrations apply in correct order; 4 ai_draft_* columns present per local MCP probe; `schema_migrations` shows `20260518000000 → 20260518100000 → 20260518200000 → 20260519000000`) + 573/573 tests + type-check + lint all green.
+
+- **Other claude bot findings rejected per user's own Codex triage** (concur with all rejections): `ai_draft_model` last-writer-wins (P3 — both models are `claude-opus-4-7` today, no real divergence); `user`/`supabaseClient: any` (pre-existing on `origin/main`); `SubmissionDetail` missing `ai_draft_metadata` field (type-doc only — `ReviewDetail` reads through `submissionData`, not the typed interface); merged JSONB not re-validated before write (P3 hardening, no current risk); duplicate Anthropic client + missing LLM timeouts + literal vocab values in tests + CLI `console.log` (all P3 nits, kickoff "don't refactor beyond task" applies).
+
+**Decisions made:**
+
+- **Rule-exception rename over reset-TEST-DB**. The `database-migrations` skill + `supabase/migrations/CLAUDE.md` explicitly say "NEVER edit a migration file that has been pushed." The skill offers two escape paths: (a) "create a new fix migration", or (b) "reset TEST DB". Neither fits this bug — (a) can't fix a back-sorted FILENAME (the back-sorted file would still be in the tree tripping `db push --dry-run`); (b) is heavyweight (~800 rows of TEST data) and unnecessary because no remote DB has the migration applied. The rule's spirit is "don't drift TEST/PROD" — that drift cannot occur when TEST has nothing applied. Documented the exception explicitly in the migration file header + commit message + a new bullet in Recent decisions covering the exception class. User pre-approved the rename approach in this session before any file changes.
+
+- **Two fix-up commits, not one combined**. Cleaner git log + bisect; matches Session 43's "round-N fix-up pattern." Squash-merge collapses to one commit on main anyway.
+
+- **Skipped Security Audit fix.** Pre-existing `@lhci/cli`/`tmp`/`postcss`/`basic-ftp`/`ip-address` chain (already in MEMORY.md hygiene-follow-ups). Not introduced by this PR. Belongs to a focused dependency-upgrade PR; outside this round's scope per `feedback_pr_bot_review_workflow.md` rule "default-reject hardening for internal-only."
+
+**Process notes for Session 45+:**
+
+- **Push bundle = 4 commits ahead of origin**: Session 43 docs (`4ef9cb0`) + rename (`fff430d`) + regex (`4ea642b`) + Session 44 docs. Per `feedback_no_docs_push_during_pr.md`, Session 43's docs commit rides along with the fix-ups instead of pushing standalone (avoid CI cycle on docs-only changes).
+
+- **TEST DB verification fires when CI applies the renamed migration** (this is round 1 of bot review per `feedback_per_round_test_db_verification.md`). Required probes: 6/6 RPC body signals on `complete_review_atomic` (declare `v_ai_draft jsonb` + pluck from `lesson_submissions.ai_draft_metadata` + INSERT array passthrough for `activityType` + UPDATE array passthrough for `activityType` + INSERT tags from draft + UPDATE tags carry-forward) + tags column distribution unchanged on legacy rows (no NULL → [] flip) + 3-signal edge fn pattern (version + ezbr_sha256 + source-content grep for `loadCrfPrompt` AND `loadActivityTypePrompt` AND both `submit_tags` tool definitions) + 4-case submission smoke matrix (gated on `ANTHROPIC_API_KEY` set on TEST). The renamed migration is functionally identical to the original; TEST should apply cleanly on first try.
+
+- **Watch the rebase-rename-sweep pattern** (newly captured in Recent decisions): when rebasing migrations onto a branch with newer-timestamp migrations, ALL files on the rebased branch with timestamps EARLIER than the rebase target's tip migration must be renamed, regardless of body-conflict status. Local `supabase db reset` won't catch the issue because it applies in version order — only `db push --dry-run` against TEST does. Single occurrence so far (Session 38's miss); promote to `feedback_*.md` if it recurs on a future rebase.
+
+- **Round-cap rule applies after one more round**: this is round 1. Per kickoff PER-PR RITUAL step 10, after 2 rounds of bot review fix only critical bugs and ship. If a round-2 fires (next session if bots return after the push), apply the same rebuttal pass + four-surface query + per-round TEST DB re-verification.
+
+- **Anticipated next-session shape**: (a) push bundle → wait for CI to apply migrations + run E2E + CodeQL clean → run TEST DB verification round 1 → if green and no new bot findings, await user merge approval; (b) if round 2 fires, apply same triage rules and re-verify.
+
+### Session 43 — 2026-05-07 — PR 2 PUSHED + OPENED as #477 (CRF + activity_type only; tags LLM deferred)
+
+**Done (1 fix-up code commit `233dfd3` + this session-end docs commit pending — local only per `feedback_no_docs_push_during_pr.md`):**
+
+- **PR-scope decision settled.** Recommended (and user confirmed) shipping PR 2 with CRF + activity_type only and deferring tags LLM to a follow-up PR. Reasoning: tags column is brand-new from PR 1 with no historical reviewer-labeling, so the eval-gate methodology that anchored the prior two prompts (CRF on 353 reviewer-tagged rows, activity_type on 113 reviewer-tagged rows) doesn't apply. Tags sample-set decision (synthetic worksheet vs. organic post-deploy data vs. defer until reviewers tag enough lessons) gets its own PR after the question is answered. Trades scope-completeness in one PR for shorter time-to-deploy on the two prompts that ARE eval-gated and ready, plus avoids a half-eval-gated middle path for tags.
+
+- **Pre-push code-reviewer agent dispatched** (`feature-dev:code-reviewer`, model=opus per `feedback_opus_subagents.md`) on `git diff main...HEAD` (~9,125 insertions / 224 deletions across 27 files). Prompt covered: PR scope + what's deferred + key files for special attention (CRF + activity_type LLM blocks, the dual-purpose `complete_review_atomic` migration, the `ai_draft_metadata` column-add migration, ReviewDetail draft-init reader, Zod canonical + Deno mirror equivalence) + what to look for (correctness, data-safety, logical inconsistency, scope creep) + what to de-prioritize (hardening, style, test-coverage). **Findings: 0 P0/P1, 3 P2, 3 P3.**
+
+- **Triage applied (rebuttal pass per `feedback_bot_review_investigation.md`):**
+  - **ACCEPTED P2-1 — rollback comment block** added to `20260516000000_lesson_submissions_ai_draft_metadata.sql`. Sibling migration already had the trailer; `supabase/migrations/CLAUDE.md` template specifies it as required. Pure compliance.
+  - **ACCEPTED P2-2 — `NULL → []` flip on tags column** during approve_update for legacy lessons. The pre-fix COALESCE chain ended in `ARRAY[]::text[]`, flipping `v_existing.tags = NULL` to `[]` on every approve_update even though no tags writer ships in this PR. The INSERT path on line 263 uses `_phase4_jsonb_text_array_or_null` (returns NULL) — UPDATE was asymmetric. Fix: drop final `ARRAY[]::text[]` arm; COALESCE returns NULL when all three arms are NULL; `valid_tags` CHECK accepts NULL. UPDATE now matches INSERT.
+  - **REJECTED P2-3** (Zod result.data discard in complete-review): pre-existing PR-1 code; per kickoff "don't refactor beyond task." Defense-in-depth value half-realized but not in scope.
+  - **REJECTED P3-1** (CRF block comment phrasing on RMW direction): the comment is on the activity_type block (Step 4.6, labeled as such); reads fine in context. Agent's "ambiguity" call doesn't hold up against the surrounding cues.
+  - **REJECTED P3-2** (CRF regex `header` vs `anywhere`): pre-existing CRF code from Task 2.3 step 5 (`67a3cd7`). Same scope-creep argument as P2-3.
+  - **REJECTED P3-3**: agent itself flagged "not a real issue" — activity_type's lack of content gate is intentional (activity_type works on any submission body; CRF skip is pre-D9-template specific).
+
+- **Pre-push verification clean:** `npm run type-check` + `npm run lint` + `npm run test` (573/573 passing) + `supabase db reset` (all migrations apply with the new COALESCE chain).
+
+- **PR opened** at https://github.com/danfeder/esnyc-lesson-search-react/pull/477 with full description: scope summary (CRF + activity_type with eval gate metrics), what's deliberately deferred (tags LLM + Stage-1-gated prompts + reviewer picker UI), pre-push review summary (0 P0/P1, 2 P2 fix-ups applied, 4 rejected with rationale), 12-item Test plan checklist covering CI apply + complete_review_atomic body signals + edge function deploy verification + 4-case submission smoke matrix + round-cap rule.
+
+**Decisions made:**
+
+- **Cherry-pick approach NOT needed for this push** (unlike Session 38's PR 2 rebase). Branch was rebased clean against `bd9d6e4` in Session 38; no further rebase work needed before push.
+
+- **Read-modify-write pattern accepted as-is** (not refactored to single-write-at-end). Reviewer agent dismissed this proactively per kickoff de-prioritization. Worth noting: pattern stays viable for Task 2.5 (tags) when it eventually ships — third writer reads merged-after-CRF-and-activity_type JSONB and overlays tags key. If 4+ writers eventually exist, refactor to accumulator-pattern; until then, RMW is fine.
+
+- **Single fix-up commit** for both P2 changes (rather than amending each into the original commit). Nothing was pushed when the agent reviewed; amending was an option. Picked fix-up for transparency in local git log + traceability of "what was changed in review." Squash-merge collapses to one commit on main anyway.
+
+- **Session-end docs commit lands locally only.** Per `feedback_no_docs_push_during_pr.md`: don't push session-end docs commits when a PR is open. Bundle with next fix-up push (or final pre-merge docs roll-up if no fix-ups needed). Avoids burning a CI cycle on docs-only changes.
+
+**Process notes for Session 44+:**
+
+- **Active-PR session-orientation rule applies** at session start. Status doc at session-end says "PR #477 open, awaiting bot reviews" — that's stale by next session because bots reviewed in the gap. Run `git log @{u}..HEAD` + `gh pr view 477 --json reviews,comments,state,mergeable` + `gh pr checks 477` BEFORE any other work. The four-surface query (`gh pr view --comments` + `gh api .../reviews` + `gh api .../comments` + `gh run view --log-failed`) is mandatory for "0 findings" claims (per `feedback_pr_comment_surfaces.md`).
+
+- **TEST DB verification per-round.** First verification fires when CI applies the migrations (round 0 = PR open). Per `feedback_per_round_test_db_verification.md`, every subsequent round that produces DB-affecting fix-up commits needs its own re-verification — not just one-time at PR open. The 6-signal RPC body check + tags-column-distribution check + edge function 3-signal check are the load-bearing probes.
+
+- **`ANTHROPIC_API_KEY` secret on TEST** is the gating prerequisite for any submission smoke testing. Without it, the LLM blocks gracefully skip and the smoke can only verify "no crash on missing key," not "drafts populate correctly." Confirm secret is set BEFORE running submission tests. Same will apply for PROD deploy.
+
+- **Watch for the SASL flake** at the Apply step of `migrate-production.yml` AND the esm.sh CDN 522 flake at `deploy-edge-functions.yml` (per MEMORY.md hygiene-follow-ups). Both are recurring transient patterns; mitigation is `gh run rerun --failed <run_id>`. Approval gate behavior differs: SASL re-fires the gate (CLI re-handshakes), CDN doesn't (matrix slot has its own re-run path).
+
+- **No code changes anticipated next session** unless bot rounds surface real findings. Prepare for: (a) zero-findings ship path (TEST DB verify → user PROD-merge approval → PROD verify), (b) 1-2 round fix-up cycle (re-dispatch fresh review per kickoff "every push that follows" rule, NOT just round 0).
+
+### Session 42 — 2026-05-07 — PR 2 Task 2.4 step 4: activity_type prompt wired into process-submission edge function
+
+**Done (1 code commit `5c6b7ea` + this session-end docs commit pending):**
+
+- **Activity_type prompt wired into `supabase/functions/process-submission/index.ts`** (+129 lines). Module-level constants + loader: `ACTIVITY_TYPE_MODEL = 'claude-opus-4-7'`, `ACTIVITY_TYPE_PROMPT_URL` pointing to `./prompts/activity-type.md`, `loadActivityTypePrompt()` cache helper. New `ACTIVITY_TYPE_VALUES` import added to the existing `_shared/metadataSchemas.ts` import block.
+
+- **Step 4.6 wire-up block** placed immediately after the CRF block (Step 4.5), before the duplicate-detection branch. Skip predicate is `!regenerateEmbedding` only — no body-content preflight (unlike CRF's "Cultural Responsiveness" header check) since activity_type works on summary + agenda + skills which every ESYNYC submission carries. Tool: `submit_tags` with `selected_values` array enum-restricted to `ACTIVITY_TYPE_VALUES` (4 values) + `uniqueItems: true`. Multi-label per D2.1.
+
+- **Read-modify-write into `ai_draft_metadata`.** After Zod validation succeeds, the block SELECTs the existing `ai_draft_metadata` JSONB, spreads it into a new object, overlays the `activityType` key, and UPDATEs the row. CRF's writer at lines 404-411 of the merge-base does a plain UPDATE (overwrites the JSONB column wholesale); a second writer with the same pattern would drop CRF's `culturalResponsivenessFeatures` key. RMW preserves CRF's data without touching CRF's code. Sequential within the request — no race with CRF.
+
+- **Failure paths**: Zod validation fail → log + skip write; SELECT fail → log + skip write; UPDATE fail → log + continue; outer try/catch → log + continue. Submission flow never blocks on tagging. Same shape as CRF.
+
+- **Type-check + lint pass**: clean baseline before commit, clean after commit.
+
+**Decisions made:**
+
+- **RMW over alternatives** (`jsonb_set` raw SQL or refactor to single accumulator-write). Three options were on the table:
+  - **(A) RMW (chosen)**: read existing JSONB, merge in JS, write back. One extra SELECT per writer. Simple, doesn't touch CRF. Scales to Task 2.5 (tags) by adding a third writer that reads the merged-after-CRF+activity_type JSONB.
+  - **(B) `jsonb_set` raw SQL**: atomic, single round-trip, but requires raw SQL via `rpc()` or a helper function. Adds infrastructure for a problem that doesn't exist (no concurrency between writers within a single request).
+  - **(C) Refactor to single end-of-flow write**: collect all prompt outputs in an in-memory accumulator, write once at the end. Cleanest at scale but requires touching CRF's commit (`67a3cd7`) which is already in the PR 2 chain. Kickoff guidance: "Don't add features, refactor, or introduce abstractions beyond what the task requires." Defer to Task 2.5 if multi-write round-trip cost becomes painful at 3+ writers.
+
+  Picked (A) for minimal-diff + extension friendliness for Task 2.5. (C) is queued as a candidate refactor when 4+ writers exist and the round-trip cost is measurably painful.
+
+- **No body-content skip predicate.** Considered mirroring CRF's regex check on the body content for activity_type — but the activity_type prompt explicitly works on summary + agenda + skills (the standard ESYNYC submission template), not on a specific section header. A submission with empty body produces noisy predictions but Zod still validates the array; cost is one wasted Anthropic call. Adding a predicate would cost more in maintenance than it saves in calls.
+
+- **`ai_draft_model` column reflects the last writer.** When both CRF and activity_type fire, both writes hit `ai_draft_model = 'claude-opus-4-7'` so the column is identical regardless of order. If models diverge (e.g., a future Haiku-classified prompt), the column would only reflect the last writer. Schema accepts this for foundation phase; revisit when models actually diverge (Phase 2).
+
+- **`submit_tags` tool name shared with CRF.** Both blocks declare a tool named `submit_tags` in separate Anthropic API calls. The two tool definitions have different enum lists (`ACTIVITY_TYPE_VALUES` vs `CULTURAL_RESPONSIVENESS_FEATURE_VALUES`); the prompt cache treats them as distinct cache slots based on the serialized tool definition + system prompt. No conflict.
+
+**Process notes for Session 43+:**
+
+- **PR 2 push decision required.** Session 41's "Next session picks up" framed Task 2.5 (tags) as the next coding task; with step 4 done, the user can choose to:
+  - **(a) Open PR 2 now** with CRF + activity_type only. Tags ships as a small follow-up PR after Task 2.5's sample-set question is answered. Faster time-to-TEST for the two prompts that ARE eval-gated.
+  - **(b) Continue to Task 2.5** (tags prompt + eval). Bigger PR scope, longer time-to-TEST, but ships all three vocab-locked prompts in one PR.
+  Surface to user at session start.
+
+- **Task 2.5 sample-set question is the highest-impact open decision.** Tags has no historical reviewer truth (the column is brand-new from PR 1). Three options:
+  - **(i) Hand-curated synthetic worksheet (~30-50 lessons)**: reviewer-tags a small set across orientation / bilingual_handouts / neither for the canonical eval gate. ~1-2 hrs of user time.
+  - **(ii) Skip canonical eval; smoke-test only**: ship the prompt without the eval gate's structured signal. Eval gate would have to come post-deploy when reviewer activity organically produces a sample set.
+  - **(iii) Defer Task 2.5 entirely**: ship CRF + activity_type only; tags waits until reviewers have organically tagged enough lessons through the post-deploy review flow.
+  Surface to user at session start.
+
+- **Watch for the type-coupled cluster pattern** if Task 2.5 (or any Gate-C-classified vocab-locked prompt) introduces type-narrowing across edge function + Zod schemas + mappers. This session's wire-up was purely additive (one more loader + one more call site + one more Zod validate); no cluster invariants tripped. Same shape expected for Task 2.5 unless tags introduces something unusual.
+
+- **TEST DB verification deferred until PR 2 push.** Per the per-round verification rule, verification fires when the PR opens (round 0) and after every fix-up round. Pre-push there is nothing on TEST or PROD that's affected by this session's local-only commit.
+

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,42 +1,44 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-07 — Session 46 (PR 2 SHIPPED + PROD-applied + verified; squash commit `cf2aad4` on main; PR 2 cycle is closed; this session-end docs commit lands on the merged branch and gets bundled into the next PR per Session 36 → 38 precedent).
+**Last updated:** 2026-05-08 — Session 47 (PR 4 cycle started: 21 third-party imports soft-retired + 7 archive-only concepts recovered + FSA Pt 1 retitle; 2 migrations local-only on `feat/metadata-foundation-corpus-cleanup`; PR-cycle archival of Sessions 37-46 done this session).
 
-> **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-36 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (~1600 lines, read on demand via grep). When a new PR cycle begins, that PR's session entries can move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
+> **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-46 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**PR #477 (PR 2 — lesson-submission LLM auto-tag, CRF + activity_type) — SHIPPED + PROD-applied + verified 2026-05-07.** Squash commit `cf2aad4` on main at 21:34:06 UTC. Both PROD migrations (`20260518200000_lesson_submissions_ai_draft_metadata` + `20260519000000_complete_review_atomic_tags_side_channel`) applied. PROD `process-submission` edge fn at version 31 (was 30 pre-deploy); ezbr_sha256 matches TEST exactly. 4/4 PROD MCP probes confirm the substrate. No SASL flake on the migration apply, no esm.sh CDN 522 flake on the edge fn deploy.
+**PR 4 (corpus cleanup) — Session 47, in flight 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 2 commits ahead: `0672cc8` (Session 46 docs cherry-pick from merged PR 2 branch per Session 38 precedent) + `ed8ca21` (PR 4 substantive migrations). NOT pushed yet; PR opens after filter-surface follow-ups land per `feedback_no_docs_push_during_pr.md` spirit (bundle substrate migrations + filter surfaces in one PR cycle).
 
-**Foundation-phase substrate live on PROD now includes:**
-- All PR 1 substrate (lesson_format dropped + series_id + part_number + crf_confirmed + activity_type/tags multi-select array shape with closed enums + cultural_responsiveness_features array of 7 Brown CR features + 3 CHECK constraints + trigger value-validation + Zod canonical + Deno mirror + freshness CI test + filter UI + complete-review Zod-validated)
-- All PR 1b substrate (`activity_type` array passthrough end-to-end via `complete_review_atomic`; retired the synthetic `both` value; repointed [both] → [cooking, garden] on PROD)
-- **PR 2 substrate (NEW):** `lesson_submissions.ai_draft_metadata` JSONB + `ai_draft_generated_at` + `ai_draft_model`; submission-time CRF + activity_type LLM auto-tag in `process-submission` (Opus 4.7, eval-gated macroF1=0.937 / 0.887); `complete_review_atomic` reads `v_ai_draft` and writes tags to lessons.tags column on approve_new + 3-tier carry-forward chain on approve_update (`tags = COALESCE(NULLIF(v_existing.tags, ARRAY[]::text[]), _phase4_jsonb_text_array_or_null(v_ai_draft->'tags'), v_existing.tags)`); ReviewDetail pre-fills form from ai_draft on first review (when no existing review row).
+**Locked decisions this session (3 user-confirmed):**
+1. **Soft-delete via `retired_at timestamptz` + `retired_reason text` columns** with cluster-key namespace `import:<source>` (7 distinct keys for the 21 imports: pflp_2003 / foodcorps_2017 / cas_food_justice / nyc_doe_colonial_ny / city_blossoms_botanical_artists / nyc_dep_watershed / oregon_doe_leaves). Reversible. Future retirement reasons can use other namespaces.
+2. **404 UX for direct-link to retired lessons** — same `WHERE retired_at IS NULL` filter as search; 0 PROD bookmarks anywhere makes any custom UI for retired moot.
+3. **Filter retired in 6 surfaces** (next session's work): lessons_with_metadata view, search_lessons RPC, smart-search edge fn, lesson detail query, facetCounts.ts, embedding regen script. detect-duplicates + content-hash dedup intentionally NOT filtered (cross-checking against retired imports is useful at submission time).
 
-**Eval-gate state (unchanged since Session 41):** CRF macroF1=0.937 (cleared Session 25); activity_type macroF1=0.887 (cleared Session 41 with Rule Y hybrid garden semantics); per-value F1 cooking 0.889 / garden 0.809 / academic 1.000 / craft 0.852; macro recall 0.956; `academic` truth count = 1 (Lorax binary); `maxPredictionRateForAbsentValues=0.10` guardrail dormant.
+**Pre-flight investigation (4 PROD probes, all clean):**
+- **Drop list count** — actual is **21**, not 23 (kickoff/decision-journal "23" is stale early estimate). Memory file's listing is authoritative; structural sweep against PROD found 30 false positives + 0 obvious additional candidates. TEST↔PROD parity exact at 21.
+- **FK + user-state audit** — bookmarks_total=0 anywhere in PROD; 0 lesson_versions / collections / submissions / reviews / similarities on the 21 drop rows. 2 historical references (Leaves We Eat + Stone Soup as canonical winners of dedup `group_6` and `group_82` resolved 2025-09-01 `merge_and_archive`) preserved intact under soft-delete.
+- **FSA current title** — confirmed "Food System Advocates (Part 1 & 2)"; tags + format columns NULL.
+- **Archive-only concepts** — 7 distinct lesson_ids with ~19 concepts surviving only in `lesson_versions` archive (all archived 2026-04-27 Phase 6.2). Tally drift from memory's "16 concepts" → 19 measured 2026-05-08 is the same population.
 
-**Tasks deferred to follow-up PR:** Task 2.5 — tags LLM prompt + eval — sample-set methodology decision pending (tags column is PR-1-new with no historical reviewer-labeling so the eval-gate methodology that anchored CRF and activity_type doesn't apply). Decision shape: synthetic worksheet (manually authored sample set) vs. organic post-deploy data (collect after enough reviewer-tagged submissions arrive) vs. defer until Stage 2 worksheet round.
+**PR 4 substantive code shipped this session (commit `ed8ca21`, 2 files / +256):**
+- `supabase/migrations/20260520000000_corpus_cleanup_retire_imports.sql` — adds `retired_at` + `retired_reason` columns; UPDATEs 21 drop rows with cluster keys; UPDATEs FSA row to drop "& 2"; idempotent guards (`AND retired_at IS NULL`, `AND title = '...'`).
+- `supabase/migrations/20260520010000_recover_archive_only_concepts.sql` — restores `academicConcepts` from archive into 7 live rows; DISTINCT ON + ORDER BY version_number DESC defensively; idempotent.
+
+**Local verification clean**: `supabase db reset` applies all migrations; type-check + lint clean; vitest 575/575; MCP probe confirms `retired_at` + `retired_reason` columns present with correct types.
+
+**Foundation-phase substrate WILL include after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 6 filter surfaces filtering retired rows.
+
+**Next session picks up — PR 4 follow-up work:**
+1. **Filter surfaces** — add `WHERE retired_at IS NULL` (or equivalent shape filter) to: `search_lessons` RPC body + companion view `lessons_with_metadata`, `smart-search` edge fn (`supabase/functions/smart-search/index.ts`), lesson detail page query (front-end), `src/utils/facetCounts.ts`, embedding regen script (find via grep). Probably one new migration + 2-3 frontend/edge edits.
+2. **Tests** — extend any tests that count corpus rows to expect `live_count` semantics; verify retired filter end-to-end.
+3. **Pre-push code-reviewer agent** dispatched on `git diff main...HEAD` (Opus per `feedback_opus_subagents.md`); accept/reject findings; commit fix-ups before push.
+4. **Push branch + open PR**. CI applies migrations to TEST DB; round 0 verification via `mcp__supabase-test__execute_sql` (21 retired count + FSA new title + 7 concepts recovered shape-correct).
+5. **Bot review rounds + ritual**.
 
 **Branches:**
 - `main` at `cf2aad4` (PR 2 squash-merge); origin matches
-- `feat/metadata-foundation-llm-tagging` (merged; deletable at convenience; this session's docs commit lands on it)
-- `backup/feat-metadata-foundation-llm-tagging-pre-rebase` (created Session 38 pre-rebase; deletable now PR 2 has shipped)
-- `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
-
-**Next session picks up — choose the next PR (user-decision):**
-
-```bash
-git checkout main && git pull origin main
-git status --short --branch && git log --oneline -5
-npm run type-check && npm run lint
-```
-
-**Three options for the next PR:**
-1. **PR 3a — search infra** (search_vector + embeddings + smart-search drift fix; independent of Stage 1 outputs; impl-plan ready in `…-foundation-implementation.md`)
-2. **PR 4 — corpus drops** (23 third-party imports + concept recovery + N1 retitle; independent of Stage 1; pre-delete checklist matters per Phase 6.2 §4D learning — verify FK refs INTO each row + `lessons.original_submission_id` OUT FROM each row before deleting)
-3. **Post-PR-2 tags-LLM follow-up PR** (sample-set methodology decision required first; smaller scope than 3a or 4; rides the same `submit_tags` tool-call infra PR 2 just shipped)
-
-**PR-cycle archival fires at session-1 of whichever PR is next.** Sessions 37-46 (currently in this active file) move to the archive at that time per kickoff session-end ritual step 5.
+- `feat/metadata-foundation-corpus-cleanup` — this session's work, 2 commits ahead (3 after this session-end docs commit)
+- `feat/metadata-foundation-llm-tagging` (PR 2 merged; deletable at convenience)
+- `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
 
 ## Recent decisions worth carrying forward (PR 1 → PR 1b → PR 2)
 
@@ -90,7 +92,7 @@ These flowed out of the PR 1 + PR 1b rituals (Sessions 13-36). General patterns 
 - **Decision journal:** `docs/plans/2026-04-30-metadata-rebuild-stakeholder-decisions-resolved.md` (per-card Decision + Reasoning + Implications)
 - **Implementation plan:** `docs/plans/2026-05-03-metadata-rebuild-foundation-implementation.md` (WHAT for each PR's tasks)
 - **Validator architecture (Gate B output):** `docs/plans/2026-05-03-metadata-rebuild-foundation-validator-architecture.md`
-- **Archive (Sessions 1-36 full journal):** `docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status-archive.md`
+- **Archive (Sessions 1-46 full journal):** `docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status-archive.md`
 
 Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 - `feedback_*.md` for process patterns: `feedback_pr_bot_review_workflow.md` / `feedback_bot_review_investigation.md` / `feedback_pr_comment_surfaces.md` / `feedback_per_round_test_db_verification.md` / `feedback_data_safety_top_priority.md` / `feedback_no_docs_push_during_pr.md` / `feedback_plain_language.md` / `feedback_opus_subagents.md` / `feedback_multi_session_execution.md` / `feedback_workflows_not_sacred.md` / `feedback_user_relearning.md`
@@ -99,395 +101,61 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 
 ## Recent session log
 
-### Session 37 — 2026-05-07 — PR-cycle archival + 2 feedback promotions
+### Session 47 — 2026-05-08 — PR 4 cycle started: 21 imports soft-retired + 7 concepts recovered + FSA retitle (migrations local-only)
 
-**Done (1 docs commit on `docs/session-36-pr1b-shipped`, accumulating with Session 36's `c6b68f7`):**
+**Done (1 substantive commit `ed8ca21` + PR-cycle archival on disk + this session-end docs commit):**
 
-- **Moved Sessions 28-36 from active file into archive** per kickoff session-end ritual step 5 ("PR-cycle archival, do at the START of each new PR cycle"). Active file shrunk from 392 lines to ~95 lines (Current State + decisions + out-of-scope + pointers + this single session entry). Archive grew by 9 sessions (PR 1b cycle: Tasks 1b.1-1b.8 implementation Sessions 28-32 + PR push/round-1/round-2/ship Sessions 33-36).
+- **Branch setup**: pulled main → `cf2aad4` (PR 2 squash); branched off as `feat/metadata-foundation-corpus-cleanup`; cherry-picked `07d9878` (Session 46 docs commit on the merged PR 2 branch) → `0672cc8`. Per Session 38 precedent, the merged-branch session-end docs commit bundles into the next PR.
 
-- **Reconstructed missing Session 34 header.** During the move the source file was missing `### Session 34 — 2026-05-06 — PR 1b round 1 bot triage + fix-up shipped (commit \`131168b\`)` between Sessions 33 and 35 (3 blank lines where the header should have been; body started at "**Done (1 commit + 1 docs commit pending):**"). Fix-up reconstructed from cross-references in surrounding sessions: Session 35's "Round-cap-of-2 rule activated for round 3+" + Session 36's "round-2 fix-up's CI completion" + Out-of-scope follow-up's `131168b` reference all triangulate to Session 34 = round-1-fix-up. Committed the reconstruction as part of the archive append.
+- **Pre-flight investigation** (4 PROD probes via `mcp__supabase-remote__execute_sql`):
+  1. **Drop list count** — all 21 listed lesson_ids confirmed; structural sweep for additional candidates returned 30 false positives (older ESYNYC `Aim:`/`Summary:` template that doesn't use the literal "Opening Circle"/"Engaging Activity"/"Question of the Day" phrases). Spec count "23" identified as stale early estimate; locked actual count is 21. TEST↔PROD parity exact.
+  2. **FK + user-state audit** — bookmarks_total=0 (PROD has zero bookmarks anywhere), 0 lesson_versions on drops, 0 collections, 0 submissions, 0 reviews, 0 similarities. 2 historical references to drop list: Leaves We Eat (`0B1MDYcmyESHgWDIyelRWbHljZ1k`) + Stone Soup (`1syFNS-FUiVWUvkZRhfyxfXc0ukDrwnkO`) are canonical winners of dedup `group_6` and `group_82` (resolved 2025-09-01 `merge_and_archive`). Soft-delete preserves these references intact.
+  3. **FSA current title** — confirmed "Food System Advocates (Part 1 & 2)" exists at lesson_id `1iqGFHrQ0rWfyoLo4R4n8FO9N-S7LW1ZpalaLNF5_Tmk`; tags + format columns NULL.
+  4. **Archive-only concepts** — 7 distinct lesson_ids have ~19 concepts surviving only in `lesson_versions` archive (all archived 2026-04-27 Phase 6.2). The `v_title='Unknown'` outlier (`11oY-EaKF7FTeNxSE_xbsCmSytnBmjc9WPlyBF11Chz0` for live "Green Acai Bowls") still has a plausible concept (`{Science: [garden exploration]}`); only the concept JSONB blob is recovered, not the title field.
 
-- **Promoted 2 patterns to `feedback_pr_bot_review_workflow.md`** per Session 36's process notes (which explicitly flagged them as candidates for promotion):
-  1. **Empirical evidence can escalate a single-voice low-confidence finding to P0.** From Session 34 (PR 1b round 1): Codex P2 #1 framed as "2 historical rows"; TEST + PROD MCP probe revealed all 113 historical scalar `tagged_metadata.activityType` rows had the bad shape, every reviewer reopen crashing to error boundary. Reachable via 'approved'/'all' filter — mainline. The pattern: for any single-voice finding citing a small row count, run the corresponding MCP probe before triage; the escalation can be load-bearing.
-  2. **Active-PR session-orientation rule (always check PR review state at session-start).** From the 4-occurrence pattern across Sessions 33→34→35→36: when a session opens and the prior session's status doc claims "N commits unpushed" or "awaiting round N", that's stale because the prior session's docs commit didn't push (per `feedback_no_docs_push_during_pr.md` they bundle with next fix-up), CI ran on the pushed fix-up, bots reviewed it, round N+1 fired between sessions. Mitigation: at session-start, run `git log @{u}..HEAD` AND `gh pr view <PR> --json reviews,comments` for any active PR. Trust git + live PR state; refresh Current State header inline before proceeding.
+- **Three implementation decisions surfaced + locked** (see Current State for full statements):
+  1. Soft-delete via `retired_at` + `retired_reason` columns with cluster-key namespace.
+  2. 404 UX for direct-link to retired lessons.
+  3. Filter retired in 6 surfaces (lessons_with_metadata view + search_lessons RPC + smart-search + lesson detail + facetCounts.ts + embedding regen); detect-duplicates + content-hash dedup intentionally NOT filtered.
 
-- **Type-coupled cluster impl-plan flaw NOT promoted (single occurrence).** Session 30 surfaced this in PR 1b — schema-shape change cascaded through Tasks 1b.3 + 1b.4 + 1b.5 type-couplings, breaking tsc invariants if shipped piecemeal. The note explicitly self-described as "candidate for `feedback_*` if it recurs"; PR 1b's later sessions (31, etc.) had truly independent tasks (Session 31 explicitly noted the contrast) so no recurrence yet. Stays in the active file's Recent decisions section as a watch-pattern for PR 2+; promote if it recurs.
+- **Migration 1 — `20260520000000_corpus_cleanup_retire_imports.sql`** (107 lines). Adds 2 columns; UPDATEs 21 rows with cluster-key reasons; UPDATEs FSA row to drop "& 2"; idempotent guards.
 
-- **Audit pass on Out-of-scope follow-ups** — no new resolutions to remove, no new entries to add. Current 12 entries all carry forward.
+- **Migration 2 — `20260520010000_recover_archive_only_concepts.sql`** (149 lines). Restores `academicConcepts` from `lesson_versions.metadata.academicIntegration.concepts` into live `lessons.metadata.academicConcepts` for 7 lesson_ids. DISTINCT ON (lesson_id) + ORDER BY version_number DESC defensively. Idempotent (`AND l.metadata->'academicConcepts' IS NULL OR ...`). Per-row ROLLBACK enumerated.
 
-**Decisions made:**
+- **Local verification clean**: `supabase db reset` applies all migrations; MCP probe confirms columns; type-check + lint + vitest 575/575.
 
-- **`docs/session-36-pr1b-shipped` accumulates Session 37's commit too** rather than branching for the archival. Per kickoff session-end ritual step 4 ("Commit the status file"), this session's docs work commits on the current branch. The carrier choice (bundle into rebased PR 2 OR open standalone docs PR) was already deferred from Session 36; deferring it again to Session 38 is the cleanest call. The branch now holds 2 commits ahead of main: Session 36's status update + Session 37's archival.
+- **PR-cycle archival** (per kickoff session-end ritual step 5, fires at session 1 of new PR cycle): Sessions 37-46 (PR 2 ritual cycle) moved from active execution-status.md → archive file. Active file shrinks from 493 → ~135 lines (Current State + Recent decisions + Out-of-scope + Pointers + Auto-loaded MEMORY + Session 47 entry + archive pointer). Archive grows by ~417 lines (sessions 37-46 + intro section header summarizing the PR 2 cycle).
 
-- **Did NOT delete the merged feature branches** (`feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema`). Per past PR 1 + PR 1b precedent ("deletable at convenience"), branch retention is user-side cleanup. Keeping them avoids any risk of deleting work that hasn't fully replicated forward; user can run `git branch -D` at any time.
-
-- **Did NOT touch `feat/metadata-foundation-llm-tagging`** (PR 2 branch). Rebase work is the substantive next-session task; archival session stays scoped to docs-only changes per kickoff "ONE task per session" guidance.
-
-**Process notes for Session 38+:**
-
-- **Order on next session:** PR 2 rebase first (substantive), then carrier choice (small follow-up). The PR 2 rebase is non-trivial (`complete_review_atomic` `CREATE OR REPLACE` collision + tags side-channel re-fold + migration timestamp rename to sort after `20260518100000_*`). Plan: `git checkout feat/metadata-foundation-llm-tagging && git rebase main`, work the conflict via Edit, verify via `mcp__supabase-test__execute_sql pg_get_functiondef(...)` post-rebase, commit-amend the rename + body merge as one logical fix-up.
-
-- **Carrier choice options for the docs commits.** Bundle into rebased PR 2: simplest, no extra PR overhead, but the docs commits land in PR 2's history under PR 2's title. Open a standalone docs PR: cleaner separation, but adds PR overhead for what's effectively just session-end housekeeping. The bundle path matches `feedback_no_docs_push_during_pr.md` spirit (don't burn CI cycles on docs-only pushes).
-
-- **Watch the type-coupled cluster pattern.** PR 2's Task 2.4-2.5 will write to columns + Zod + mappers + edge function (LLM auto-tag wires across all four surfaces). If the impl plan has decompose-by-file ordering and any task introduces a type-shape change, expect tsc-break invariants to require cluster shipping like Session 30. Better to plan cluster commits up front than rediscover the pattern.
-
-### Session 38 — 2026-05-08 — PR 2 rebase onto PR 1b (main `bd9d6e4`) + Sessions 36+37 docs bundled
-
-**Done (10 commits on `feat/metadata-foundation-llm-tagging` after rebase, accumulating with this session-end docs commit):**
-
-- **Rebased PR 2 onto `bd9d6e4`** (main with PR 1b shipped) via cherry-pick approach. `git reset --hard main` + cherry-picked 7 code commits in chronological order (the 13 stale docs commits from PR 2 dropped). New SHAs: `66ad77d` (Task 2.2a — ai_draft_metadata columns) → `97c35ab` (Task 2.2b — ReviewDetail reads draft, autosquashed test fix-up included) → `1e9fa8a` (Task 2.2c — tags side-channel migration RENAMED + body merged) → `7cd2a3f` (Task 2.2 — eval-gate harness) → `5eeaf47` (Task 2.3 partial — CRF eval inputs) → `efefcff` (Task 2.3 ship — CRF canonical run) → `67a3cd7` (Task 2.3 step 5 — CRF auto-tag in process-submission edge fn).
-
-- **Migration rename + body merge** (commit `1e9fa8a`). Renamed `20260517000000_complete_review_atomic_tags_side_channel.sql` → `20260519000000_*` so it sorts AFTER PR 1b's `20260518100000_complete_review_atomic_activity_type_multi.sql`. Body re-folded to carry both: PR 1b's array-passthrough for `activityType` (INSERT site uses `_phase4_jsonb_text_array(v_meta->'activityType')`; UPDATE site uses `_phase4_jsonb_text_array_or_null(v_meta->'activityType')` + COALESCE chain) AND PR 2's tags side-channel (declare `v_ai_draft jsonb`, pluck from `v_submission.ai_draft_metadata`, write `tags` column in INSERT, carry-forward `tags` in UPDATE). Header comment documents the rebase + rename context for future readers; rollback comment updated to point at PR 1b's body as the revert target. ROUND of CREATE OR REPLACE preserved grants; signature unchanged.
-
-- **Test fix-up for `reviewMetadataInit.test.ts`** (autosquashed into `97c35ab`). PR 2's original test expected `activityType: 'cooking'` (scalar) per merge-base `lessonToReview` mapper signature; PR 1b changed `lessonToReview` to return arrays, so the test had to update to `activityType: ['cooking']`. Auto-squashed via `git commit --fixup=<sha>` + `GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash bd9d6e4` so the per-commit invariant "every commit's tests pass" holds for git bisect. Other 5 tests in `reviewMetadataInit.test.ts` (null/undefined inputs, schema-failure cases, empty draft) all unchanged.
-
-- **Bundled Sessions 36 + 37 docs into PR 2.** Cherry-picked `c6b68f7` (Session 36 — PR 1b SHIPPED + PROD-applied + verified) + `af431f8` (Session 37 — PR-cycle archival + 2 feedback promotions) onto rebased PR 2 branch. Both applied cleanly (status doc + archive only; no code overlap). Carrier choice resolved per Session 37's deferred decision: bundle into PR 2 over standalone docs PR.
-
-- **Local DB rebuild verified.** `supabase db reset` ran cleanly (all migrations applied; seed complete: 5 lessons + 3 users). Final `complete_review_atomic` body inspected via `mcp__supabase__execute_sql pg_get_functiondef` — 6/6 verification signals YES (declare + pluck + INSERT array passthrough + UPDATE array passthrough + INSERT tags from draft + UPDATE tags carry-forward). Schema check confirms `lesson_submissions.ai_draft_metadata jsonb` / `lessons.tags ARRAY` / `lessons.activity_type ARRAY` / `lessons.lesson_format` dropped. Migration list shows `20260516000000` → `20260518000000` → `20260518100000` → `20260519000000` (correct order; orphan `20260517000000_*` is gone). 569/569 tests passing.
-
-- **Backup branch `backup/feat-metadata-foundation-llm-tagging-pre-rebase` created** before `git reset --hard main`. Allows recovery of the original 20-commit PR 2 branch if rebase needs to be undone. Deletable after PR 2 ships.
+- **Migration commit `ed8ca21`** + this session-end docs commit on `feat/metadata-foundation-corpus-cleanup`. Branch is 2 commits ahead of main (Session 46 docs cherry-pick `0672cc8` + Session 47 migrations `ed8ca21`); session-end docs commit makes 3 ahead.
 
 **Decisions made:**
 
-- **Cherry-pick approach instead of `git rebase main`** (captured as new bullet in "Recent decisions worth carrying forward"). Vanilla rebase would have hit ~13 separate docs conflicts (one per docs commit since main's docs are now PR 1b's Session 37 archival state vs PR 2's older Session 17-27 layout). Cherry-picking only the 7 code commits bypassed all docs conflicts; docs re-bundled cleanly via fresh cherry-picks + this session-end docs commit.
+- **Soft-delete over hard-delete or archive-table.** 0 bookmarks in PROD makes user-state preservation moot, but soft-delete still wins on (a) reversibility (UPDATE retired_at = NULL), (b) historical FK preservation (the 2 dup_resolutions / lesson_archive references stay intact), (c) smaller blast radius (no row deletes, no Phase 6.2 §4D FK-checklist gauntlet). Hard-delete + Drive-folder-backup adds operational overhead for a population that's pre-Phase-6.2 batch imports with no submission lineage. Archive-table approach would split rows across two tables and adds FK-handling work.
 
-- **Migration sort-key `20260519000000`** chosen to sort cleanly after PR 1b's `20260518100000_*`. Convention: when same-day or adjacent migrations conflict, advance one full UTC day to dodge the digits-vs-underscore ASCII gotcha (per MEMORY.md migration-naming note). Today's actual date is 2026-05-08; `20260519` is purely a sort key.
+- **Cluster-key reason namespace, not free-text.** Free-text is more flexible but harder to aggregate. Cluster keys (e.g., `import:foodcorps_2017`) enable forward audit queries like "show all FoodCorps imports retired" without re-scanning content. Foundation-phase PR 4 has 7 cluster keys. Future retirement reasons can use other namespaces (e.g., `dedup:near_duplicate_winner` if dedup work later retires a row); namespace separation makes intent explicit.
 
-- **Bundle Sessions 36 + 37 docs into PR 2** (carrier choice resolved per Session 37's deferred decision). Cherry-picked into rebased PR 2 branch directly; standalone docs PR rejected as overhead-heavy for what was effectively PR 1b's session-end housekeeping. Matches `feedback_no_docs_push_during_pr.md` spirit — no separate CI cycle for docs-only changes.
+- **404 UX over retirement page or banner.** 0 bookmarks anywhere in PROD means no user is depending on direct links. A retirement page would require a new component + a non-filtered query path; a banner would render the lesson normally and undercut the point of retirement. Phase 2 reviewer-UX redesign can revisit if a use case emerges.
 
-- **Test fix-up auto-squashed instead of standalone fix-up commit.** Per-commit "tests pass" invariant matters for git bisect; the test was correct vs the merge-base mapper but wrong against the rebased mapper, so it semantically belongs IN the cherry-picked Task 2.2b commit, not as a follow-up.
+- **Six filter surfaces, two intentionally exempt.** lessons_with_metadata view + search_lessons RPC + smart-search + lesson detail + facetCounts.ts + embedding regen all need the filter for consistency; partial application would create a confusing partial-retirement state (invisible from search but accessible by URL). detect-duplicates + content-hash dedup stay unfiltered because cross-checking against retired imports at submission time is useful (helps prevent re-importing the same FoodCorps Stone Soup).
 
-- **Did NOT delete merged feature branches or `docs/session-36-pr1b-shipped` this session.** Per past PR 1 + PR 1b precedent ("deletable at convenience"), branch retention is user-side cleanup. Leaving them in place avoids any risk of deleting work that hasn't fully replicated forward; user can `git branch -D` at any time.
+- **Spec-count "23" → actual "21" — note in migration header, no further investigation.** The structural sweep returned 30 false positives + 0 obvious additional candidates. If 2 more candidates surface later (via, e.g., reviewer feedback or a more sophisticated Opus re-read), a follow-up migration can extend the retirement set; the soft-delete mechanism generalizes.
 
-**Process notes for Session 39+:**
+- **Migrations committed in one substantive commit, docs in a separate commit** (matches PR 1b/2 patterns). Cleaner git log for the next session's review pass.
 
-- **Vanilla `git rebase` is rarely the right primitive when stale-docs commits are involved.** The cherry-pick approach generalizes: identify the substantive (code/feature) commits vs the housekeeping (docs/status) commits; cherry-pick only the substantive set; re-run docs work fresh at the end. Watch for recurrence of this pattern; promote to feedback memory if it happens again on a future rebase.
+**Process notes for Session 48+:**
 
-- **Watch the type-coupled cluster pattern in Task 2.4.** PR 1b's Session 30 learning: when a task's schema-shape change touches Zod + mappers + consumer files + tests, ship as one cluster commit, not decomposed by file. Task 2.4 (activity_type prompt) is more contained than PR 1b's Task 1b.3-1b.5 cluster, but if it adds new vocab keys or field shapes, watch for the pattern.
+- **Filter-surface follow-ups still local on this branch** — don't push until they land. Per `feedback_no_docs_push_during_pr.md` spirit, bundle CI cycles. Substrate migrations + filter surfaces ship as one PR.
 
-- **TEST DB verification deferred until PR 2 push.** Rebase substrate work is local-only this session; TEST DB will get the new migrations + edge fn updates when PR 2 opens (CI applies). Per-round verification rule applies to PR rounds (round 0 = initial open), not pre-PR sessions. The 6/6 RPC body signals + schema check via local MCP at session-end give high confidence that TEST will be clean on first apply.
+- **TEST DB verification fires when CI applies migrations** (round 0 = PR open). Per `feedback_per_round_test_db_verification.md`, every subsequent fix-up round needs its own re-verification. The migration apply on TEST is the load-bearing probe (21 retired count + FSA new title + 7 concepts recovered).
 
-### Session 39 — 2026-05-06 — PR 2 Task 2.4 step 1: activity_type prompt + worksheet v2 stub + harness absent-values guardrail
+- **Pre-PROD-apply MCP probe pattern as Session 46 surfaced** — keep doing the body-signal probe pre-PROD-apply as well as round-by-round. Distinct axis from per-round verification. Session 46 explicitly flagged this as a `feedback_per_round_test_db_verification.md` promotion candidate; consider adding the bullet during PR 4's pre-PROD-deploy session if not done sooner.
 
-**Done (1 code commit `fccd05e` + this session-end docs commit pending):**
+- **Pre-delete checklist for any future hard-deletes.** Phase 6.2 §4D pattern (FK refs INTO + FK ref OUT FROM via lessons.original_submission_id) doesn't apply to soft-delete but stays in `MEMORY.md` for future hard-delete work. The Session 47 audit (15-FK-table count probe) is the inverse pattern for soft-delete; document for future PR-cycle reference.
 
-- **Activity_type prompt** at `supabase/functions/process-submission/prompts/activity-type.md` (47 lines). Mirrors CRF prompt structure: role intro → 4 canonical values with example agenda blocks → selection rules with substantial-block bar + tie-breakers → input format (priority order: agenda timed blocks > summary > skills lists > title) → output via `submit_tags` tool, multi-label.
-- **Vocab + thresholds + samples README** scaffolded under `scripts/eval-data/activity-type-{vocab,thresholds,samples.README}.{json,md}`. Vocab matches `ACTIVITY_TYPE_VALUES` from `_shared/metadataSchemas.ts` (4 values, multi-label). Thresholds carry CRF baseline (macroF1=0.7 + minRecallPerValue=0.5) plus the new `maxPredictionRateForAbsentValues=0.10` guardrail. README documents methodology + regeneration SQL + harness invocation + the craft-zero-truth caveat.
-- **Worksheet v2** at `scripts/eval-data/activity-type-relabel-worksheet-v2.md` (2331 lines, 113 entries). Pulled all 113 reviewer-tagged submissions from TEST DB via 4 chunked MCP queries (offset 0/30/60/90, limit 30 each). Each entry: numbered header with title, submission_id + old single-label + body length, summary excerpt (350 chars via SQL `SUBSTRING ... FOR 350` from `position('summary' IN lower(content))`) + agenda excerpt (500 chars from `position('agenda' IN lower(content))`) in `<details>` blocks, empty `**New labels (multi-label):**` line. SQL extracts already replaced newlines with spaces via `REGEXP_REPLACE` so excerpts are single-line; titles with stray `` (vertical tab) characters cleaned during formatting. Two duplicate-title rows (entries 104 + 105: "Welcome and Exploration: How humans work in the garden") flagged inline as "duplicate submission" with byte-identical bodies.
-- **Harness `maxPredictionRateForAbsentValues` threshold** added to `scripts/lib/evalMetrics.ts` (~12 LOC). When a vocabulary value has `truthCount === 0` AND `sampleCount > 0`, computes `predictionCount / sampleCount` and fails if > ceiling. Failure message names the value + the rate + the absent-from-truth context: `prediction rate X.XXX for "<value>" exceeds ceiling Y when value is absent from truth (N of M samples)`. Threshold schema mirror in `scripts/eval-llm-tagging-prompt.ts` updated; help text extended with the new flag. 4 new unit tests added (above-ceiling fail; at-ceiling pass; truthCount>0 no-op; empty-input no-op); 21/21 evalMetrics tests passing.
-- **Comment block on the new threshold key** documents the WHY: CRF's reference set has truth coverage for all 7 features (truthCount ≥ 48 per feature on 353 rows); activity_type's reference set may have zero craft labels under old vocab so per-value craft recall is undefined, but a runaway false-positive rate is still a fail. Generalizes to any vocabulary value missing from truth; not craft-specific.
+- **Watch for type-coupled cluster pattern in filter-surface follow-ups.** Adding `WHERE retired_at IS NULL` to `lessons_with_metadata` view changes the projection's row count; if any test fixture or RPC consumer counts rows in a way that drops retired lessons, those break together. Per Session 30 PR 1b learning, ship as one cluster commit if type-narrowing cascades.
 
-**Decisions made:**
+- **The `search_lessons` RPC will need a DROP+CREATE pattern** if the filter clause changes function signature (e.g., adding a `filter_include_retired` boolean for forward flexibility). Otherwise a `CREATE OR REPLACE` is fine — same pattern Task 1.4b used to add `filter_tags`. Decide at impl time based on whether the API needs an opt-in escape hatch.
 
-- **Worksheet body excerpts use `<details>` blocks rather than blockquotes or markdown tables.** v1 used `<details>` and the format read cleanly during reviewer triage. Blockquotes would force line-by-line `>` prefixing on multi-line excerpts; tables would break on the `|` characters embedded in Google-Docs-table-extracted bodies. `<details>` keeps the worksheet visually compact when scrolling and lets the reviewer expand only the rows where summary alone is ambiguous.
-- **Single SQL substring window per excerpt section, not full-body context.** Pulled 350 chars of summary + 500 chars of agenda per row. Tried full-body excerpts in the first sample query (~5K-17K chars/row) — would have hit MCP's 25K-token output cap inside 5 rows. Trimmed to the structurally-meaningful sections (Summary cell + Agenda cell) where body content has predictable shape. If reviewer needs longer context for any row, regeneration SQL is documented in the samples README + the worksheet footer offers per-row pull on request.
-- **Pre-formatted markdown via SQL string concatenation considered, rejected.** Could have built the row markdown inside the SQL `SELECT` and pasted output verbatim; would have saved ~20% of the formatting cost client-side. Tradeoff: harder to debug if format glitches; tighter coupling between query + worksheet structure. Decided client-side formatting is more flexible for the one-off worksheet build (per-row tweaks easier).
-- **No "Reviewer's Distilled" line per row.** v1 had Claude-pre-summarized 1-sentence synopses per row. v2 omits — the summary excerpt + agenda excerpt are already pulled from the body, and reviewer-side reasoning is more grounded when working from raw body excerpts than from Claude's pre-judgment. Cuts ~$30 in API cost (113 reads × Opus body summarization) + ~30 min of session-side processing time. Worth it.
-- **maxPredictionRateForAbsentValues uses `>` not `>=`** for the ceiling comparison. A rate exactly at the ceiling passes, mirroring `minRecallPerValue` semantics where the floor compares with `<`. The unit test "passes when an absent-from-truth value is predicted at or below the ceiling" exercises the edge case at rate=0.1, ceiling=0.1.
-- **Threshold key named for the general principle, not the specific use case.** `maxPredictionRateForAbsentValues` rather than `maxCraftRate` or `craftGuardrail`. Future eval gates may have other vocabulary values absent from a given truth set (e.g., a tags eval where neither orientation nor bilingual_handouts shows up in the user's labeling); this rule fires for all of them automatically.
+### Sessions 18-46 — archived
 
-**Process notes for Session 40+:**
-
-- **User labeling is the bottleneck.** Worksheet v2 stub stops at the empty `**New labels (multi-label):**` lines; user fills 113 rows over ~2-3 hrs. Resume after user signals done. Parser to write Session 40 will be similar shape to whatever ad-hoc parsing CRF samples used; if no formal parser exists, build a small `scripts/build-activity-type-samples.mjs` that reads worksheet markdown + writes samples.json.
-- **Watch for the CLIProxyAPI cache_read=0 cost gotcha at canonical eval time.** Per Session 25 + MEMORY.md, every harness call through the proxy shows `cache_read=0` even with explicit `cache_control: ephemeral`. Per-call cost ~3-4× direct Console API rates. Activity_type canonical run on 113 samples expected ~$30 via proxy vs ~$7 direct. User has $200 Max extra-usage budget; ~6 prompts at proxy rates fits, but if running tight, drop the `--base-url` flag and bill against Console API instead.
-- **No type-coupled cluster pattern fired this session.** Per Session 30 PR 1b learning, schema-shape changes touching Zod + mappers + edge fn + tests need to ship as one cluster commit. Task 2.4 step 1 added a new threshold key to one file (evalMetrics.ts) + threshold-schema mirror in one file (eval-llm-tagging-prompt.ts) + threshold-config JSON + unit tests; no schema-shape change. Watch for the pattern at Task 2.4 step 4 (wire into process-submission/index.ts) — should mostly be additive (one more `loadX()` + one more Anthropic call + one more Zod validation), no type narrowing across consumers.
-
-### Session 40 — 2026-05-06 — PR 2 Task 2.4 step 2: worksheet labels + samples.json built
-
-**Done (1 code commit `a426114` + this session-end docs commit pending):**
-
-- **User completed worksheet labels** between sessions: 113/113 entries filled in, 0 invalid labels (all in canonical 4-value vocab `cooking / garden / academic / craft`), 0 empty lines. Local pre-build parse confirmed parseability before any DB work. Per-label distribution: garden 68 / cooking 34 / craft 13 / academic 11; 12 multi-label rows (10.6%, range 2-2 labels per multi row). Old-vs-new shifts: garden 67→68, cooking 33→34, academic 11→11 (unchanged), `both` 2→0 (retired; expressed as `cooking, garden`), craft 0→13 (new value; reviewers were forced to mis-classify these in the old vocab).
-
-- **Bodies pulled from TEST DB via `mcp__supabase-test__execute_sql`** in a single query (id + extracted_content for the 113 reviewer-tagged submissions, ordered `extracted_title NULLS LAST, ls.id` matching worksheet order). 113-row payload was 696,399 chars (~700KB) and exceeded the inline MCP cap; the persisted-output file path was returned in the error message. Extracted the JSON-wrapped result via small `extract-bodies.mjs` helper that parses outer JSON → inner JSON → regex match between `<untrusted-data-XXX>` markers → bodies array. Written to `/tmp/activity-type-bodies.json` (intermediate, not committed). 113 unique IDs; perfect overlap with worksheet IDs (0 missing, 0 extra).
-
-- **Built `scripts/build-activity-type-samples.ts`** (200 LOC, npx tsx). Mirrors harness style (zod schema validation, similar argv parsing, similar logging output). Reads worksheet via regex split on `^---$` then per-chunk extraction of `- **ID:** \`uuid\`` and `**New labels (multi-label):** values` (strip inline `<!-- -->` comments before split-by-comma + trim + lowercase). Reads bodies dump + vocab JSON. Validates: every worksheet ID has a body in the bodies dump; every truth label is in vocab; no entry has an empty/missing label line. Exits 0 on success / 1 + per-error report on validation failure. De-duplicates within a single label list with a warn log if duplicates collapsed (none triggered).
-
-- **Ran build → emitted `scripts/eval-data/activity-type-samples.json`** (805 lines, 664KB, 113 entries). Schema matches harness's `sampleSchema = z.object({id, body, truth: string[]})`. Total body chars 652,580 matches MCP sanity query.
-
-- **Verified end-to-end via perfect-prediction dry-run** (no API spend): generated truth-as-predicted from samples.json via 1-line node helper, ran `--dry-run-with-predictions` against full 113-row sample set with all thresholds active. Result: `samples=113`, all per-value P=R=F1=1.000, macroF1=microF1=1.000, exit 0. Confirmed: harness's zod sampleSchema parses; truth-in-vocab validation passes; metrics math runs across all 4 values; threshold logic evaluates; output file format intact.
-
-- **Updated `activity-type-samples.README.md`**: replaced "Eval-gate caveat — `craft` may have zero truth labels" section with "Eval-gate guardrails — actual state after relabeling" reflecting craft truth count = 13 (guardrail dormant, per-value P/R applies); expanded distribution table with both pre- and post-relabel columns; added "How samples.json was built" pipeline section documenting the bodies-pull → build-script invocation. Total body chars + min/max/avg added so future readers can size their MCP pulls.
-
-**Decisions made:**
-
-- **Single full-pull MCP query over chunked batches.** Initial plan was 12 batches of 10 rows (113 rows / 100K-char inline cap = ~12 batches at avg row size). After running batch 0/12 and seeing the persisted-output mechanism fire on the very first batch, realized persistence already bypasses the inline cap — switched to a single 113-row query. Saved 11 round-trips. The `Error: result (696,399 characters) exceeds maximum allowed tokens` is not a failure mode; the persisted file path is fully usable.
-
-- **Build script committed (not ad-hoc).** CRF samples were assembled ad-hoc with no committed build script (verified via `git show 5eeaf47 --stat`); v2 of activity_type takes a different path because (a) Session 39's process notes explicitly called for a build script, (b) Task 2.5 (tags) and any future Gate-C-classified vocab-locked prompts will need similar parser infrastructure, (c) the worksheet → samples.json reproduction is high-leverage to keep machine-driven (avoids manual JSON crafting + paste mistakes). 200 LOC TS file mirrors the harness's style for maintainer continuity.
-
-- **`/tmp/activity-type-bodies.json` intermediate not committed.** Same rationale as CRF's pull (no committed bodies dump): the bodies are already in samples.json once merged, and the regeneration recipe in README + the build-script invocation cover reproducibility. Avoids duplicating ~700KB of body text across two committed files.
-
-- **Worksheet labels committed in the same commit as samples.json + build script.** Worksheet labels are the source-of-truth that drove samples.json; bundling them keeps the data lineage visible in one commit. Matches the way Session 39 bundled prompt + worksheet stub + harness extension into a single Task 2.4 step 1 commit.
-
-- **README distribution table given both pre- and post-relabel columns.** Earlier README had only pre-relabel (single-label) distribution; post-relabel (multi-label) adds a "count truth-occurrences" framing that's cleaner than trying to express multi-label in row-counts. The split also visually shows the `both` retirement and the craft surfacing.
-
-**Process notes for Session 41+:**
-
-- **CLIProxyAPI vs Console API decision required before Task 2.4 step 3.** Per MEMORY.md, proxy adds cache_read=0 → ~3-4× cost vs direct Console API. Activity_type canonical run on 113 samples: ~$30 proxy / ~$7 direct. User's $200 Max extra-usage budget covers ~6 prompts at proxy rates, but if running tight on budget, drop the `--base-url` flag and bill against Console API. CRF run (Session 25) used proxy at $30.23. The decision should surface to the user before the run, not be silently chosen.
-
-- **Most-likely-fail values on canonical run: craft (over-prediction) or academic (small denominator).** Craft: prompt biases toward conservative tagging (substantial-block bar) but `academic, craft` and `craft` are easy to over-recall on lessons with substantial closing art segments. Per-value floor 0.5 recall on 13-row truth = need ≥ 7/13 craft TPs and per-value precision floor not in thresholds. Academic: 11-row truth means each missed academic = 0.091 recall drop; LLM probably tags more conservatively than reviewers on subtle academic-discussion frames. If gate fails, study the per-value confusion in the JSON output before iterating prompt.
-
-- **Watch for the type-coupled cluster pattern at step 4.** Wiring activity_type into `process-submission/index.ts` should be structurally parallel to CRF's wire-up (Task 2.3 step 5, commit `67a3cd7`): one new prompt-load helper, one new Anthropic call, one new Zod-validate-into-`ai_draft_metadata`. Likely additive, no type narrowing — but if a shared interface like `AiDraftPayload` needs widening, ship as one cluster commit covering edge fn + Zod schema + any consumer reads.
-
-- **No PR 2 push this session.** Branch is now 13 commits ahead of main. PR 2 push waits on Tasks 2.4 (3-5) + 2.5 closure. Bundle session-end docs commits with the next code push (`feedback_no_docs_push_during_pr.md` spirit: don't burn CI cycles on docs-only changes).
-
-### Session 41 — 2026-05-07 — PR 2 Task 2.4 step 3: activity_type eval gate cleared + Rule Y hybrid garden
-
-**Done (1 code commit `5e25431` + this session-end docs commit pending):**
-
-- **Canonical eval gate cleared at macroF1=0.887** (gate floor 0.700) on the post-Rule-Y truth set. Per-value F1: cooking 0.889 / garden 0.809 / academic 1.000 / craft 0.852. Macro recall 0.956 / macro precision 0.836. Result file `/tmp/activity-type-eval-result-v3.json` (not committed; CRF pattern doesn't commit eval results).
-
-- **Rule Y design call (mid-session)**: user introduced `garden` as a hybrid tag firing for both hands-on garden activity AND food/agriculture/garden topical content. `academic` becomes mode-exclusive and narrow. The user authored this rule mid-session after seeing v2's failure mode (garden→craft confusion) revealed the reviewers had been using "garden" both topically (lesson is about pollinators / food systems / etc.) and activity-based (students do hands-on garden work) inconsistently across samples. Rule Y disambiguates: garden is hybrid by design; academic is the rare narrow fallback for non-food/non-garden conceptual content (e.g., The Lorax Debate).
-
-- **17 truth retags applied** via one-off helper `/tmp/apply-retags.mjs` (not committed; intentional — script reads `/tmp/retag-pairs.json` and edits worksheet markdown by ID-matching regex):
-  - 7 `[academic]` → `[garden]` or `[garden, craft]` (food/agriculture topical lessons that previously got academic by reviewer judgment): Meet The Food System; African American Food Traditions; Foods From Around the World; How Food Moves (Food Miles); School Lunch Heroes (added craft); The Apple Story (added craft); The Ugly Vegetables (added craft).
-  - 10 `[garden]` → `[garden, craft]` (lessons that already had garden topical truth but had substantial craft activity reviewers didn't tag): All About Birds, Anthotype, Bug Camouflage, Butterflies, Exquisite Plants, Ladybugs, Garden Community, Tea Bags, Honey Bee Pollinators, What Gardeners Wear.
-  - The Lorax Debate stays as the sole `[academic]` entry — deforestation/environmentalism, not food/agriculture.
-
-- **Iteration trajectory** (3 full canonical runs + 1 smoke):
-  - Smoke (5 samples, original prompt): macroF1=0.756 on tiny denominator; passed gate but unrepresentative — only 1 of 5 samples exhibited the academic FP problem.
-  - v1 full (113 samples, original prompt): macroF1=0.605 — failed. Academic FPs 72 of 113 (LLM tagged academic on 73% of lessons; reviewers tagged it on 11). Confusion matrix revealed dominant pattern: opening rituals + closing reflections triggering academic across hands-on lessons.
-  - v2 full (113 samples, mode-exclusive academic prompt + 3 academic-handson outlier retags): macroF1=0.670 — failed (improved by 0.065 but didn't clear). Academic FPs dropped 72→6 (massive precision improvement); but garden FNs grew 19→23 via new garden→craft confusion pattern (LLM read garden-themed-craft lessons as `[craft]` instead of `[garden]`). User's analysis: reviewers were using "garden" both topically and activity-based; the v2 prompt forced activity-based interpretation, dropping topical garden tags.
-  - **v3 full (113 samples, Rule Y prompt + 17 retags): macroF1=0.887 — passed.** Garden recall now 1.000 (was 0.667 in v2); garden precision 0.679 (LLM aggressive on topical tag, fits draft-validate use case where reviewers easily remove extras).
-
-- **README updated** (`scripts/eval-data/activity-type-samples.README.md`):
-  - Distribution table extended to three columns: pre-relabel old vocab / post-v2-relabel / post-Rule-Y retag.
-  - Added "Canonical run result (Session 41)" block with full per-value metrics + actual cost.
-  - Updated cost note: Console API direct ~$2 per 113-sample run (was $7 projection; ~3-4× cheaper than CLIProxyAPI proxy as expected).
-
-- **Cost actuals**: Console API direct billing ~$2 per full canonical run (vs my $5.43 estimate; vs $30 via CLIProxyAPI proxy with `cache_read=0` cost gotcha). User tracked actuals from Anthropic console; my pricing estimates were ~3× over. Total session spend: ~$6 of $9 budget (smoke $0.13 + v1 $2 + v2 $2 + v3 $2). ~$3 budget margin remaining.
-
-**Decisions made:**
-
-- **Direct Console API over CLIProxyAPI proxy** for this run. User had $9 in console credits; proxy would have cost ~$30 via Max billing (cache_read=0 gotcha). Decision: swap `ANTHROPIC_API_KEY` in `.env.local` for a Console key (`sk-ant-api03-...`), keep proxy key under separate name `ANTHROPIC_CONSOLE_API_KEY`, use shell prefix `ANTHROPIC_API_KEY="$(grep ... .env.local | cut -d= -f2)"` to inject at runtime without polluting shell history. dotenv's `override: false` default keeps shell env winning over `.env.local`. Both keys coexist; future runs can pick which billing path.
-
-- **Smoke-then-full vs straight-to-full**: did smoke first ($0.13) to verify Console key works + measure per-call cost. Smoke passed (macroF1=0.756 on 5) but had unreliable signal on academic FPs (only 1 of 5 samples exhibited the problem). For subsequent iterations (v2, v3), went straight to full instead of smoking — v1's full data showed smoke was too small to predict full-run behavior.
-
-- **Rule Y design over alternatives**: when v2 failed, considered three paths — (A) retag the 14 garden→craft outlier truths to `[craft]`, (B) loosen prompt to read garden-themed-craft as `[garden, craft]`, (C) accept v2 as close-to-pass + adjust gate threshold. User picked B with caveat: "garden tag fires for anything plant/agriculture-related, including food systems, food culture, agricultural history" — which became Rule Y (hybrid tag). Strong design call that simplified the entire mental model; reviewer truth was using `garden` inconsistently both topically and activity-based.
-
-- **Retag scope**: 17 lessons total, not the broader cooking-lessons-with-food-discussion. User's intent reading: garden topical fires when the lesson's CONTENT is about food/garden/agriculture (discussion topic, summary, objectives), not just because cooking lessons "involve food." 31 `[cooking]`-only truth labels left untouched — those represent the user's earlier judgment that the cooking activity was the dominant frame, not garden topical.
-
-- **Ship v3 without further iteration**: macroF1=0.887 cleared by 0.187. Garden precision 0.679 (36 garden FPs) is the only soft spot; LLM is being slightly aggressive on the topical tag, applying it where reviewers didn't. For the draft-validate use case, this is the right direction (reviewers easily remove extras; missed tags harder to catch). Pattern across iterations showed each tightening introduced new failure modes; further iteration likely diminishing returns.
-
-- **Don't commit eval result JSON**: CRF pattern doesn't commit `/tmp/*-eval-result.json`; canonical run is regeneratable from prompt + samples + thresholds. Headline numbers captured in commit message + README + this status entry.
-
-- **Don't commit one-off retag scripts**: `/tmp/apply-retags.mjs` and `/tmp/retag-pairs.json` are one-off helpers. Session log + README documents the retag intent; the helper script regex pattern (`(- \\*\\*ID:\\*\\* \`<id>\`[^\\n]*\\n[\\s\\S]*?\\n)\\*\\*New labels \\(multi-label\\):\\*\\*[^\\n]+`) is the reusable bit and is captured here.
-
-**Process notes for Session 42+:**
-
-- **Task 2.4 step 4 should be structurally parallel to CRF wire-up.** Activity_type adds one more prompt loader + one more Anthropic call + one more Zod validation in `process-submission/index.ts`. Key differences from CRF: multi-label tool call (`submit_tags` not `submit_tag`); array shape return (`activityType: string[]`); merge-not-overwrite into `ai_draft_metadata` (CRF writes `cultural_responsiveness_features` key; activity_type adds `activityType` key without dropping CRF's). Verify CRF's pattern handles read-modify-write of `ai_draft_metadata` cleanly before adding the second writer.
-
-- **Watch for the type-coupled cluster pattern at step 4 (per Session 30 PR 1b learning)** — wiring activity_type into the edge function should be additive (one new prompt + one new call site + one new Zod validate). No type narrowing across consumers expected. But if a shared interface like `AiDraftPayload` needs widening, ship as one cluster commit.
-
-- **CLIProxyAPI cost gotcha confirmed**: actual proxy cost was ~$30 (Session 25 CRF) vs ~$2 direct (Session 41 activity_type). The 15× ratio mostly comes from the prompt-cache miss (proxy adds Claude Code's session prompt per call, breaks cache). For future eval runs with budget pressure, direct Console API is dramatically cheaper. The proxy still has a place when burning Max credits is preferred over Console balance.
-
-- **My API cost estimates were ~3× over actuals.** Across smoke + v1 + v2 + v3, my projected cost per call was 2.7-3.5× the actual. Likely my chars-per-token assumption (3.5) was too low, OR Anthropic's billing has a discount I'm unaware of, OR there's a workspace-credit subsidy. For future projections, anchor on user-observed actuals not my pricing math; my math is consistently overestimating.
-
-- **Single-truth-row eval values are stringent.** Academic now has 1 truth row in the 113-sample set. Per-value academic recall is binary: 1.000 if the LLM correctly tags Lorax, 0.000 if it doesn't. Future canonical re-runs need to keep producing this 1/1 to maintain the per-value floor. If the 1-row category becomes a flake risk, options: (a) add 2-3 more academic-only lessons to the sample set (would need to find/invent), (b) drop the per-value floor for academic only via threshold-config exemption, (c) accept the binary signal as load-bearing — a regression on Lorax tells us the prompt has shifted academic interpretation away from the rule.
-
-### Session 46 — 2026-05-07 — PR 2 SHIPPED + PROD-applied + verified (CRF + activity_type LLM auto-tag)
-
-**Done (1 squash-merge to main + this session-end docs commit on the merged feature branch):**
-
-- **Active-PR session-orientation correction** (6th occurrence of the "stale unpushed claim" pattern; rule already captured in `feedback_pr_bot_review_workflow.md`): status doc claimed "1 code commit ahead of origin + docs commit pending" but `git log @{u}..HEAD` was empty at session start — Session 45's CRF test fix-up `c92b94c` AND Session 45's docs commit `8d645c0` had both already pushed. CI ran on `8d645c0` between Session 45 and Session 46.
-
-- **Round-3 bot voice triaged (4-surface query per `feedback_pr_comment_surfaces.md`).** Round-3 fired on `8d645c0`: claude formal review COMMENTED ("No P0/P1 findings. Four P3 observations inline; none block merge") + claude long-form issue comment + 4 inline P3 comments + Codex round-3 reviewer pass at 21:20 UTC ("**No new blocking P1/P2 findings**"; recommends ship). **Both bot voices converged on ship.** Triage shape: 1 P1 (no Anthropic call timeout — already in OOS follow-ups), 2 P2 (`ai_draft_model` last-writer-wins — already in OOS follow-ups; missing test for "existing review row" — `!existingReview` guard at `ReviewDetail.tsx:460` is correct by construction), 5 P3 nits (4 carry-overs from rounds 1-2 + 1 new `evalMetrics.averageDefined` NaN typing nit — callers handle correctly per claude's own admission). Per round-cap rule "fix only critical bugs" — no critical bugs surfaced.
-
-- **Pre-PROD-apply MCP body-signal probe on TEST DB** (added belt-and-braces hygiene step prompted by user mid-session: "did we already do that?"). Status doc claim was that Session 45's commit was test-only so no fresh per-round verification needed; that's true at the round level. But the *pre-PROD-apply* TEST DB body-signal probe via MCP had not been run for PR 2 specifically (only via CI auto-apply + E2E green). Ran the probe; 6/6 green — all 3 ai_draft_* columns present + both PR 2 migrations (`20260518200000`, `20260519000000`) applied + `complete_review_atomic` body has `v_ai_draft` + reads `ai_draft_metadata` + INSERT writes tags from draft + UPDATE has 3-tier COALESCE chain reading `v_ai_draft` (`tags = COALESCE(NULLIF(v_existing.tags, ARRAY[]::text[]), _phase4_jsonb_text_array_or_null(v_ai_draft->'tags'), v_existing.tags)`) + edge fn TEST version 9 has Anthropic SDK + CRF prompt + activity_type prompt with RMW merge. False alarm on initial regex (looked for `_phase4_..(v_ai_draft` as the FIRST arg of COALESCE, but it's the SECOND arg behind `NULLIF(v_existing.tags...)` — chain order is "existing wins, then LLM draft, then preserve NULL").
-
-- **PR #477 squash-merged via `gh pr merge 477 --squash`** at 2026-05-07T21:34:06Z. Squash commit `cf2aad4` on main. PR was MERGEABLE (UNSTABLE mergeStateStatus only because of pre-existing Security Audit failure on `@lhci/cli` chain, not blocking).
-
-- **PROD migrate + edge-function deploy approved by user; both succeeded on first approval.** `migrate-production.yml` run `25523339957` + `deploy-edge-functions.yml` run `25523339945` — no SASL handshake flake on Apply step, no esm.sh CDN 522 flake on edge fn deploy. Order followed kickoff Recent decisions ("migrations-first, edge-functions-second when both PROD workflows queue together").
-
-- **Post-PROD-apply MCP verification ALL GREEN (4 surfaces, 3-signal pattern):**
-  - `lesson_submissions.ai_draft_*` columns: 3/3 present (jsonb + timestamptz + text, all nullable)
-  - `schema_migrations`: both PR 2 migrations applied (`20260518200000` + `20260519000000`)
-  - `complete_review_atomic` body: 4/4 signals (`v_ai_draft` declared, reads `ai_draft_metadata`, array passthrough for v_ai_draft, `tags = COALESCE(NULLIF(v_existing.tags...` chain present); body_length 14,900 == TEST exactly
-  - `process-submission` edge fn: version 30 → **31** (signal 1: version increment ✓); ezbr_sha256 `94e8bb71...` IDENTICAL to TEST's deploy of same merge commit (signal 2: cross-environment match ✓); source has `import Anthropic`, CRF prompt block, activity_type prompt block with RMW merge into `ai_draft_metadata` (signal 3: source-content grep for new code ✓).
-
-- **PR 2 SHIPPED.** Foundation-phase substrate now includes submission-time Opus 4.7 LLM auto-tag for two fields: cultural_responsiveness_features (gated on body containing "cultural responsiveness" header text — older legacy template ~45% of corpus skipped) + activity_type (always-on, multi-label per Rule Y hybrid garden semantics).
-
-**Decisions made:**
-
-- **User-mid-session intercept on TEST DB verification surfaced an axis gap.** Per-round verification covers the "round changed DB-applied state?" axis, but pre-PROD-apply verification covers the "is TEST DB confirmed in expected post-merge state via MCP?" axis. Both axes apply. Session 45's status-doc claim "no fresh verification needed" was correct at the per-round axis but didn't trip the pre-PROD-apply axis. The 2-min MCP body-signal probe is high-leverage and should fire pre-PROD-apply regardless of per-round-verification status. Worth promoting to the per-round verification feedback memory or kickoff PER-PR RITUAL — see Process notes for Session 47+.
-
-- **`gh pr merge --squash` without `--delete-branch`.** Per past PR 1 + PR 1b precedent, branch retention is user-side cleanup ("deletable at convenience"). Auto-deletion would foreclose any need to recover the per-task hashes from the feature branch.
-
-- **Stay on the merged feature branch for this session's docs commit** (vs. checkout main + create `docs/session-46-pr2-shipped`). Session 36's pattern was the latter, but Session 46's docs are short (~150 lines append + Current State refresh) and the next-PR session can cherry-pick from any branch. Lower-friction path: commit on `feat/metadata-foundation-llm-tagging` (already deletable). If user prefers the dedicated docs branch, easy to recreate later.
-
-- **No new out-of-scope follow-ups added this session.** Session 45's three (any-types cleanup, per-field models provenance, Anthropic call timeout) cover the round-3 substantive findings; round-3's only NEW item was the `evalMetrics.averageDefined` NaN typing nit which is too minor to track.
-
-**Process notes for Session 47+:**
-
-- **PR-cycle archival fires at the START of the next PR (Session 47 if it opens a fresh branch).** Sessions 37-46 in the active file move to the archive at that time per kickoff session-end ritual step 5.
-
-- **Branch cleanup deferrable.** All 5 metadata-foundation feature/backup/docs branches are deletable at user convenience. No urgency.
-
-- **Foundation-phase next-PR options.** Three branches the user can pick (see Current State for command-line first steps). PR 3a (search infra) and PR 4 (corpus drops) are independent of Stage 1; the post-PR-2 tags-LLM follow-up needs its sample-set methodology decision before any code work begins.
-
-- **No v-tag yet.** Per Recent decisions "v-tag deferred to end-of-foundation-phase" — PR 2 is the third foundation-phase PR; tagging mid-phase is premature.
-
-- **Pre-PROD-apply MCP probe pattern is high-leverage — promote to feedback memory.** This session's user-prompted "did we already do that?" check turned a routine 2-min step into a confirmed-green pre-flight check that would have caught any TEST-DB-not-actually-applied case before PROD apply triggered. Candidate: append a bullet to `feedback_per_round_test_db_verification.md` distinguishing "per-round verification" (round changed DB-state?) from "pre-PROD-apply verification" (TEST DB confirmed in expected post-merge state?), making both fire independently. Or fold into kickoff PER-PR RITUAL step 9 explicitly. Decide on Session 47.
-
-### Session 45 — 2026-05-07 — PR 2 round 2 triage + 1 accept (CRF test coverage); round-cap activated
-
-**Done (1 code commit `c92b94c` + this session-end docs commit pending):**
-
-- **Active-PR session-orientation correction**: Session 44 status doc claimed "4 commits ahead of origin awaiting push" but `git log @{u}..HEAD` was empty at session start — push happened post-Session 44 docs commit (likely as part of Session 44's session-end ritual after the doc was written). Origin now at `6596782`. CI ran on push; E2E + CodeQL turned green (Session 44's fix-ups landed correctly); only Security Audit remains red (pre-existing `@lhci/cli` chain per MEMORY hygiene-follow-ups). This is the 5th occurrence of the "stale unpushed claim" pattern (Sessions 33, 34, 35, 36, 45) — already captured in `feedback_pr_bot_review_workflow.md`'s active-PR session-orientation rule.
-
-- **Round-2 bot review triaged (4-surface query per `feedback_pr_comment_surfaces.md`).** New review on `6596782` from `claude` at 16:14 UTC: `CHANGES_REQUESTED` with 7 findings (3 P2 + 4 P3). User's Codex round-2 pass at 19:18 UTC recommended 1 accept + round-cap. My rebuttal pass converged with Codex on the same shape: 1 accept, 6 reject.
-
-  - **ACCEPT (1)**: P2 — Missing `culturalResponsivenessFeatures` test in `reviewMetadataInit.test.ts`. Real coverage gap; CRF is the *other* field this PR auto-tags but only `activityType` was tested end-to-end. Two tests added: (a) valid CRF passthrough using actual master-list value `'Communicates high expectations'`, (b) invalid CRF returns null (mirrors existing `activityType` invalid-enum test). 8/8 tests passing (was 6).
-
-  - **REJECT (6)**: P2 `any` types at lines 136-137 — `git blame` proves pre-existing from `2c14ff04` 2025-08-06, ~9 months pre-PR-2; out of scope per kickoff. P2 TOCTOU race on `ai_draft_metadata` SELECT→merge→UPDATE — no realistic concurrent-write path (both LLM steps run sequentially in one edge invocation; `regenerateEmbedding` skips both); atomic JSONB merge is hypothetical-future-proofing. P3 `as ReviewMetadata` cast — load-bearing because `lessonToReview` returns `ReviewFormPayloadValidated` (Zod-inferred), not `ReviewMetadata` (legacy hand-written interface); removing it would couple the new mapper to legacy interface, wrong direction per Gate B architecture. P3 CRF Select `label: v` — verified all 7 master-list features have `value === label` in `filterDefinitions.ts:67-86`, byte-identical output; the cookingSkills/gardenSkills config-lookup pattern exists because *those* fields have slug-vs-label divergence which CRF doesn't. P3 no content truncation — production must match eval harness; `eval-llm-tagging-prompt.ts:191` sends full `body` with no cap. Truncating in production but not eval would cause production to underperform eval (eval-gated metrics CRF macroF1=0.937 / activity_type macroF1=0.887 reflect full-content behavior). Embedding's 8K cap is OpenAI hard limit; Opus is 200K. P3 `evalMetrics.ts` Array.includes — ~10K ops per metric run at current 113-353 sample sizes, harness is one-shot project-internal infra, not a hot path.
-
-  - **Round-1 inline carry-overs all rebutted in same pass:** `ai_draft_model` last-writer-wins (both prompts use same model; logged as out-of-scope); merged JSONB not re-validated (existingDraft was written by *the same function* with prior Zod validation; no untrusted source); two Anthropic clients (code-style nit); no Anthropic call timeout (SDK default 600s, edge-fn cap ~150s is binding constraint; logged as out-of-scope); ReviewDetail form-init guard (verified at `ReviewDetail.tsx:460` — AI draft block lines 470-473 IS inside `if (!reviews || reviews.length === 0)`; bot's "guard isn't visible in diff" claim was wrong).
-
-- **Fix-up commit `c92b94c`** — added 2 tests to `src/pages/reviewMetadataInit.test.ts`. vitest 8/8 green; type-check + lint clean. Test value `'Communicates high expectations'` chosen from actual Brown CR master list per Codex round-2 guidance — Claude's sample `'Windows-mirrors-and-sliding-doors'` is not a real CR feature.
-
-- **3 new out-of-scope follow-ups added** to status doc: (1) pre-PR-2 `any` types cleanup PR; (2) per-field `_models` provenance inside `ai_draft_metadata` for future model divergence; (3) explicit 30s Anthropic call timeout for resilience hardening.
-
-- **Round-cap activated** per kickoff PER-PR RITUAL ("round-cap after 2 rounds"). Round 1 = Session 44 fix-ups (back-sort migration rename + CodeQL regex). Round 2 = Session 45 fix-up (CRF test coverage). Any round-3 bot voice triages to "fix critical bugs only, document the rest, ship" — design preferences, perf nits, and pre-existing issues all auto-defer.
-
-**Decisions made:**
-
-- **Skipped fresh TEST DB verification this session.** Session 45's commit is test-only (no DB-applied state changed). The 6/6 RPC body signal probe + edge-function 3-signal verification can wait until pre-PROD-deploy. Per `feedback_per_round_test_db_verification.md` the rule is "every round that touches DB-applied state needs its own evidence" — test-only round doesn't trigger it. Session 44's push (which CI applied) is the most recent DB-affecting verification, and Codex round-2 confirmed via E2E logs the apply step ran and listed both renamed migrations correctly.
-
-- **Bot voice convergence as round-cap signal: Codex round-2 + my rebuttal pass aligned independently on 1 accept (CRF test). The convergence between independent analyses on the same accept choice — and on the same rejection rationales — is the signal that no real bug is being missed. Single-voice from claude on the rejected findings is the absence-of-convergence pattern that justifies the round-cap.
-
-**Process notes for Session 46+:**
-
-- **Push timing.** Per `feedback_no_docs_push_during_pr.md` bundle the docs commit with the next code push. Session 46 picks up with `git push` to send Session 45's code fix-up + this docs commit together. Watch CI for ~10 min to confirm checks remain green.
-
-- **Round-3 watchpoint.** If a third claude review fires, follow round-cap protocol: only fix findings that show convergence with another bot voice OR represent real production bugs. Use the same 4-surface query + rebuttal pass shape — but compress the report (kickoff "ROUND-CAP AFTER 2 ROUNDS — fix only critical bugs, document the rest, ship").
-
-- **Ready-to-ship boundary.** Once CI is green and no round-3 bot voice arrives within ~1 hour of CI completing, the PR is ready for user-decision merge. `c92b94c` + Session 45 docs is the last fix-up; pre-PROD-deploy verification (3-signal edge fn + 6/6 RPC body) fires after squash-merge but before approving the production migration in CI.
-
-### Session 44 — 2026-05-07 — PR 2 round 1 fix-ups: migration rename for back-sort + CodeQL regex slice
-
-**Done (2 code commits + this session-end docs commit pending — local only per `feedback_no_docs_push_during_pr.md` until next push):**
-
-- **Active-PR session-orientation per Session 43's process note**: ran `git log @{u}..HEAD` + `gh pr view 477 --json reviews,comments,state,mergeable` + `gh pr checks 477` + four-surface comment query (issue-comments + reviews + line-comments + failing-job logs). Findings: bots have all completed reviews (claude-review + GHAS CodeQL + user's own Codex pass at 15:45); 3 failing checks (E2E Tests, Security Audit, CodeQL); zero P1 from bot voice convergence — bot voice is single-voice `claude` on substance + single-voice `GHAS` on the regex; Security Audit is the pre-existing `@lhci/cli` chain (already in MEMORY hygiene-follow-ups, not introduced by this PR).
-
-- **Migration back-sort root cause investigated** via `mcp__supabase-test__execute_sql` + `mcp__supabase-remote__execute_sql` against `supabase_migrations.schema_migrations`. Both TEST and PROD are at `20260518100000` (PR 1b's tip) — neither PR 2 migration is recorded on either DB, and `lesson_submissions.ai_draft_metadata` columns do NOT exist on TEST (column probe returned `[]`). **Codex review's claim ("TEST has 20260516000000 and 20260519000000 recorded") was WRONG** per fresh probe — likely Codex hallucinated or read against a different DB. Rule learning: single-source MCP claims in review comments can be stale; always re-probe at the time of action, not at the time of review.
-
-- **CI behavior chain confirmed**: `supabase db push --dry-run` (line 59 of `.github/workflows/e2e.yml`) exits 1 on the back-sort detection ("Found local migration files to be inserted before the last migration on remote database"); `set -o pipefail` propagates the exit code; GHA's default fail-fast skips the subsequent `supabase db push` step (line 121) because its `if:` check doesn't override the implicit `success()`. The migration genuinely never applied. The bug is the FILENAME (timestamp), not the body.
-
-- **Fix-up commit 1 (`fff430d`) — migration rename via `git mv`**: `20260516000000_lesson_submissions_ai_draft_metadata.sql` → `20260518200000_lesson_submissions_ai_draft_metadata.sql`. New timestamp sorts cleanly post-PR-1b (`> 20260518100000`) and before PR 2's RPC migration that reads these columns (`< 20260519000000`). Body unchanged (additive `ADD COLUMN IF NOT EXISTS` + comments). Header gets a context block explaining the rename + rationale for the rule exception (mirrors `20260519000000_*`'s own rename header pattern).
-
-- **Fix-up commit 2 (`4ea642b`) — CodeQL regex slice**: replaced `replace(/<!--.*?-->/g, '')` on `scripts/build-activity-type-samples.ts:90` with `indexOf('<!--')` + `slice` approach. Clears 2 CodeQL alerts (alerts #23 "Incomplete multi-character sanitization" + #24 "Bad HTML filtering regexp"). Behavior-equivalent on real worksheet input — only 1 occurrence of `<!--` in the entire current worksheet, in the intro section, not in any label line. Inline comment documents the intent: treat `<!--` as a line-comment terminator, not as one half of an HTML tag pair.
-
-- **Local verification clean**: `supabase db reset` (all 15 migrations apply in correct order; 4 ai_draft_* columns present per local MCP probe; `schema_migrations` shows `20260518000000 → 20260518100000 → 20260518200000 → 20260519000000`) + 573/573 tests + type-check + lint all green.
-
-- **Other claude bot findings rejected per user's own Codex triage** (concur with all rejections): `ai_draft_model` last-writer-wins (P3 — both models are `claude-opus-4-7` today, no real divergence); `user`/`supabaseClient: any` (pre-existing on `origin/main`); `SubmissionDetail` missing `ai_draft_metadata` field (type-doc only — `ReviewDetail` reads through `submissionData`, not the typed interface); merged JSONB not re-validated before write (P3 hardening, no current risk); duplicate Anthropic client + missing LLM timeouts + literal vocab values in tests + CLI `console.log` (all P3 nits, kickoff "don't refactor beyond task" applies).
-
-**Decisions made:**
-
-- **Rule-exception rename over reset-TEST-DB**. The `database-migrations` skill + `supabase/migrations/CLAUDE.md` explicitly say "NEVER edit a migration file that has been pushed." The skill offers two escape paths: (a) "create a new fix migration", or (b) "reset TEST DB". Neither fits this bug — (a) can't fix a back-sorted FILENAME (the back-sorted file would still be in the tree tripping `db push --dry-run`); (b) is heavyweight (~800 rows of TEST data) and unnecessary because no remote DB has the migration applied. The rule's spirit is "don't drift TEST/PROD" — that drift cannot occur when TEST has nothing applied. Documented the exception explicitly in the migration file header + commit message + a new bullet in Recent decisions covering the exception class. User pre-approved the rename approach in this session before any file changes.
-
-- **Two fix-up commits, not one combined**. Cleaner git log + bisect; matches Session 43's "round-N fix-up pattern." Squash-merge collapses to one commit on main anyway.
-
-- **Skipped Security Audit fix.** Pre-existing `@lhci/cli`/`tmp`/`postcss`/`basic-ftp`/`ip-address` chain (already in MEMORY.md hygiene-follow-ups). Not introduced by this PR. Belongs to a focused dependency-upgrade PR; outside this round's scope per `feedback_pr_bot_review_workflow.md` rule "default-reject hardening for internal-only."
-
-**Process notes for Session 45+:**
-
-- **Push bundle = 4 commits ahead of origin**: Session 43 docs (`4ef9cb0`) + rename (`fff430d`) + regex (`4ea642b`) + Session 44 docs. Per `feedback_no_docs_push_during_pr.md`, Session 43's docs commit rides along with the fix-ups instead of pushing standalone (avoid CI cycle on docs-only changes).
-
-- **TEST DB verification fires when CI applies the renamed migration** (this is round 1 of bot review per `feedback_per_round_test_db_verification.md`). Required probes: 6/6 RPC body signals on `complete_review_atomic` (declare `v_ai_draft jsonb` + pluck from `lesson_submissions.ai_draft_metadata` + INSERT array passthrough for `activityType` + UPDATE array passthrough for `activityType` + INSERT tags from draft + UPDATE tags carry-forward) + tags column distribution unchanged on legacy rows (no NULL → [] flip) + 3-signal edge fn pattern (version + ezbr_sha256 + source-content grep for `loadCrfPrompt` AND `loadActivityTypePrompt` AND both `submit_tags` tool definitions) + 4-case submission smoke matrix (gated on `ANTHROPIC_API_KEY` set on TEST). The renamed migration is functionally identical to the original; TEST should apply cleanly on first try.
-
-- **Watch the rebase-rename-sweep pattern** (newly captured in Recent decisions): when rebasing migrations onto a branch with newer-timestamp migrations, ALL files on the rebased branch with timestamps EARLIER than the rebase target's tip migration must be renamed, regardless of body-conflict status. Local `supabase db reset` won't catch the issue because it applies in version order — only `db push --dry-run` against TEST does. Single occurrence so far (Session 38's miss); promote to `feedback_*.md` if it recurs on a future rebase.
-
-- **Round-cap rule applies after one more round**: this is round 1. Per kickoff PER-PR RITUAL step 10, after 2 rounds of bot review fix only critical bugs and ship. If a round-2 fires (next session if bots return after the push), apply the same rebuttal pass + four-surface query + per-round TEST DB re-verification.
-
-- **Anticipated next-session shape**: (a) push bundle → wait for CI to apply migrations + run E2E + CodeQL clean → run TEST DB verification round 1 → if green and no new bot findings, await user merge approval; (b) if round 2 fires, apply same triage rules and re-verify.
-
-### Session 43 — 2026-05-07 — PR 2 PUSHED + OPENED as #477 (CRF + activity_type only; tags LLM deferred)
-
-**Done (1 fix-up code commit `233dfd3` + this session-end docs commit pending — local only per `feedback_no_docs_push_during_pr.md`):**
-
-- **PR-scope decision settled.** Recommended (and user confirmed) shipping PR 2 with CRF + activity_type only and deferring tags LLM to a follow-up PR. Reasoning: tags column is brand-new from PR 1 with no historical reviewer-labeling, so the eval-gate methodology that anchored the prior two prompts (CRF on 353 reviewer-tagged rows, activity_type on 113 reviewer-tagged rows) doesn't apply. Tags sample-set decision (synthetic worksheet vs. organic post-deploy data vs. defer until reviewers tag enough lessons) gets its own PR after the question is answered. Trades scope-completeness in one PR for shorter time-to-deploy on the two prompts that ARE eval-gated and ready, plus avoids a half-eval-gated middle path for tags.
-
-- **Pre-push code-reviewer agent dispatched** (`feature-dev:code-reviewer`, model=opus per `feedback_opus_subagents.md`) on `git diff main...HEAD` (~9,125 insertions / 224 deletions across 27 files). Prompt covered: PR scope + what's deferred + key files for special attention (CRF + activity_type LLM blocks, the dual-purpose `complete_review_atomic` migration, the `ai_draft_metadata` column-add migration, ReviewDetail draft-init reader, Zod canonical + Deno mirror equivalence) + what to look for (correctness, data-safety, logical inconsistency, scope creep) + what to de-prioritize (hardening, style, test-coverage). **Findings: 0 P0/P1, 3 P2, 3 P3.**
-
-- **Triage applied (rebuttal pass per `feedback_bot_review_investigation.md`):**
-  - **ACCEPTED P2-1 — rollback comment block** added to `20260516000000_lesson_submissions_ai_draft_metadata.sql`. Sibling migration already had the trailer; `supabase/migrations/CLAUDE.md` template specifies it as required. Pure compliance.
-  - **ACCEPTED P2-2 — `NULL → []` flip on tags column** during approve_update for legacy lessons. The pre-fix COALESCE chain ended in `ARRAY[]::text[]`, flipping `v_existing.tags = NULL` to `[]` on every approve_update even though no tags writer ships in this PR. The INSERT path on line 263 uses `_phase4_jsonb_text_array_or_null` (returns NULL) — UPDATE was asymmetric. Fix: drop final `ARRAY[]::text[]` arm; COALESCE returns NULL when all three arms are NULL; `valid_tags` CHECK accepts NULL. UPDATE now matches INSERT.
-  - **REJECTED P2-3** (Zod result.data discard in complete-review): pre-existing PR-1 code; per kickoff "don't refactor beyond task." Defense-in-depth value half-realized but not in scope.
-  - **REJECTED P3-1** (CRF block comment phrasing on RMW direction): the comment is on the activity_type block (Step 4.6, labeled as such); reads fine in context. Agent's "ambiguity" call doesn't hold up against the surrounding cues.
-  - **REJECTED P3-2** (CRF regex `header` vs `anywhere`): pre-existing CRF code from Task 2.3 step 5 (`67a3cd7`). Same scope-creep argument as P2-3.
-  - **REJECTED P3-3**: agent itself flagged "not a real issue" — activity_type's lack of content gate is intentional (activity_type works on any submission body; CRF skip is pre-D9-template specific).
-
-- **Pre-push verification clean:** `npm run type-check` + `npm run lint` + `npm run test` (573/573 passing) + `supabase db reset` (all migrations apply with the new COALESCE chain).
-
-- **PR opened** at https://github.com/danfeder/esnyc-lesson-search-react/pull/477 with full description: scope summary (CRF + activity_type with eval gate metrics), what's deliberately deferred (tags LLM + Stage-1-gated prompts + reviewer picker UI), pre-push review summary (0 P0/P1, 2 P2 fix-ups applied, 4 rejected with rationale), 12-item Test plan checklist covering CI apply + complete_review_atomic body signals + edge function deploy verification + 4-case submission smoke matrix + round-cap rule.
-
-**Decisions made:**
-
-- **Cherry-pick approach NOT needed for this push** (unlike Session 38's PR 2 rebase). Branch was rebased clean against `bd9d6e4` in Session 38; no further rebase work needed before push.
-
-- **Read-modify-write pattern accepted as-is** (not refactored to single-write-at-end). Reviewer agent dismissed this proactively per kickoff de-prioritization. Worth noting: pattern stays viable for Task 2.5 (tags) when it eventually ships — third writer reads merged-after-CRF-and-activity_type JSONB and overlays tags key. If 4+ writers eventually exist, refactor to accumulator-pattern; until then, RMW is fine.
-
-- **Single fix-up commit** for both P2 changes (rather than amending each into the original commit). Nothing was pushed when the agent reviewed; amending was an option. Picked fix-up for transparency in local git log + traceability of "what was changed in review." Squash-merge collapses to one commit on main anyway.
-
-- **Session-end docs commit lands locally only.** Per `feedback_no_docs_push_during_pr.md`: don't push session-end docs commits when a PR is open. Bundle with next fix-up push (or final pre-merge docs roll-up if no fix-ups needed). Avoids burning a CI cycle on docs-only changes.
-
-**Process notes for Session 44+:**
-
-- **Active-PR session-orientation rule applies** at session start. Status doc at session-end says "PR #477 open, awaiting bot reviews" — that's stale by next session because bots reviewed in the gap. Run `git log @{u}..HEAD` + `gh pr view 477 --json reviews,comments,state,mergeable` + `gh pr checks 477` BEFORE any other work. The four-surface query (`gh pr view --comments` + `gh api .../reviews` + `gh api .../comments` + `gh run view --log-failed`) is mandatory for "0 findings" claims (per `feedback_pr_comment_surfaces.md`).
-
-- **TEST DB verification per-round.** First verification fires when CI applies the migrations (round 0 = PR open). Per `feedback_per_round_test_db_verification.md`, every subsequent round that produces DB-affecting fix-up commits needs its own re-verification — not just one-time at PR open. The 6-signal RPC body check + tags-column-distribution check + edge function 3-signal check are the load-bearing probes.
-
-- **`ANTHROPIC_API_KEY` secret on TEST** is the gating prerequisite for any submission smoke testing. Without it, the LLM blocks gracefully skip and the smoke can only verify "no crash on missing key," not "drafts populate correctly." Confirm secret is set BEFORE running submission tests. Same will apply for PROD deploy.
-
-- **Watch for the SASL flake** at the Apply step of `migrate-production.yml` AND the esm.sh CDN 522 flake at `deploy-edge-functions.yml` (per MEMORY.md hygiene-follow-ups). Both are recurring transient patterns; mitigation is `gh run rerun --failed <run_id>`. Approval gate behavior differs: SASL re-fires the gate (CLI re-handshakes), CDN doesn't (matrix slot has its own re-run path).
-
-- **No code changes anticipated next session** unless bot rounds surface real findings. Prepare for: (a) zero-findings ship path (TEST DB verify → user PROD-merge approval → PROD verify), (b) 1-2 round fix-up cycle (re-dispatch fresh review per kickoff "every push that follows" rule, NOT just round 0).
-
-### Session 42 — 2026-05-07 — PR 2 Task 2.4 step 4: activity_type prompt wired into process-submission edge function
-
-**Done (1 code commit `5c6b7ea` + this session-end docs commit pending):**
-
-- **Activity_type prompt wired into `supabase/functions/process-submission/index.ts`** (+129 lines). Module-level constants + loader: `ACTIVITY_TYPE_MODEL = 'claude-opus-4-7'`, `ACTIVITY_TYPE_PROMPT_URL` pointing to `./prompts/activity-type.md`, `loadActivityTypePrompt()` cache helper. New `ACTIVITY_TYPE_VALUES` import added to the existing `_shared/metadataSchemas.ts` import block.
-
-- **Step 4.6 wire-up block** placed immediately after the CRF block (Step 4.5), before the duplicate-detection branch. Skip predicate is `!regenerateEmbedding` only — no body-content preflight (unlike CRF's "Cultural Responsiveness" header check) since activity_type works on summary + agenda + skills which every ESYNYC submission carries. Tool: `submit_tags` with `selected_values` array enum-restricted to `ACTIVITY_TYPE_VALUES` (4 values) + `uniqueItems: true`. Multi-label per D2.1.
-
-- **Read-modify-write into `ai_draft_metadata`.** After Zod validation succeeds, the block SELECTs the existing `ai_draft_metadata` JSONB, spreads it into a new object, overlays the `activityType` key, and UPDATEs the row. CRF's writer at lines 404-411 of the merge-base does a plain UPDATE (overwrites the JSONB column wholesale); a second writer with the same pattern would drop CRF's `culturalResponsivenessFeatures` key. RMW preserves CRF's data without touching CRF's code. Sequential within the request — no race with CRF.
-
-- **Failure paths**: Zod validation fail → log + skip write; SELECT fail → log + skip write; UPDATE fail → log + continue; outer try/catch → log + continue. Submission flow never blocks on tagging. Same shape as CRF.
-
-- **Type-check + lint pass**: clean baseline before commit, clean after commit.
-
-**Decisions made:**
-
-- **RMW over alternatives** (`jsonb_set` raw SQL or refactor to single accumulator-write). Three options were on the table:
-  - **(A) RMW (chosen)**: read existing JSONB, merge in JS, write back. One extra SELECT per writer. Simple, doesn't touch CRF. Scales to Task 2.5 (tags) by adding a third writer that reads the merged-after-CRF+activity_type JSONB.
-  - **(B) `jsonb_set` raw SQL**: atomic, single round-trip, but requires raw SQL via `rpc()` or a helper function. Adds infrastructure for a problem that doesn't exist (no concurrency between writers within a single request).
-  - **(C) Refactor to single end-of-flow write**: collect all prompt outputs in an in-memory accumulator, write once at the end. Cleanest at scale but requires touching CRF's commit (`67a3cd7`) which is already in the PR 2 chain. Kickoff guidance: "Don't add features, refactor, or introduce abstractions beyond what the task requires." Defer to Task 2.5 if multi-write round-trip cost becomes painful at 3+ writers.
-
-  Picked (A) for minimal-diff + extension friendliness for Task 2.5. (C) is queued as a candidate refactor when 4+ writers exist and the round-trip cost is measurably painful.
-
-- **No body-content skip predicate.** Considered mirroring CRF's regex check on the body content for activity_type — but the activity_type prompt explicitly works on summary + agenda + skills (the standard ESYNYC submission template), not on a specific section header. A submission with empty body produces noisy predictions but Zod still validates the array; cost is one wasted Anthropic call. Adding a predicate would cost more in maintenance than it saves in calls.
-
-- **`ai_draft_model` column reflects the last writer.** When both CRF and activity_type fire, both writes hit `ai_draft_model = 'claude-opus-4-7'` so the column is identical regardless of order. If models diverge (e.g., a future Haiku-classified prompt), the column would only reflect the last writer. Schema accepts this for foundation phase; revisit when models actually diverge (Phase 2).
-
-- **`submit_tags` tool name shared with CRF.** Both blocks declare a tool named `submit_tags` in separate Anthropic API calls. The two tool definitions have different enum lists (`ACTIVITY_TYPE_VALUES` vs `CULTURAL_RESPONSIVENESS_FEATURE_VALUES`); the prompt cache treats them as distinct cache slots based on the serialized tool definition + system prompt. No conflict.
-
-**Process notes for Session 43+:**
-
-- **PR 2 push decision required.** Session 41's "Next session picks up" framed Task 2.5 (tags) as the next coding task; with step 4 done, the user can choose to:
-  - **(a) Open PR 2 now** with CRF + activity_type only. Tags ships as a small follow-up PR after Task 2.5's sample-set question is answered. Faster time-to-TEST for the two prompts that ARE eval-gated.
-  - **(b) Continue to Task 2.5** (tags prompt + eval). Bigger PR scope, longer time-to-TEST, but ships all three vocab-locked prompts in one PR.
-  Surface to user at session start.
-
-- **Task 2.5 sample-set question is the highest-impact open decision.** Tags has no historical reviewer truth (the column is brand-new from PR 1). Three options:
-  - **(i) Hand-curated synthetic worksheet (~30-50 lessons)**: reviewer-tags a small set across orientation / bilingual_handouts / neither for the canonical eval gate. ~1-2 hrs of user time.
-  - **(ii) Skip canonical eval; smoke-test only**: ship the prompt without the eval gate's structured signal. Eval gate would have to come post-deploy when reviewer activity organically produces a sample set.
-  - **(iii) Defer Task 2.5 entirely**: ship CRF + activity_type only; tags waits until reviewers have organically tagged enough lessons through the post-deploy review flow.
-  Surface to user at session start.
-
-- **Watch for the type-coupled cluster pattern** if Task 2.5 (or any Gate-C-classified vocab-locked prompt) introduces type-narrowing across edge function + Zod schemas + mappers. This session's wire-up was purely additive (one more loader + one more call site + one more Zod validate); no cluster invariants tripped. Same shape expected for Task 2.5 unless tags introduces something unusual.
-
-- **TEST DB verification deferred until PR 2 push.** Per the per-round verification rule, verification fires when the PR opens (round 0) and after every fix-up round. Pre-push there is nothing on TEST or PROD that's affected by this session's local-only commit.
-
-### Sessions 18-36 — archived
-
-PR 2's earlier session entries (Sessions 18-27) and PR 1b's full implementation cycle (Sessions 28-36) live in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md`. Read on demand via `grep -n "Session N" archive.md` or targeted Read with offset/limit. Audit performed during the move (Session 37) surfaced 2 promotions to `feedback_pr_bot_review_workflow.md` (empirical-evidence-escalates pattern + active-PR session-orientation rule) and 1 watch-pattern preserved in Recent decisions (type-coupled cluster impl-plan flaw, single occurrence).
+PR 2's design reference (Session 18) + earlier session entries (Sessions 18-27 implementation), PR 1b's full implementation cycle (Sessions 28-36), and PR 2 ritual cycle (Sessions 37-46) all live in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md`. Read on demand via `grep -n "Session N" archive.md` or targeted Read with offset/limit. Process learnings collected during Sessions 28-46 that promoted to feedback memory: empirical-evidence-escalates pattern + active-PR session-orientation rule (both in `feedback_pr_bot_review_workflow.md` post-Session 37). Watch-patterns preserved in Recent decisions above (type-coupled cluster impl-plan flaw / cherry-pick-over-rebase / rebase-rename-sweep / database-migrations skill exception class — all single-occurrence, promote to feedback if they recur).

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,42 +1,50 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-08 — Session 47 (PR 4 cycle started: 21 third-party imports soft-retired + 7 archive-only concepts recovered + FSA Pt 1 retitle; 2 migrations local-only on `feat/metadata-foundation-corpus-cleanup`; PR-cycle archival of Sessions 37-46 done this session).
+**Last updated:** 2026-05-08 — Session 48 (PR 4 filter-surface follow-up: 8 user-facing surfaces filter retired imports + view migration that exposes `retired_at` to the view + LessonSearchPicker `excludeRetired` prop; pre-push code-reviewer agent caught and fixed P0 latent bug; ready to push and open PR).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-46 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**PR 4 (corpus cleanup) — Session 47, in flight 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 2 commits ahead: `0672cc8` (Session 46 docs cherry-pick from merged PR 2 branch per Session 38 precedent) + `ed8ca21` (PR 4 substantive migrations). NOT pushed yet; PR opens after filter-surface follow-ups land per `feedback_no_docs_push_during_pr.md` spirit (bundle substrate migrations + filter surfaces in one PR cycle).
+**PR 4 (corpus cleanup) — Sessions 47-48, ready to push 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 5 commits ahead (6 after this session-end docs commit): `0672cc8` (Session 46 docs cherry-pick) + `ed8ca21` (PR 4 substantive migrations: 21 imports retired + 7 archive concepts recovered + FSA retitle) + `868ed54` (Session 47 docs) + `f522740` (PR 4 follow-up: 8 user-facing surfaces filter retired) + `b0f2564` (P0 fix from pre-push review: view migration + ReviewDetail hardening comment). NOT pushed yet; PR opens immediately after the docs commit.
 
-**Locked decisions this session (3 user-confirmed):**
-1. **Soft-delete via `retired_at timestamptz` + `retired_reason text` columns** with cluster-key namespace `import:<source>` (7 distinct keys for the 21 imports: pflp_2003 / foodcorps_2017 / cas_food_justice / nyc_doe_colonial_ny / city_blossoms_botanical_artists / nyc_dep_watershed / oregon_doe_leaves). Reversible. Future retirement reasons can use other namespaces.
-2. **404 UX for direct-link to retired lessons** — same `WHERE retired_at IS NULL` filter as search; 0 PROD bookmarks anywhere makes any custom UI for retired moot.
-3. **Filter retired in 6 surfaces** (next session's work): lessons_with_metadata view, search_lessons RPC, smart-search edge fn, lesson detail query, facetCounts.ts, embedding regen script. detect-duplicates + content-hash dedup intentionally NOT filtered (cross-checking against retired imports is useful at submission time).
+**Surface inventory locked (from Session 48 investigation):**
+- **Filtered (8 surfaces):** `search_lessons` RPC body, `smart-search` edge fn, `search-lessons` edge fn (defensive — dead front-end caller), `useLessonStats` hook, `LessonSearchPicker` (new `excludeRetired` prop, default false), `RevisingSubmissionForm` caller (passes `excludeRetired`), `process-submission` update-target validation (defense-in-depth), `generate-embeddings.mjs` + `regenerate-all-embeddings.mjs` (don't burn OpenAI cost on retired).
+- **Unfiltered (intentional asymmetry):** `detect-duplicates` edge fn, `get_lesson_details_for_review` RPC, `ReviewDetail` similar-lesson + off-list submitter target fetches, `ReviewDashboard` queue-badge title lookup, `src/lib/supabase.ts` connectivity test, `lessons_with_metadata` view itself. These exist so dup-checking + reviewer dup-flow catch future re-submissions of retired imports.
+- **Out of scope:** ~13 admin/historical scripts in `scripts/` (one-shots, not user-facing).
 
-**Pre-flight investigation (4 PROD probes, all clean):**
-- **Drop list count** — actual is **21**, not 23 (kickoff/decision-journal "23" is stale early estimate). Memory file's listing is authoritative; structural sweep against PROD found 30 false positives + 0 obvious additional candidates. TEST↔PROD parity exact at 21.
-- **FK + user-state audit** — bookmarks_total=0 anywhere in PROD; 0 lesson_versions / collections / submissions / reviews / similarities on the 21 drop rows. 2 historical references (Leaves We Eat + Stone Soup as canonical winners of dedup `group_6` and `group_82` resolved 2025-09-01 `merge_and_archive`) preserved intact under soft-delete.
-- **FSA current title** — confirmed "Food System Advocates (Part 1 & 2)"; tags + format columns NULL.
-- **Archive-only concepts** — 7 distinct lesson_ids with ~19 concepts surviving only in `lesson_versions` archive (all archived 2026-04-27 Phase 6.2). Tally drift from memory's "16 concepts" → 19 measured 2026-05-08 is the same population.
+**Per-consumer filter approach** (not view-bake): the 3 view-based call sites (`useLessonStats` / `smart-search` / `search-lessons`) call `.is('retired_at', null)` after `.from('lessons_with_metadata')` directly. The view stays unfiltered so `detect-duplicates` / `get_lesson_details_for_review` / `ReviewDetail` similar-lesson fetch / `ReviewDashboard` badges still see retired rows.
 
-**PR 4 substantive code shipped this session (commit `ed8ca21`, 2 files / +256):**
-- `supabase/migrations/20260520000000_corpus_cleanup_retire_imports.sql` — adds `retired_at` + `retired_reason` columns; UPDATEs 21 drop rows with cluster keys; UPDATEs FSA row to drop "& 2"; idempotent guards (`AND retired_at IS NULL`, `AND title = '...'`).
-- `supabase/migrations/20260520010000_recover_archive_only_concepts.sql` — restores `academicConcepts` from archive into 7 live rows; DISTINCT ON + ORDER BY version_number DESC defensively; idempotent.
+**P0 caught and fixed via pre-push review:** the 3 view-based `.is('retired_at', null)` calls would have failed with PostgREST 400 because `lessons_with_metadata` view (last redefined `20260512000000`) uses an explicit column list that doesn't auto-include columns added later. Migration `20260520030000_lessons_with_metadata_expose_retired.sql` recreates the view with `retired_at` + `retired_reason` appended at the end (PostgreSQL allows appending columns to `CREATE OR REPLACE VIEW`). NOTIFY pgrst reload schema for immediate cache invalidation. Local toggle test confirms 4 expected behaviors: view filtered count 5→4, view unfiltered stays 5, RPC count 5→4, view + RPC restoration on `retired_at = NULL`.
 
-**Local verification clean**: `supabase db reset` applies all migrations; type-check + lint clean; vitest 575/575; MCP probe confirms `retired_at` + `retired_reason` columns present with correct types.
+**PR 4 substantive code shipped Sessions 47-48 (3 migrations + 5 source edits + 2 test files + 1 hardening comment):**
+- `20260520000000_corpus_cleanup_retire_imports.sql` (Session 47): `retired_at` / `retired_reason` columns + 21 retire UPDATEs + FSA retitle.
+- `20260520010000_recover_archive_only_concepts.sql` (Session 47): restores `academicConcepts` from archive into 7 live rows.
+- `20260520020000_search_lessons_filter_retired.sql` (Session 48): `CREATE OR REPLACE FUNCTION search_lessons` body adds `AND l.retired_at IS NULL` to count + select WHERE clauses.
+- `20260520030000_lessons_with_metadata_expose_retired.sql` (Session 48): `CREATE OR REPLACE VIEW lessons_with_metadata` appends 2 new columns at the end.
+- 5 source edits: `smart-search/index.ts`, `search-lessons/index.ts`, `useLessonStats.ts`, `LessonSearchPicker.tsx` (new `excludeRetired` prop), `RevisingSubmissionForm.tsx` (passes prop), `process-submission/index.ts` (server-side validation), `generate-embeddings.mjs`, `regenerate-all-embeddings.mjs`.
+- 2 test files updated for the new chain shape (`useLessonStats.test.ts`, `LessonSearchPicker.test.tsx`); +2 new tests for `excludeRetired` prop.
+- 1 hardening comment at `ReviewDetail.tsx:1319` documenting why reviewer flow intentionally does NOT pass `excludeRetired`.
 
-**Foundation-phase substrate WILL include after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 6 filter surfaces filtering retired rows.
+**Local verification clean**: `supabase db reset` applies all 4 PR 4 migrations cleanly; type-check + lint clean; vitest 577/577 (was 575/575; +2 new for `excludeRetired` prop). MCP probes confirm:
+- `lessons.retired_at` + `lessons.retired_reason` columns present with correct types
+- `lessons_with_metadata` view exposes both new columns post-migration
+- Toggle test: view filtered count drops 5→4 when LESSON-001 retired; view unfiltered stays at 5; `search_lessons()` RPC drops to 4; restored to 5 on `retired_at = NULL`
 
-**Next session picks up — PR 4 follow-up work:**
-1. **Filter surfaces** — add `WHERE retired_at IS NULL` (or equivalent shape filter) to: `search_lessons` RPC body + companion view `lessons_with_metadata`, `smart-search` edge fn (`supabase/functions/smart-search/index.ts`), lesson detail page query (front-end), `src/utils/facetCounts.ts`, embedding regen script (find via grep). Probably one new migration + 2-3 frontend/edge edits.
-2. **Tests** — extend any tests that count corpus rows to expect `live_count` semantics; verify retired filter end-to-end.
-3. **Pre-push code-reviewer agent** dispatched on `git diff main...HEAD` (Opus per `feedback_opus_subagents.md`); accept/reject findings; commit fix-ups before push.
-4. **Push branch + open PR**. CI applies migrations to TEST DB; round 0 verification via `mcp__supabase-test__execute_sql` (21 retired count + FSA new title + 7 concepts recovered shape-correct).
-5. **Bot review rounds + ritual**.
+**Foundation-phase substrate after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + view exposes them + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 8 filter surfaces filtering retired rows + `LessonSearchPicker.excludeRetired` prop infrastructure for submitter-vs-reviewer asymmetry.
+
+**Next session picks up — PR 4 push + bot review cycle:**
+1. **Push branch + open PR** with `gh pr create`. CI applies migrations to TEST DB; this fires the round 0 verification window.
+2. **Round 0 TEST DB verification** via `mcp__supabase-test__execute_sql`: 21 retired count + FSA new title + 7 concepts recovered shape + view exposes new columns + search_lessons RPC count drops appropriately.
+3. **Bot review rounds + ritual** per `feedback_pr_bot_review_workflow.md` (CodeRabbit + Claude Review). Investigate every finding; default-reject hardening for internal-only paths.
+4. **Per-round TEST DB re-verification** for any DB-affecting fix-up commits.
+5. **Round-cap after 2 rounds of bot review.**
+6. **Pre-PROD-apply MCP probe** (Session 46 pattern) before approving the production migration workflow.
+7. **Post-PROD verify** via `mcp__supabase-remote__execute_sql` (21 retired count + view shape + RPC count).
 
 **Branches:**
 - `main` at `cf2aad4` (PR 2 squash-merge); origin matches
-- `feat/metadata-foundation-corpus-cleanup` — this session's work, 2 commits ahead (3 after this session-end docs commit)
+- `feat/metadata-foundation-corpus-cleanup` — this session's work, 5 commits ahead (6 after this session-end docs commit)
 - `feat/metadata-foundation-llm-tagging` (PR 2 merged; deletable at convenience)
 - `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
 
@@ -100,6 +108,74 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 - Project-specific memories: `project_metadata_three_regimes.md` / `project_vocabulary_drift_scope.md` / `project_lesson_format_conflated.md` / `project_dedup_third_state.md` / `project_metadata_cleanup_candidates.md` / `project_crf_stamp_theater.md` / `project_teacher_zero_metadata_model.md` / `project_imported_non_esynyc_drops.md`
 
 ## Recent session log
+
+### Session 48 — 2026-05-08 — PR 4 follow-up: 8 filter surfaces + view migration + P0 fix from pre-push review (ready to push)
+
+**Done (2 substantive commits + this session-end docs commit):**
+
+- **Surface inventory pass** (~30 min). Targeted greps + MCP probes mapped every consumer of `lessons` / `lessons_with_metadata`. Result: 8 surfaces filter retired (search_lessons RPC + smart-search + search-lessons + useLessonStats + LessonSearchPicker + RevisingSubmissionForm + process-submission + 2 embedding scripts), 6 surfaces stay unfiltered (detect-duplicates + ReviewDetail + ReviewDashboard + get_lesson_details_for_review + supabase.ts connectivity test + view itself), ~13 admin scripts out of scope. Empirical TEST DB pre-commit probe: 0 current submissions / similarities / reviews / bookmarks reference any of the 21 retired IDs (only 2 expected dedup-winner rows in `duplicate_resolutions`). PR 4 is forward-looking, not backfilling broken state.
+
+- **3 NEW surfaces beyond status doc's original 6** identified during inventory: `search-lessons` edge fn (defensive — dead front-end caller today, but deployed), `LessonSearchPicker` (new `excludeRetired` prop with submitter-vs-reviewer asymmetry), `process-submission` server-side validation (defense-in-depth even if picker UI is bypassed).
+
+- **Per-consumer filter approach (not view-bake)** — locked because detect-duplicates / get_lesson_details_for_review / ReviewDetail similar-lesson fetch / ReviewDashboard badges all read from view (or `lessons` directly) AND need to keep seeing retired rows for future re-submission catch. View-bake forces consumers off the view; per-consumer is cleaner.
+
+- **`LessonSearchPicker.excludeRetired` prop** — new `excludeRetired?: boolean` prop, default false. Threaded through `runSearch` useCallback dep array. RevisingSubmissionForm caller passes `excludeRetired`; ReviewDetail caller leaves default false (with a hardening comment per pre-push review's P1 #4 finding). 2 new tests cover both paths.
+
+- **Migration 1 — `20260520020000_search_lessons_filter_retired.sql`** (192 lines). `CREATE OR REPLACE FUNCTION search_lessons` body adds `AND l.retired_at IS NULL` to BOTH count + select WHERE clauses. Body-only change → no GRANT re-issue needed. NOTIFY pgrst reload schema for cache safety.
+
+- **Migration 2 — `20260520030000_lessons_with_metadata_expose_retired.sql`** (133 lines). `CREATE OR REPLACE VIEW lessons_with_metadata` appends `l.retired_at` + `l.retired_reason` at the end (PostgreSQL allows column appends to existing views). View stays unfiltered — consumers apply `.is('retired_at', null)` at query site for the asymmetry. Critical fix from pre-push review (without it, 3 view-based call sites would have hit PostgREST 400).
+
+- **Source edits across 8 files** (commit `f522740`):
+  - `smart-search/index.ts:155` + `search-lessons/index.ts:62` + `useLessonStats.ts:25-28` (3 view-based callers)
+  - `LessonSearchPicker.tsx` (new prop + chain integration with useCallback dep)
+  - `RevisingSubmissionForm.tsx:174` (passes `excludeRetired`)
+  - `process-submission/index.ts:212` (server-side validation)
+  - `generate-embeddings.mjs:129 + 240/244` (fetch + verify denominators)
+  - `regenerate-all-embeddings.mjs:72/154/206` (regenerate + verify + mock fetch)
+
+- **Tests updated** (commit `f522740`):
+  - `useLessonStats.test.ts` mock chain updated to include `is` (terminal call), 4 of 9 tests modified, +1 assertion for `expect(isMock).toHaveBeenCalledWith('retired_at', null)`. All 9 pass.
+  - `LessonSearchPicker.test.tsx` mock chain updated to include `is: vi.fn().mockReturnThis()` across 4 mock setups; +2 new tests covering `excludeRetired={true}` triggers `.is(...)` and unset-default does NOT trigger it. All pass.
+
+- **Pre-push code-reviewer agent dispatched (Opus mode per `feedback_opus_subagents.md`)** on `git diff main...HEAD` — caught 1 P0 (the view doesn't expose `retired_at` → 3 callers would have 400'd at runtime), 3 P1s (2 deferred as "not bugs today / future hardening" + 1 actionable hardening comment), 1 P2 (defer). P0 fix applied in commit `b0f2564`: new view migration. P1 #4 hardening comment applied at `ReviewDetail.tsx:1319` documenting reviewer-flow rationale.
+
+- **Local verification clean post-fix**: `supabase db reset` applies all 4 PR 4 migrations cleanly; `lessons_with_metadata` view confirmed exposing both new columns via information_schema query; toggle test passes (view filtered 5→4, view unfiltered stays 5, RPC drops to 4, restoration works); type-check + lint + vitest 577/577 clean.
+
+- **Migration commit `f522740` + fix-up commit `b0f2564`** on `feat/metadata-foundation-corpus-cleanup`. Branch is now 5 commits ahead of main (Session 46 docs cherry-pick + 2 substantive Session 47 + Session 47 docs + Session 48 substantive + Session 48 fix-up); session-end docs commit makes 6 ahead.
+
+**Decisions made:**
+
+- **Per-consumer filter approach over view-bake** — confirmed cleanest given the asymmetry requirement (detect-duplicates / reviewer dup-flow keep seeing retired). View-bake would force consumers off the view, more refactor.
+
+- **`LessonSearchPicker.excludeRetired` prop with default=false (not bake-into-component)** — chose prop over single behavior because of the genuine submitter/reviewer asymmetry. Default false preserves all existing callers (including `ReviewDetail`); the new submitter caller (`RevisingSubmissionForm`) explicitly opts in. Hardening comment at reviewer call-site prevents silent drift if future refactor flips the default.
+
+- **Empirical TEST DB probe before locking surface inventory** — discovered 0 current state references any retired ID. PR 4 is forward-looking (catches future Stone Soup re-submissions); current state is empirically clean. Lower blast radius than the original 6-surface concern implied.
+
+- **3 NEW surfaces beyond status doc's original 6** — added `search-lessons` edge fn (defensive symmetry), `LessonSearchPicker` (UX asymmetry), `process-submission` server-side validation (defense-in-depth). Status doc's "6 surfaces" was directional; investigation refined to 8.
+
+- **CREATE OR REPLACE for both migrations (not DROP+CREATE)** — both `search_lessons` (signature unchanged, body-only change) and `lessons_with_metadata` view (PostgreSQL permits appending columns) can use the lighter pattern. No GRANT re-issue needed; existing function/view identity preserved.
+
+- **Pre-push code-reviewer agent value confirmed.** P0 finding (view-doesn't-expose-retired) was a latent bug that local `supabase db reset` did NOT catch (the failing call sites use mocked tests; the local DB ran but the chain was never exercised against the actual view). Local toggle test only exercised the search_lessons RPC path, not the view path. Pre-push review is exactly the kind of independent eyes that catches this class of bug — a concrete data point for `feedback_pr_bot_review_workflow.md`.
+
+**Process notes for Session 49+:**
+
+- **Push branch immediately when next session starts** — substrate + filter surfaces are bundled per `feedback_no_docs_push_during_pr.md` spirit. CI applies all 4 PR 4 migrations to TEST DB on first push. Round 0 verification fires immediately after CI.
+
+- **Round 0 verification queries** (run via `mcp__supabase-test__execute_sql` after CI applies migrations to TEST DB):
+  - 21 retired count: `SELECT count(*) FROM lessons WHERE retired_at IS NOT NULL;` should return 21
+  - 7 distinct reasons: `SELECT count(DISTINCT retired_reason) FROM lessons WHERE retired_at IS NOT NULL;` should return 7
+  - FSA retitle: `SELECT title FROM lessons WHERE lesson_id = '1iqGFHrQ0rWfyoLo4R4n8FO9N-S7LW1ZpalaLNF5_Tmk';` should be `'Food System Advocates (Part 1)'`
+  - View exposes columns: `SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='lessons_with_metadata' AND column_name IN ('retired_at','retired_reason');` should return 2 rows
+  - View live count: `SELECT count(*) FROM lessons_with_metadata WHERE retired_at IS NULL;` ≈ 767 (TEST corpus 788 minus 21)
+  - Concepts recovery: `SELECT count(*) FROM lessons WHERE lesson_id = ANY(ARRAY[<7-id list>]) AND metadata->'academicConcepts' IS NOT NULL;` should return 7
+
+- **Pre-PROD-apply MCP probe pattern** (Session 46 + 47 precedent) — same probes via `mcp__supabase-remote__execute_sql` AS A READ before approving PROD migration workflow. Belt-and-braces: TEST↔PROD diff via same query body to spot-check both surfaces.
+
+- **Post-PROD verify** — same probes via `mcp__supabase-remote__execute_sql` after PROD migrations applied. Mandatory per kickoff hard rule (CI verify-step has known SASL flake).
+
+- **Watch the migrate-production.yml SASL flake on apply step.** PR 4 has 4 migrations applying together (vs the typical 1-2). If the apply step flakes, `gh run rerun --failed <run_id>` is the working primitive (per memory's hygiene-follow-ups). Approval gate re-fires for re-approval. Migrations are idempotent (`CREATE OR REPLACE` + `IF NOT EXISTS` + `AND retired_at IS NULL` guards) so retry is safe.
+
+- **Bot review rounds expected.** PR 1 had 5 rounds; PR 2 had 5 rounds. PR 4 should be lighter (smaller diff + cleaner separation of concerns) but expect 2-3 rounds at minimum. Round-cap after 2 per kickoff.
 
 ### Session 47 — 2026-05-08 — PR 4 cycle started: 21 imports soft-retired + 7 concepts recovered + FSA retitle (migrations local-only)
 

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,57 +1,48 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-08 — Session 49 (PR 4 round-1 bot review triaged + consolidated fix-up `bfb3786` applied: F1 type sync + F3 PR-N comment cleanup + F4 detect-duplicates intent guards; 4 findings rejected/deferred per default-reject calibration; ready to push fix-up and await round 2).
+**Last updated:** 2026-05-08 — Session 50 (PR 4 round-2 bot review IN — clean across 3 surfaces; Codex R2-1 cosmetic cleanup applied bundled with this docs commit; round-cap activated; ready to merge + approve PROD migration).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-46 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**PR 4 (corpus cleanup) — PR #478 OPEN, Session 49 round-1 fix-up applied 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 7 commits ahead (8 after this session-end docs commit): `0672cc8` (Session 46 docs cherry-pick) + `ed8ca21` (PR 4 substantive migrations: 21 imports retired + 7 archive concepts recovered + FSA retitle) + `868ed54` (Session 47 docs) + `f522740` (PR 4 follow-up: 8 user-facing surfaces filter retired) + `b0f2564` (P0 fix from pre-push review: view migration + ReviewDetail hardening comment) + `6a801c1` (Session 48 docs) + `bfb3786` (Session 49 round-1 fix-up: F1 types + F3 comment cleanup + F4 detect-duplicates intent guards).
+**PR 4 (corpus cleanup) — PR #478 OPEN, round 2 IN clean, round-cap activated, ready to merge.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 8 commits ahead pre-Session-50 (10 after Session 50 fix-up + docs commit): `0672cc8` (Session 46 docs cherry-pick) + `ed8ca21` (PR 4 substantive migrations) + `868ed54` (Session 47 docs) + `f522740` (8 filter-surface follow-up) + `b0f2564` (pre-push P0 view-migration fix) + `6a801c1` (Session 48 docs) + `bfb3786` (Session 49 round-1 fix-up: F1+F3+F4) + `786203b` (Session 49 docs, push happened post-Session-49) + `<TBD>` (Session 50 round-2 cleanup — Codex R2-1 cosmetic strip + Session 50 docs).
 
-**Round 0 TEST DB verification PASS (Session 49):** 21 retired count ✓, 7 distinct retired_reason groups ✓, FSA retitle ✓, view exposes 2 new columns ✓, 7/7 concepts recovered with object shape ✓, view live count 751 ✓, search_lessons RPC count 751 ✓, F7 verification (0 array-shape archive concepts anywhere) ✓. PROD pre-state confirmed all 7 concept-recovery targets currently NULL with object-shape archives ready.
+**Round 0 TEST DB verification PASS (Session 49) + Session 50 spot-check PASS:** 21 retired ✓, 7 distinct retired_reason groups ✓, 751 live via view ✓, FSA retitle ✓, view exposes 2 new columns ✓, 7/7 concepts populated with object shape ✓, F7 verification (0 array-shape archive concepts) ✓. Session 50 spot-check probe re-confirmed all counts unchanged after the non-DB-affecting Round-1 fix-up — Round 0 probes remain load-bearing.
 
-**Round 1 bot review triage (Session 49):** 7 findings across 3 reviewer surfaces (claude-review formal, claude long-form, Codex). Acceptance trajectory 3/7 — squarely within `feedback_pr_bot_review_workflow.md` default-reject calibration band:
-- **ACCEPT**: F1 (database.types.ts type sync — added retired_at/retired_reason to 6 type blocks), F3 (stripped 13 `PR 4` references across 9 files; kept WHY content), F4 (4 intent comments in detect-duplicates symmetric with ReviewDetail's hardening pattern).
-- **REJECT/DEFER**: F2 (pushed-migration comment correction; documented in out-of-scope), F5 (partial index hypothetical at corpus 788; documented), F6 (dead search-lessons edge fn; surface inventory tracked it; documented), F7 (TEST + PROD probe confirms zero array-shape archives — verification gate passed).
+**Round 1 bot review triage (Session 49):** 7 findings across 3 reviewer surfaces. Acceptance 3/7. ACCEPT: F1 type sync, F3 PR-N comment cleanup, F4 detect-duplicates intent guards. REJECT/DEFER: F2 pushed-migration comment, F5 partial index, F6 dead search-lessons edge fn, F7 array-shape verifiably clean.
 
-**Surface inventory locked (from Session 48 investigation):**
-- **Filtered (8 surfaces):** `search_lessons` RPC body, `smart-search` edge fn, `search-lessons` edge fn (defensive — dead front-end caller), `useLessonStats` hook, `LessonSearchPicker` (new `excludeRetired` prop, default false), `RevisingSubmissionForm` caller (passes `excludeRetired`), `process-submission` update-target validation (defense-in-depth), `generate-embeddings.mjs` + `regenerate-all-embeddings.mjs` (don't burn OpenAI cost on retired).
-- **Unfiltered (intentional asymmetry):** `detect-duplicates` edge fn, `get_lesson_details_for_review` RPC, `ReviewDetail` similar-lesson + off-list submitter target fetches, `ReviewDashboard` queue-badge title lookup, `src/lib/supabase.ts` connectivity test, `lessons_with_metadata` view itself. These exist so dup-checking + reviewer dup-flow catch future re-submissions of retired imports.
-- **Out of scope:** ~13 admin/historical scripts in `scripts/` (one-shots, not user-facing).
+**Round 2 bot review IN clean (Session 50) — 3-surface convergence on ship:**
+- **claude-review formal** (commit `786203b`): "**0 P0/P1 findings. Ready to merge from a code-quality perspective.**" 2 P3 observations (process-submission error message merge, regenerate-embeddings retired-no-embedding diagnostic) — both debuggability nuances, not bugs.
+- **claude long-form**: 1 "Minor" false-positive (claimed missing `excludeRetired=false` negative test — test exists at `LessonSearchPicker.test.tsx:284`; same bot's inline review at L284 + Codex Round 2 both confirm) + 3 informational items already deferred from Round 1 (raw lessons query, view body duplication, dead edge fn).
+- **Codex round 2 (user-pass)** (commit `786203b`): "**No P1/P2 issues found on the new head.**" 1 P3 cosmetic: 2 stray `post-PR-4` comments in `useLessonStats.test.ts:22,175` missed by F3's grep (the form was hyphenated, not literal `PR 4`).
 
-**Per-consumer filter approach** (not view-bake): the 3 view-based call sites (`useLessonStats` / `smart-search` / `search-lessons`) call `.is('retired_at', null)` after `.from('lessons_with_metadata')` directly. The view stays unfiltered so `detect-duplicates` / `get_lesson_details_for_review` / `ReviewDetail` similar-lesson fetch / `ReviewDashboard` badges still see retired rows.
+**Round 2 triage (Session 50):** Acceptance 1/4 — squarely default-reject calibration band.
+- **ACCEPT R2-1**: Codex P3 cosmetic strip — 2 lines fixed. Mirrors F3 disposition (CLAUDE.md "don't reference current task"). Verified clean post-fix via grep.
+- **REJECT R2-2**: claude-review P3 process-submission error message merge — Codex explicitly defers; debuggability nuance for direct-API callers, not user-visible.
+- **REJECT R2-3**: claude-review P3 regenerate-embeddings diagnostic — Codex explicitly defers; correct for normal operation; latent gap only if rows un-retire.
+- **REJECT R2-4 (false positive)**: claude long-form "missing negative test" — test exists at L284; bot's own inline comment + Codex confirm.
 
-**P0 caught and fixed via pre-push review:** the 3 view-based `.is('retired_at', null)` calls would have failed with PostgREST 400 because `lessons_with_metadata` view (last redefined `20260512000000`) uses an explicit column list that doesn't auto-include columns added later. Migration `20260520030000_lessons_with_metadata_expose_retired.sql` recreates the view with `retired_at` + `retired_reason` appended at the end (PostgreSQL allows appending columns to `CREATE OR REPLACE VIEW`). NOTIFY pgrst reload schema for immediate cache invalidation. Local toggle test confirms 4 expected behaviors: view filtered count 5→4, view unfiltered stays 5, RPC count 5→4, view + RPC restoration on `retired_at = NULL`.
+**Round-cap activated per kickoff hard rule §10**: round 2 just landed clean → natural ship-decision point. R2 surface convergence ("ready to merge", "no P1/P2") is the bot-voice signal.
 
-**PR 4 substantive code shipped Sessions 47-48 (3 migrations + 5 source edits + 2 test files + 1 hardening comment):**
-- `20260520000000_corpus_cleanup_retire_imports.sql` (Session 47): `retired_at` / `retired_reason` columns + 21 retire UPDATEs + FSA retitle.
-- `20260520010000_recover_archive_only_concepts.sql` (Session 47): restores `academicConcepts` from archive into 7 live rows.
-- `20260520020000_search_lessons_filter_retired.sql` (Session 48): `CREATE OR REPLACE FUNCTION search_lessons` body adds `AND l.retired_at IS NULL` to count + select WHERE clauses.
-- `20260520030000_lessons_with_metadata_expose_retired.sql` (Session 48): `CREATE OR REPLACE VIEW lessons_with_metadata` appends 2 new columns at the end.
-- 5 source edits: `smart-search/index.ts`, `search-lessons/index.ts`, `useLessonStats.ts`, `LessonSearchPicker.tsx` (new `excludeRetired` prop), `RevisingSubmissionForm.tsx` (passes prop), `process-submission/index.ts` (server-side validation), `generate-embeddings.mjs`, `regenerate-all-embeddings.mjs`.
-- 2 test files updated for the new chain shape (`useLessonStats.test.ts`, `LessonSearchPicker.test.tsx`); +2 new tests for `excludeRetired` prop.
-- 1 hardening comment at `ReviewDetail.tsx:1319` documenting why reviewer flow intentionally does NOT pass `excludeRetired`.
+**Pre-existing CI noise (NOT a PR 4 finding):** `Security & Dependencies` workflow FAIL on `@lhci/cli` transitive vulns (basic-ftp / ip-address / postcss / tmp). Documented in MEMORY.md hygiene-follow-ups; recurs on every PR; both Codex and claude-review confirmed baseline. NOT a merge blocker.
 
-**Local verification clean**: `supabase db reset` applies all 4 PR 4 migrations cleanly; type-check + lint clean; vitest 577/577 (was 575/575; +2 new for `excludeRetired` prop). MCP probes confirm:
-- `lessons.retired_at` + `lessons.retired_reason` columns present with correct types
-- `lessons_with_metadata` view exposes both new columns post-migration
-- Toggle test: view filtered count drops 5→4 when LESSON-001 retired; view unfiltered stays at 5; `search_lessons()` RPC drops to 4; restored to 5 on `retired_at = NULL`
+**Foundation-phase substrate after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + view exposes them + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 8 filter surfaces + `LessonSearchPicker.excludeRetired` prop infrastructure.
 
-**Foundation-phase substrate after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + view exposes them + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 8 filter surfaces filtering retired rows + `LessonSearchPicker.excludeRetired` prop infrastructure for submitter-vs-reviewer asymmetry.
-
-**Next session picks up — push round-1 fix-up + monitor round 2:**
-1. **Push fix-up `bfb3786` + Session 49 docs commit together** per `feedback_no_docs_push_during_pr.md`. CI re-runs on the new HEAD.
-2. **Per-round TEST DB re-verification** — round-1 fix-up has zero DB-affecting commits (only TS source / test / scripts / edge fn body comments + intent comments), so a quick spot-check is sufficient (verify 21-retired / 751-live counts haven't drifted). Round 0 probes remain load-bearing.
-3. **Wait for round 2 bot review.** Round 1 acceptance was 3/7 — bots may push back on the rejects. Default to documenting rather than re-fixing if F2/F5/F6 come back. F7 is verifiably moot.
-4. **Round-cap after round 2 of bot review** per kickoff hard rule.
-5. **Pre-PROD-apply MCP probe** (Session 46 pattern) before approving production migration workflow.
-6. **Post-PROD verify** via `mcp__supabase-remote__execute_sql` (21 retired count + view shape + RPC count).
+**Next session picks up — merge + PROD migration ship:**
+1. **Wait for CI re-run** on Session 50 push HEAD (type-check / lint / tests / claude-review one more pass — no DB changes).
+2. **Post Round-2 response on PR #478** with the 4-finding triage table and acceptance trajectory.
+3. **Pre-PROD MCP probe** via `mcp__supabase-remote__execute_sql` confirming PROD pre-state (21 retired = 0; 7 concept-recovery targets NULL; FSA original title) — Session 46 / 47 / 48 precedent.
+4. **User merges PR #478** (squash-merge per Recent decisions; that triggers `migrate-production.yml`).
+5. **User approves PROD migration workflow** in GitHub Actions — `migrate-production.yml` applies the 4 PR 4 migrations to PROD.
+6. **Watch for the Apply-step SASL flake** (per MEMORY.md hygiene-follow-ups: `migrate-production.yml` SASL apply-step variant; recurring pattern). If it flakes, `gh run rerun --failed <run_id>` re-runs only the Apply slot; approval gate re-fires for re-approval. Migrations are all idempotent (`CREATE OR REPLACE` + `IF NOT EXISTS` + idempotent UPDATE guards) so retry is safe.
+7. **Post-PROD MCP verify** via `mcp__supabase-remote__execute_sql` — same probe set as Round 0 (21 retired + 7 distinct reasons + FSA new title + view exposes 2 cols + 7/7 concepts populated).
+8. **PR-cycle archival prep** — at the start of the next PR's first session, move PR 4 session entries (47-50) into the archive file.
 
 **Branches:**
 - `main` at `cf2aad4` (PR 2 squash-merge); origin matches
-- `feat/metadata-foundation-corpus-cleanup` — PR #478, 7 commits ahead (8 after this session-end docs commit)
-- `feat/metadata-foundation-llm-tagging` (PR 2 merged; deletable at convenience)
-- `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
+- `feat/metadata-foundation-corpus-cleanup` — PR #478, 8 commits ahead pre-Session-50 (10 after Session 50 fix-up + docs commit)
+- `feat/metadata-foundation-llm-tagging`, `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
 
 ## Recent decisions worth carrying forward (PR 1 → PR 1b → PR 2)
 
@@ -120,7 +111,48 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 
 ## Recent session log
 
-### Session 49 — 2026-05-08 — PR 4 round-1 bot review triaged + consolidated fix-up applied
+### Session 50 — 2026-05-08 — PR 4 round-2 IN clean + Codex R2-1 cosmetic cleanup + spot-check + ready to merge
+
+**Done (1 cosmetic fix-up commit + this session-end docs commit, bundled per `feedback_no_docs_push_during_pr.md`):**
+
+- **Session-orientation reconciliation**: status doc claimed "ready to push fix-up and await round 2" but `git log @{u}..HEAD` returned empty — Session 49 push had already happened (commits `bfb3786` + `786203b` were already on origin, head OID matched PR HEAD). Same `feedback_pr_bot_review_workflow.md` "Active-PR session-orientation" pattern that recurred 4× in PR 1b sessions 33-36 + once in Session 49. Reconciled all 4 PR comment surfaces against reality before any code work.
+
+- **Round 2 triage** (3-surface convergence on ship — full collection per kickoff hard rule §6):
+  - claude-review formal review (commit `786203b`, 20:32 UTC, 4 min after Session 49 docs commit): "0 P0/P1 findings. Ready to merge from a code-quality perspective." 2 P3 observations (process-submission error message merge, regenerate-embeddings retired-no-embedding diagnostic).
+  - claude long-form review (commit `786203b`, 20:31 UTC): 1 "Minor" finding ("missing negative test for `excludeRetired=false`") which is a **false positive** — the test exists at `LessonSearchPicker.test.tsx:284`; same bot's own inline comment at L284 says "Clean approach"; Codex Round 2 confirmed. Plus 3 informational items (raw lessons query in LessonSearchPicker, view body duplication across migrations, dead `search-lessons` edge fn) all already deferred from Round 1.
+  - Codex round-2 user-pass (commit `786203b`, 20:47 UTC): "No P1/P2 issues found on the new head." 1 P3 cosmetic: 2 stray `post-PR-4` comments in `useLessonStats.test.ts:22,175` — F3's grep targeted literal `PR 4` and missed the hyphenated form.
+
+- **Round 2 dispositions (1/4 acceptance, default-reject calibration band)**:
+  - **R2-1 ACCEPT (Codex P3)**: stripped `(post-PR-4)` from `useLessonStats.test.ts:22` ("Chain shape: from(...).select(...).is('retired_at', null)") and `:175` ("Rejection happens at the terminal `is()` call.") — preserved the WHY, dropped the task reference. Mirrors F3 (CLAUDE.md). Grep post-fix confirms 0 hits across `src/`. Migration file `20260520030000:130` also has `post-PR-4` in a verification comment but is NOT edited (pushed/applied migration; F2 disposition pattern; database-migrations skill rule).
+  - **R2-2 REJECT (claude-review P3, process-submission error msg)**: Codex defers; debuggability nuance for direct-API callers, not user-visible.
+  - **R2-3 REJECT (claude-review P3, regenerate-embeddings diagnostic)**: Codex defers; correct for normal operation; latent gap only if rows un-retire.
+  - **R2-4 REJECT (claude long-form, false positive)**: negative test exists. Confirmed by inline comment + Codex Round 2.
+
+- **TEST DB spot-check via `mcp__supabase-test__execute_sql`** (per Session 49's relaxed-rubric note for non-DB-affecting rounds): 21 retired ✓, 7 distinct reasons ✓, 751 live via view ✓, FSA new title ✓, view exposes 2 new columns ✓, 7/7 concepts populated with object shape ✓. Round 0 numbers unchanged.
+
+- **Repeated Session 49's mistake of using hallucinated lesson_ids on the concept-recovery probe** — initial probe returned `concepts_populated = 1` because 6 of 7 IDs didn't match the migration target list. Re-ran with verbatim IDs from migration `20260520010000_*` header → 7/7 confirmed. Reinforces Session 49's "copy lesson_ids verbatim from migration source" lesson; this is a recurring pattern worth flagging for any future migration-outcome probe.
+
+- **Pre-existing CI noise on `Security & Dependencies`** (`@lhci/cli` transitive vulns: basic-ftp / ip-address / postcss / tmp). Documented in MEMORY.md hygiene-follow-ups; recurs on every PR. Codex Round 2 explicitly confirmed as baseline.
+
+- **Type-check + lint + vitest 14/14** on `useLessonStats.test.ts` post-edit. Local clean.
+
+**Decisions made:**
+
+- **Round-cap activated per kickoff hard rule §10**: Round 2 IN with bot-voice convergence on ship. R2-1 was a 2-line cosmetic that mirrored an already-accepted F3 disposition; R2-2/R2-3/R2-4 fall in default-reject. Foundation-phase ship pattern.
+- **Bundle Session 50 cosmetic fix-up with this session-end docs commit per `feedback_no_docs_push_during_pr.md`** — saves a CI cycle on docs-only changes; bot review on the bundled push is the same "no DB changes" rubric as Session 49.
+- **Migration file's `post-PR-4` reference NOT edited** — `20260520030000:130` is a pushed/applied migration. F2-pattern disposition: comment-only inaccuracy, document for future verification comments to use the literal-no-task-prefix form, but don't violate the database-migrations skill rule.
+
+**Process notes for Session 51+:**
+
+- **Push Session 50 fix-up + docs commit together** (this is the Session 50 push). CI re-runs on the new HEAD; expect green except the pre-existing Security Audit baseline.
+- **Post Round-2 response on PR #478** — short writeup with the 4-finding disposition table, acceptance trajectory, round-cap rationale, and "ready to merge + approve PROD migration workflow" gate. Mirror Session 49's Round-1 response structure.
+- **Pre-PROD MCP probe** before merge — same probe shape as Round 0 verification, run via `mcp__supabase-remote__execute_sql` confirming PROD pre-state: 0 retired (`SELECT count(*) FROM lessons WHERE retired_at IS NOT NULL`), 7 concept-recovery target rows currently NULL/missing, FSA still has the original "& 2" title. This is the Session 46+47+48 pattern.
+- **PR merge → migrate-production.yml triggers**: user merges (squash-merge per Recent decisions) → workflow queues for manual approval → user approves → applies migrations → automatic verify-step (cosmetic SASL flake possible per memory; PROD MCP verification is the source of truth).
+- **Apply-step SASL flake mitigation** (MEMORY.md): if Apply step itself flakes (NOT cosmetic — migration didn't apply), `gh run rerun --failed <run_id>` re-runs only Apply, approval gate re-fires for re-approval. Migrations idempotent → retry safe. Verify post-rerun via PROD MCP that the actual schema state changed.
+- **Post-PROD MCP verify** mandatory per kickoff hard rule — full Round-0 probe set re-run on `mcp__supabase-remote__execute_sql`.
+- **PR-cycle archival deferred to Session 51 first task** per kickoff session-end ritual step 5: when starting next PR's first session, move Sessions 47-50 from active file → archive.
+
+
 
 **Done (1 substantive commit `bfb3786` + this session-end docs commit):**
 

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,43 +1,42 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-07 — Session 45 (PR 2 round 2 triage + 1 accept committed locally — CRF test coverage added; round-cap activated per PER-PR RITUAL; 1 code commit ahead of origin + this session-end docs commit will bundle).
+**Last updated:** 2026-05-07 — Session 46 (PR 2 SHIPPED + PROD-applied + verified; squash commit `cf2aad4` on main; PR 2 cycle is closed; this session-end docs commit lands on the merged branch and gets bundled into the next PR per Session 36 → 38 precedent).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-36 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (~1600 lines, read on demand via grep). When a new PR cycle begins, that PR's session entries can move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**PR #477 (PR 2 — lesson-submission LLM auto-tag, CRF + activity_type only; tags LLM deferred to follow-up) — OPEN, round 2 triage complete, 1 accept committed locally, round-cap activated.** Branch `feat/metadata-foundation-llm-tagging` at `c92b94c`, **1 code commit ahead of origin** (Session 45 CRF test fix-up `c92b94c`) + this session's docs commit pending. Origin head `6596782` from Session 44's push (which pushed all 4 prior unpushed commits between sessions). E2E + CodeQL turned green on origin push; only Security Audit still failing (pre-existing `@lhci/cli` chain per MEMORY hygiene-follow-ups, not introduced by this PR).
+**PR #477 (PR 2 — lesson-submission LLM auto-tag, CRF + activity_type) — SHIPPED + PROD-applied + verified 2026-05-07.** Squash commit `cf2aad4` on main at 21:34:06 UTC. Both PROD migrations (`20260518200000_lesson_submissions_ai_draft_metadata` + `20260519000000_complete_review_atomic_tags_side_channel`) applied. PROD `process-submission` edge fn at version 31 (was 30 pre-deploy); ezbr_sha256 matches TEST exactly. 4/4 PROD MCP probes confirm the substrate. No SASL flake on the migration apply, no esm.sh CDN 522 flake on the edge fn deploy.
 
-**Session 45 actions (this session):**
-- Active-PR session-orientation: status doc claimed "4 commits ahead of origin awaiting push" but `git log @{u}..HEAD` was empty — push happened post-Session 44 docs commit. CI ran clean; round-2 bot review came in on `6596782` with 7 findings (3 P2 + 4 P3) — `claude` `CHANGES_REQUESTED` at 16:14 UTC. User's Codex round-2 pass at 19:18 UTC recommended 1 accept + round-cap.
-- 4-surface PR comment query confirmed: claude single-voice across reviews + inline comments; GHAS CodeQL alerts on `scripts/build-activity-type-samples.ts` are stale (Session 44's fix-up cleared them, alerts persist as comment artifacts but check is PASS).
-- Rebuttal pass on all 7 round-2 findings: 1 accept + 6 reject. Accept = P2 missing CRF test in `reviewMetadataInit.test.ts`. Rejects: P2 `any` types (pre-existing from `2c14ff04` 2025-08-06, ~9 months pre-PR-2 per `git blame`); P2 TOCTOU race (no concurrent-write path — both LLM steps run sequentially in one edge invocation); P3 `as ReviewMetadata` cast (load-bearing — bridges Zod-inferred `ReviewFormPayloadValidated` to legacy `ReviewMetadata` interface, design-aligned per Gate B); P3 CRF Select `label: v` (verified all 7 master-list features have `value === label` in `filterDefinitions.ts:67-86` — byte-identical output); P3 no content truncation (production must match eval harness — `eval-llm-tagging-prompt.ts:191` sends full `body`); P3 `evalMetrics.ts` Array.includes (~10K ops/run at current scale, harness is one-shot project-internal infra). Round-1 carried-overs (`ai_draft_model` last-writer-wins, merged JSONB re-validation, two Anthropic clients, no LLM call timeout, ReviewDetail form-init guard) all rebutted in same pass.
-- Fix-up commit `c92b94c` — added 2 tests to `src/pages/reviewMetadataInit.test.ts`: valid CRF passthrough (`'Communicates high expectations'`) + invalid CRF returns null. Used actual master-list value per Codex round-2 guidance (Claude's sample value `'Windows-mirrors-and-sliding-doors'` is not a real CR feature). vitest 8/8 green; type-check + lint clean.
-- 3 new out-of-scope follow-ups added (see "Out-of-scope follow-ups"): `any` types pre-PR-2 cleanup PR; per-field `_models` provenance for future model divergence; explicit Anthropic call timeout for resilience.
-- **Round-cap activated** per kickoff PER-PR RITUAL ("round-cap after 2 rounds"). Round 1 = Session 44 fix-ups (back-sort + regex). Round 2 = Session 45 fix-up (CRF test). Any round 3 fixes critical bugs only and ships.
+**Foundation-phase substrate live on PROD now includes:**
+- All PR 1 substrate (lesson_format dropped + series_id + part_number + crf_confirmed + activity_type/tags multi-select array shape with closed enums + cultural_responsiveness_features array of 7 Brown CR features + 3 CHECK constraints + trigger value-validation + Zod canonical + Deno mirror + freshness CI test + filter UI + complete-review Zod-validated)
+- All PR 1b substrate (`activity_type` array passthrough end-to-end via `complete_review_atomic`; retired the synthetic `both` value; repointed [both] → [cooking, garden] on PROD)
+- **PR 2 substrate (NEW):** `lesson_submissions.ai_draft_metadata` JSONB + `ai_draft_generated_at` + `ai_draft_model`; submission-time CRF + activity_type LLM auto-tag in `process-submission` (Opus 4.7, eval-gated macroF1=0.937 / 0.887); `complete_review_atomic` reads `v_ai_draft` and writes tags to lessons.tags column on approve_new + 3-tier carry-forward chain on approve_update (`tags = COALESCE(NULLIF(v_existing.tags, ARRAY[]::text[]), _phase4_jsonb_text_array_or_null(v_ai_draft->'tags'), v_existing.tags)`); ReviewDetail pre-fills form from ai_draft on first review (when no existing review row).
 
-**Foundation-phase substrate live on PROD (unchanged since Session 36):** `lesson_format` dropped; `series_id` + `part_number` + `crf_confirmed` columns; `activity_type` + `tags` array-shape multi-select with closed enums; `cultural_responsiveness_features` closed to 7 Brown CR features; 3 CHECK constraints + trigger value-validation; Zod canonical + bidirectional mappers + Deno mirror + freshness CI test; filter UI Lesson Type backed by `tags`, Activity Type 4-value multi-select chips; `complete-review` Zod-validated. **`process-submission`** has CRF prompt wired in **on PROD**; activity_type wire-up is in PR 2's branch and lands on PROD only after PR 2 ships.
+**Eval-gate state (unchanged since Session 41):** CRF macroF1=0.937 (cleared Session 25); activity_type macroF1=0.887 (cleared Session 41 with Rule Y hybrid garden semantics); per-value F1 cooking 0.889 / garden 0.809 / academic 1.000 / craft 0.852; macro recall 0.956; `academic` truth count = 1 (Lorax binary); `maxPredictionRateForAbsentValues=0.10` guardrail dormant.
 
-**Eval-gate state (unchanged since Session 41):** activity_type macroF1=0.887 cleared; per-value F1 cooking 0.889 / garden 0.809 / academic 1.000 / craft 0.852; macro recall 0.956; `academic` truth count = 1 (Lorax binary); `maxPredictionRateForAbsentValues=0.10` guardrail dormant.
+**Tasks deferred to follow-up PR:** Task 2.5 — tags LLM prompt + eval — sample-set methodology decision pending (tags column is PR-1-new with no historical reviewer-labeling so the eval-gate methodology that anchored CRF and activity_type doesn't apply). Decision shape: synthetic worksheet (manually authored sample set) vs. organic post-deploy data (collect after enough reviewer-tagged submissions arrive) vs. defer until Stage 2 worksheet round.
 
-**Tasks (CRF + activity_type complete in branch; tags deferred):** 2.1-2.3 (CRF) + 2.4 step 1-4 (activity_type prompt + samples + canonical eval + edge-fn wire-up) all done. **Task 2.4 step 5 — TEST DB verification — was effectively covered by Session 44's push:** E2E suite passed (50 passed / 3 skipped per Codex round-2 report), `db push --dry-run` listed both renamed migrations cleanly + apply step ran. Session 45's fix-up is test-only (no DB-affecting change), so no fresh per-round verification needed. Task 2.5 — tags prompt + eval — deferred to a separate post-PR-2 follow-up PR (sample-set methodology decision pending).
+**Branches:**
+- `main` at `cf2aad4` (PR 2 squash-merge); origin matches
+- `feat/metadata-foundation-llm-tagging` (merged; deletable at convenience; this session's docs commit lands on it)
+- `backup/feat-metadata-foundation-llm-tagging-pre-rebase` (created Session 38 pre-rebase; deletable now PR 2 has shipped)
+- `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
 
-**Branches:** `main` at `bd9d6e4` (PR 1b squash). `feat/metadata-foundation-llm-tagging` 1 code commit ahead of origin (Session 45 fix-up `c92b94c` + pending docs commit). `backup/feat-metadata-foundation-llm-tagging-pre-rebase` (deletable post-PR-2 ship). `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (deletable at convenience).
-
-**Next session picks up — push + watch CI + (if no round 3) ready to ship:**
+**Next session picks up — choose the next PR (user-decision):**
 
 ```bash
-git log @{u}..HEAD                                         # confirm 1 code commit + 1 docs commit unpushed
-git push                                                   # bundle CRF test fix-up + Session 45 docs
-gh pr checks 477                                           # confirm checks remain green (Security Audit pre-existing)
-gh pr view 477 --json reviews,comments,state,mergeable     # check for round-3 bot voice
+git checkout main && git pull origin main
+git status --short --branch && git log --oneline -5
+npm run type-check && npm run lint
 ```
 
-**If no round-3 bot voice within ~1 hour of CI completing:** PR is ready to ship per round-cap. User decides squash-merge vs hold.
+**Three options for the next PR:**
+1. **PR 3a — search infra** (search_vector + embeddings + smart-search drift fix; independent of Stage 1 outputs; impl-plan ready in `…-foundation-implementation.md`)
+2. **PR 4 — corpus drops** (23 third-party imports + concept recovery + N1 retitle; independent of Stage 1; pre-delete checklist matters per Phase 6.2 §4D learning — verify FK refs INTO each row + `lessons.original_submission_id` OUT FROM each row before deleting)
+3. **Post-PR-2 tags-LLM follow-up PR** (sample-set methodology decision required first; smaller scope than 3a or 4; rides the same `submit_tags` tool-call infra PR 2 just shipped)
 
-**If round-3 bot voice arrives:** per kickoff "ROUND-CAP AFTER 2 ROUNDS — fix only critical bugs, document the rest, ship." Triage threshold is "real production bug" — design preferences, perf nits, pre-existing issues all auto-defer. Convergence across multiple bot voices is the only signal that warrants opening a third fix-up cycle.
-
-**No fresh TEST DB verification needed for Session 45's commit** (test-only change, no DB-applied state changed). The 6/6 RPC body signal probe + edge-function 3-signal verification can wait until pre-PROD-deploy.
+**PR-cycle archival fires at session-1 of whichever PR is next.** Sessions 37-46 (currently in this active file) move to the archive at that time per kickoff session-end ritual step 5.
 
 ## Recent decisions worth carrying forward (PR 1 → PR 1b → PR 2)
 
@@ -284,6 +283,50 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 - **My API cost estimates were ~3× over actuals.** Across smoke + v1 + v2 + v3, my projected cost per call was 2.7-3.5× the actual. Likely my chars-per-token assumption (3.5) was too low, OR Anthropic's billing has a discount I'm unaware of, OR there's a workspace-credit subsidy. For future projections, anchor on user-observed actuals not my pricing math; my math is consistently overestimating.
 
 - **Single-truth-row eval values are stringent.** Academic now has 1 truth row in the 113-sample set. Per-value academic recall is binary: 1.000 if the LLM correctly tags Lorax, 0.000 if it doesn't. Future canonical re-runs need to keep producing this 1/1 to maintain the per-value floor. If the 1-row category becomes a flake risk, options: (a) add 2-3 more academic-only lessons to the sample set (would need to find/invent), (b) drop the per-value floor for academic only via threshold-config exemption, (c) accept the binary signal as load-bearing — a regression on Lorax tells us the prompt has shifted academic interpretation away from the rule.
+
+### Session 46 — 2026-05-07 — PR 2 SHIPPED + PROD-applied + verified (CRF + activity_type LLM auto-tag)
+
+**Done (1 squash-merge to main + this session-end docs commit on the merged feature branch):**
+
+- **Active-PR session-orientation correction** (6th occurrence of the "stale unpushed claim" pattern; rule already captured in `feedback_pr_bot_review_workflow.md`): status doc claimed "1 code commit ahead of origin + docs commit pending" but `git log @{u}..HEAD` was empty at session start — Session 45's CRF test fix-up `c92b94c` AND Session 45's docs commit `8d645c0` had both already pushed. CI ran on `8d645c0` between Session 45 and Session 46.
+
+- **Round-3 bot voice triaged (4-surface query per `feedback_pr_comment_surfaces.md`).** Round-3 fired on `8d645c0`: claude formal review COMMENTED ("No P0/P1 findings. Four P3 observations inline; none block merge") + claude long-form issue comment + 4 inline P3 comments + Codex round-3 reviewer pass at 21:20 UTC ("**No new blocking P1/P2 findings**"; recommends ship). **Both bot voices converged on ship.** Triage shape: 1 P1 (no Anthropic call timeout — already in OOS follow-ups), 2 P2 (`ai_draft_model` last-writer-wins — already in OOS follow-ups; missing test for "existing review row" — `!existingReview` guard at `ReviewDetail.tsx:460` is correct by construction), 5 P3 nits (4 carry-overs from rounds 1-2 + 1 new `evalMetrics.averageDefined` NaN typing nit — callers handle correctly per claude's own admission). Per round-cap rule "fix only critical bugs" — no critical bugs surfaced.
+
+- **Pre-PROD-apply MCP body-signal probe on TEST DB** (added belt-and-braces hygiene step prompted by user mid-session: "did we already do that?"). Status doc claim was that Session 45's commit was test-only so no fresh per-round verification needed; that's true at the round level. But the *pre-PROD-apply* TEST DB body-signal probe via MCP had not been run for PR 2 specifically (only via CI auto-apply + E2E green). Ran the probe; 6/6 green — all 3 ai_draft_* columns present + both PR 2 migrations (`20260518200000`, `20260519000000`) applied + `complete_review_atomic` body has `v_ai_draft` + reads `ai_draft_metadata` + INSERT writes tags from draft + UPDATE has 3-tier COALESCE chain reading `v_ai_draft` (`tags = COALESCE(NULLIF(v_existing.tags, ARRAY[]::text[]), _phase4_jsonb_text_array_or_null(v_ai_draft->'tags'), v_existing.tags)`) + edge fn TEST version 9 has Anthropic SDK + CRF prompt + activity_type prompt with RMW merge. False alarm on initial regex (looked for `_phase4_..(v_ai_draft` as the FIRST arg of COALESCE, but it's the SECOND arg behind `NULLIF(v_existing.tags...)` — chain order is "existing wins, then LLM draft, then preserve NULL").
+
+- **PR #477 squash-merged via `gh pr merge 477 --squash`** at 2026-05-07T21:34:06Z. Squash commit `cf2aad4` on main. PR was MERGEABLE (UNSTABLE mergeStateStatus only because of pre-existing Security Audit failure on `@lhci/cli` chain, not blocking).
+
+- **PROD migrate + edge-function deploy approved by user; both succeeded on first approval.** `migrate-production.yml` run `25523339957` + `deploy-edge-functions.yml` run `25523339945` — no SASL handshake flake on Apply step, no esm.sh CDN 522 flake on edge fn deploy. Order followed kickoff Recent decisions ("migrations-first, edge-functions-second when both PROD workflows queue together").
+
+- **Post-PROD-apply MCP verification ALL GREEN (4 surfaces, 3-signal pattern):**
+  - `lesson_submissions.ai_draft_*` columns: 3/3 present (jsonb + timestamptz + text, all nullable)
+  - `schema_migrations`: both PR 2 migrations applied (`20260518200000` + `20260519000000`)
+  - `complete_review_atomic` body: 4/4 signals (`v_ai_draft` declared, reads `ai_draft_metadata`, array passthrough for v_ai_draft, `tags = COALESCE(NULLIF(v_existing.tags...` chain present); body_length 14,900 == TEST exactly
+  - `process-submission` edge fn: version 30 → **31** (signal 1: version increment ✓); ezbr_sha256 `94e8bb71...` IDENTICAL to TEST's deploy of same merge commit (signal 2: cross-environment match ✓); source has `import Anthropic`, CRF prompt block, activity_type prompt block with RMW merge into `ai_draft_metadata` (signal 3: source-content grep for new code ✓).
+
+- **PR 2 SHIPPED.** Foundation-phase substrate now includes submission-time Opus 4.7 LLM auto-tag for two fields: cultural_responsiveness_features (gated on body containing "cultural responsiveness" header text — older legacy template ~45% of corpus skipped) + activity_type (always-on, multi-label per Rule Y hybrid garden semantics).
+
+**Decisions made:**
+
+- **User-mid-session intercept on TEST DB verification surfaced an axis gap.** Per-round verification covers the "round changed DB-applied state?" axis, but pre-PROD-apply verification covers the "is TEST DB confirmed in expected post-merge state via MCP?" axis. Both axes apply. Session 45's status-doc claim "no fresh verification needed" was correct at the per-round axis but didn't trip the pre-PROD-apply axis. The 2-min MCP body-signal probe is high-leverage and should fire pre-PROD-apply regardless of per-round-verification status. Worth promoting to the per-round verification feedback memory or kickoff PER-PR RITUAL — see Process notes for Session 47+.
+
+- **`gh pr merge --squash` without `--delete-branch`.** Per past PR 1 + PR 1b precedent, branch retention is user-side cleanup ("deletable at convenience"). Auto-deletion would foreclose any need to recover the per-task hashes from the feature branch.
+
+- **Stay on the merged feature branch for this session's docs commit** (vs. checkout main + create `docs/session-46-pr2-shipped`). Session 36's pattern was the latter, but Session 46's docs are short (~150 lines append + Current State refresh) and the next-PR session can cherry-pick from any branch. Lower-friction path: commit on `feat/metadata-foundation-llm-tagging` (already deletable). If user prefers the dedicated docs branch, easy to recreate later.
+
+- **No new out-of-scope follow-ups added this session.** Session 45's three (any-types cleanup, per-field models provenance, Anthropic call timeout) cover the round-3 substantive findings; round-3's only NEW item was the `evalMetrics.averageDefined` NaN typing nit which is too minor to track.
+
+**Process notes for Session 47+:**
+
+- **PR-cycle archival fires at the START of the next PR (Session 47 if it opens a fresh branch).** Sessions 37-46 in the active file move to the archive at that time per kickoff session-end ritual step 5.
+
+- **Branch cleanup deferrable.** All 5 metadata-foundation feature/backup/docs branches are deletable at user convenience. No urgency.
+
+- **Foundation-phase next-PR options.** Three branches the user can pick (see Current State for command-line first steps). PR 3a (search infra) and PR 4 (corpus drops) are independent of Stage 1; the post-PR-2 tags-LLM follow-up needs its sample-set methodology decision before any code work begins.
+
+- **No v-tag yet.** Per Recent decisions "v-tag deferred to end-of-foundation-phase" — PR 2 is the third foundation-phase PR; tagging mid-phase is premature.
+
+- **Pre-PROD-apply MCP probe pattern is high-leverage — promote to feedback memory.** This session's user-prompted "did we already do that?" check turned a routine 2-min step into a confirmed-green pre-flight check that would have caught any TEST-DB-not-actually-applied case before PROD apply triggered. Candidate: append a bullet to `feedback_per_round_test_db_verification.md` distinguishing "per-round verification" (round changed DB-state?) from "pre-PROD-apply verification" (TEST DB confirmed in expected post-merge state?), making both fire independently. Or fold into kickoff PER-PR RITUAL step 9 explicitly. Decide on Session 47.
 
 ### Session 45 — 2026-05-07 — PR 2 round 2 triage + 1 accept (CRF test coverage); round-cap activated
 

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,12 +1,18 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-08 — Session 48 (PR 4 filter-surface follow-up: 8 user-facing surfaces filter retired imports + view migration that exposes `retired_at` to the view + LessonSearchPicker `excludeRetired` prop; pre-push code-reviewer agent caught and fixed P0 latent bug; ready to push and open PR).
+**Last updated:** 2026-05-08 — Session 49 (PR 4 round-1 bot review triaged + consolidated fix-up `bfb3786` applied: F1 type sync + F3 PR-N comment cleanup + F4 detect-duplicates intent guards; 4 findings rejected/deferred per default-reject calibration; ready to push fix-up and await round 2).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-46 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**PR 4 (corpus cleanup) — Sessions 47-48, ready to push 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 5 commits ahead (6 after this session-end docs commit): `0672cc8` (Session 46 docs cherry-pick) + `ed8ca21` (PR 4 substantive migrations: 21 imports retired + 7 archive concepts recovered + FSA retitle) + `868ed54` (Session 47 docs) + `f522740` (PR 4 follow-up: 8 user-facing surfaces filter retired) + `b0f2564` (P0 fix from pre-push review: view migration + ReviewDetail hardening comment). NOT pushed yet; PR opens immediately after the docs commit.
+**PR 4 (corpus cleanup) — PR #478 OPEN, Session 49 round-1 fix-up applied 2026-05-08.** Branch `feat/metadata-foundation-corpus-cleanup` from main `cf2aad4` (PR 2 squash-merge 2026-05-07). 7 commits ahead (8 after this session-end docs commit): `0672cc8` (Session 46 docs cherry-pick) + `ed8ca21` (PR 4 substantive migrations: 21 imports retired + 7 archive concepts recovered + FSA retitle) + `868ed54` (Session 47 docs) + `f522740` (PR 4 follow-up: 8 user-facing surfaces filter retired) + `b0f2564` (P0 fix from pre-push review: view migration + ReviewDetail hardening comment) + `6a801c1` (Session 48 docs) + `bfb3786` (Session 49 round-1 fix-up: F1 types + F3 comment cleanup + F4 detect-duplicates intent guards).
+
+**Round 0 TEST DB verification PASS (Session 49):** 21 retired count ✓, 7 distinct retired_reason groups ✓, FSA retitle ✓, view exposes 2 new columns ✓, 7/7 concepts recovered with object shape ✓, view live count 751 ✓, search_lessons RPC count 751 ✓, F7 verification (0 array-shape archive concepts anywhere) ✓. PROD pre-state confirmed all 7 concept-recovery targets currently NULL with object-shape archives ready.
+
+**Round 1 bot review triage (Session 49):** 7 findings across 3 reviewer surfaces (claude-review formal, claude long-form, Codex). Acceptance trajectory 3/7 — squarely within `feedback_pr_bot_review_workflow.md` default-reject calibration band:
+- **ACCEPT**: F1 (database.types.ts type sync — added retired_at/retired_reason to 6 type blocks), F3 (stripped 13 `PR 4` references across 9 files; kept WHY content), F4 (4 intent comments in detect-duplicates symmetric with ReviewDetail's hardening pattern).
+- **REJECT/DEFER**: F2 (pushed-migration comment correction; documented in out-of-scope), F5 (partial index hypothetical at corpus 788; documented), F6 (dead search-lessons edge fn; surface inventory tracked it; documented), F7 (TEST + PROD probe confirms zero array-shape archives — verification gate passed).
 
 **Surface inventory locked (from Session 48 investigation):**
 - **Filtered (8 surfaces):** `search_lessons` RPC body, `smart-search` edge fn, `search-lessons` edge fn (defensive — dead front-end caller), `useLessonStats` hook, `LessonSearchPicker` (new `excludeRetired` prop, default false), `RevisingSubmissionForm` caller (passes `excludeRetired`), `process-submission` update-target validation (defense-in-depth), `generate-embeddings.mjs` + `regenerate-all-embeddings.mjs` (don't burn OpenAI cost on retired).
@@ -33,18 +39,17 @@
 
 **Foundation-phase substrate after PR 4 ships:** all PR 1 / PR 1b / PR 2 substrate + soft-retire columns on `lessons` + view exposes them + 21 imports retired + 7 archive-only concepts restored + FSA Pt 1 retitle + 8 filter surfaces filtering retired rows + `LessonSearchPicker.excludeRetired` prop infrastructure for submitter-vs-reviewer asymmetry.
 
-**Next session picks up — PR 4 push + bot review cycle:**
-1. **Push branch + open PR** with `gh pr create`. CI applies migrations to TEST DB; this fires the round 0 verification window.
-2. **Round 0 TEST DB verification** via `mcp__supabase-test__execute_sql`: 21 retired count + FSA new title + 7 concepts recovered shape + view exposes new columns + search_lessons RPC count drops appropriately.
-3. **Bot review rounds + ritual** per `feedback_pr_bot_review_workflow.md` (CodeRabbit + Claude Review). Investigate every finding; default-reject hardening for internal-only paths.
-4. **Per-round TEST DB re-verification** for any DB-affecting fix-up commits.
-5. **Round-cap after 2 rounds of bot review.**
-6. **Pre-PROD-apply MCP probe** (Session 46 pattern) before approving the production migration workflow.
-7. **Post-PROD verify** via `mcp__supabase-remote__execute_sql` (21 retired count + view shape + RPC count).
+**Next session picks up — push round-1 fix-up + monitor round 2:**
+1. **Push fix-up `bfb3786` + Session 49 docs commit together** per `feedback_no_docs_push_during_pr.md`. CI re-runs on the new HEAD.
+2. **Per-round TEST DB re-verification** — round-1 fix-up has zero DB-affecting commits (only TS source / test / scripts / edge fn body comments + intent comments), so a quick spot-check is sufficient (verify 21-retired / 751-live counts haven't drifted). Round 0 probes remain load-bearing.
+3. **Wait for round 2 bot review.** Round 1 acceptance was 3/7 — bots may push back on the rejects. Default to documenting rather than re-fixing if F2/F5/F6 come back. F7 is verifiably moot.
+4. **Round-cap after round 2 of bot review** per kickoff hard rule.
+5. **Pre-PROD-apply MCP probe** (Session 46 pattern) before approving production migration workflow.
+6. **Post-PROD verify** via `mcp__supabase-remote__execute_sql` (21 retired count + view shape + RPC count).
 
 **Branches:**
 - `main` at `cf2aad4` (PR 2 squash-merge); origin matches
-- `feat/metadata-foundation-corpus-cleanup` — this session's work, 5 commits ahead (6 after this session-end docs commit)
+- `feat/metadata-foundation-corpus-cleanup` — PR #478, 7 commits ahead (8 after this session-end docs commit)
 - `feat/metadata-foundation-llm-tagging` (PR 2 merged; deletable at convenience)
 - `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema` (all deletable at convenience)
 
@@ -91,6 +96,12 @@ These flowed out of the PR 1 + PR 1b rituals (Sessions 13-36). General patterns 
 
 - **Per-field model provenance inside `ai_draft_metadata`** — `lesson_submissions.ai_draft_model text` records only the last writer (today: activity_type's model wins because it writes second). Both prompts use `claude-opus-4-7` so no provenance is wrong today, but if CRF and activity_type ever migrate to different models (e.g., CRF on Sonnet for cost savings, activity_type stays Opus), the column silently mis-attributes the CRF draft. Fix: store per-field model inside the JSONB (`{ _meta: { models: { crf: '...', activityType: '...' } } }`) or add a separate `ai_draft_models jsonb` column. Surfaced by claude-review round-1 P2 + round-2 inline P3. Not blocking PR 2; worth addressing when (a) a third LLM-auto-tag prompt lands, OR (b) CRF/activity_type model versions diverge for any reason. (Source: Session 45 round-2 triage.)
 
+- **Migration verification-comment syntax (PR 4 round-1 F2 from Codex P3).** `supabase/migrations/20260520020000_search_lessons_filter_retired.sql:216` documents an expected post-apply count via `SELECT count(*) FROM (SELECT * FROM search_lessons() LIMIT 1000) sub; -- 767 (live)`. The inner query returns at most 20 rows (page_size default), so the outer LIMIT is a no-op. Correct syntax: `SELECT total_count FROM search_lessons(page_size => 1) LIMIT 1`. Not editing the pushed migration (database-migrations skill rule); document for future verification comments. Comment-only inaccuracy; doesn't affect runtime behavior. (Source: PR #478 round-1 Codex pass.)
+
+- **Partial index `WHERE retired_at IS NULL` on `lessons` (PR 4 round-1 F5 from claude long-form Low).** Every `search_lessons` RPC call, smart-search query, and `useLessonStats` fetch now evaluates `retired_at IS NULL` against the full `lessons` table. At 788 rows this is negligible. A partial index `CREATE INDEX IF NOT EXISTS idx_lessons_retired_at_null ON lessons (lesson_id) WHERE retired_at IS NULL;` would help if corpus growth or `EXPLAIN ANALYZE` plans show pain. Codex defers; revisit when there's empirical evidence of cost. (Source: PR #478 round-1 claude long-form review.)
+
+- **Dead `search-lessons` edge fn (PR 4 round-1 F6 from claude long-form Low).** Has no live front-end caller today (front-end uses `search_lessons` RPC + `smart-search` edge fn) but stays deployed and is now kept-in-sync with the retired filter. "Kept in sync for symmetry" means every future filter change has one more place to remember. Cleanest fix is to undeploy via `supabase functions delete search-lessons --project-ref ...` after merging this PR; that's separate work outside PR 4 scope and follows the deferred-approval ordering hazard pattern from MEMORY.md (drain queued production-approval runs before approving them). (Source: PR #478 round-1 claude long-form review.)
+
 - **Explicit Anthropic call timeout in `process-submission/index.ts`** — Anthropic SDK default timeout is 600s; Supabase edge function wall-clock cap (~150s) is the binding constraint, so submissions can't hang indefinitely. But adding explicit `timeout: 30_000` per call would bound worst-case latency ~5x tighter and prevent accidentally consuming the entire edge-fn budget on one hung LLM call. Rejected from PR 2 because (a) the try/catch wrapping each call already handles transient failures gracefully (non-fatal pattern), (b) edge-fn timeout already exists as outer bound, (c) no production incident has surfaced this risk. Worth adding when a future PR is already touching this region (e.g., adding a third prompt). (Source: Session 45 round-2 triage; claude-review round-1 P3 #4.)
 
 ## Pointers to durable context
@@ -108,6 +119,51 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 - Project-specific memories: `project_metadata_three_regimes.md` / `project_vocabulary_drift_scope.md` / `project_lesson_format_conflated.md` / `project_dedup_third_state.md` / `project_metadata_cleanup_candidates.md` / `project_crf_stamp_theater.md` / `project_teacher_zero_metadata_model.md` / `project_imported_non_esynyc_drops.md`
 
 ## Recent session log
+
+### Session 49 — 2026-05-08 — PR 4 round-1 bot review triaged + consolidated fix-up applied
+
+**Done (1 substantive commit `bfb3786` + this session-end docs commit):**
+
+- **Session-orientation check** flagged status doc was stale on push state — branch was actually pushed and PR #478 OPEN with round 1 already in. Pattern matches `feedback_pr_bot_review_workflow.md` "Active-PR session-orientation" rule (recurred 4× across PR 1b sessions 33-36). Reconciled active doc to reality before any code work.
+
+- **Round 0 TEST DB verification probes** via `mcp__supabase-test__execute_sql` (single batched 13-probe query). All probes returned correct values: 21 retired ✓, 7 distinct retired_reason groups ✓, FSA new title ✓, view exposes 2 new columns ✓, 7/7 concepts recovered with `object` shape ✓, 0 array-shape archive concepts anywhere (F7 verification gate passed) ✓, search_lessons total_count 751 = 772−21 ✓, view live count 751 ✓. PROD pre-state diagnostic confirmed all 7 concept-recovery targets currently NULL with `object`-shape archives ready to populate on PROD-apply.
+
+- **My initial P6 probe used hallucinated lesson_ids** (only 1 of 7 IDs matched the actual migration target list). Re-ran with correct IDs from migration `20260520010000_*` header → all 7 confirmed populated. Lesson for future migration-outcome probes: copy lesson_ids verbatim from migration source rather than typing from memory.
+
+- **Round 1 bot review triage** (3 reviewer surfaces — claude-review formal + claude long-form + Codex via user-pass). 7 findings consolidated; rebuttal pass per `feedback_bot_review_investigation.md`:
+  - **F1 ACCEPT** (Codex P2): `database.types.ts` missing `retired_at`/`retired_reason` on `Tables.lessons.{Row,Insert,Update}` + `Views.lessons_with_metadata.{Row,Insert,Update}`. Hand-patched 6 type blocks (12 field additions). Hand-patch path correct per status doc out-of-scope note that the file is hand-patched since PR 1.
+  - **F2 REJECT (document)** (Codex P3): migration verification-comment syntax inaccuracy. Editing pushed/applied migration violates database-migrations skill rule; comment-only fix is semantically safe but doesn't justify breaking the rule. Documented in out-of-scope follow-ups for future migrations.
+  - **F3 ACCEPT** (claude-review P2 + claude long-form Low): 13 `PR 4` references stripped from 9 files (`LessonSearchPicker.tsx`, `LessonSearchPicker.test.tsx`, `useLessonStats.ts`, `useLessonStats.test.ts`, `ReviewDetail.tsx`, `search-lessons/index.ts`, `smart-search/index.ts`, `process-submission/index.ts`, `generate-embeddings.mjs` ×2, `regenerate-all-embeddings.mjs` ×3). Per CLAUDE.md project root: "Don't reference the current task". Kept the explanatory WHY content; stripped only the task-prefix. Migration internal comments left alone (per database-migrations skill rule + the date-stamped artifact framing).
+  - **F4 ACCEPT (light)** (claude-review P1, Codex P3): 4 sites in `detect-duplicates/index.ts` got 1-line intent comments explaining why they intentionally read the full corpus (no retired filter): hash check (L221), semantic embedding (L252), metadata enrichment (L268), fallback title search (L297). Symmetric with `ReviewDetail.tsx:1319`'s existing hardening comment.
+  - **F5 REJECT** (claude long-form Low): partial index hypothetical at corpus 788. Documented with revisit trigger.
+  - **F6 REJECT** (claude long-form Low): dead `search-lessons` edge fn. Already in surface inventory + tracked. Documented with the deferred-approval ordering hazard caveat.
+  - **F7 REJECT (verified clean)** (claude-review P3): TEST DB probe `P8_archive_array_shape_skipped = 0` — no array-shape archive concepts exist anywhere. PROD diagnostic confirms all 7 concept-recovery targets have object-shape archives. Codex framed as "verification gate"; gate just passed.
+
+- **Consolidated fix-up commit `bfb3786`** applies F1+F3+F4 in one commit. 12 files changed, +35/-17 net. Local verification clean: type-check + lint + 577/577 vitest (matches PR 4 baseline; F3 strips don't affect test count, F4 added intent-only comments).
+
+- **Source `PR 4` reference grep post-fix-up** returns zero hits across `src/`, `supabase/`, `scripts/` — F3 is complete (migration internal comments retained intentionally).
+
+**Decisions made:**
+
+- **Round 1 acceptance trajectory: 3/7.** Squarely in `feedback_pr_bot_review_workflow.md` default-reject calibration band — accepted F1 (real type-correctness gap), F3 (CLAUDE.md compliance), F4 (light hardening symmetric with existing pattern). Rejected F2/F5/F6 with documentation; F7 was verifiably moot.
+
+- **Pushed-migration comment correction (F2): document, don't fix.** The cited inaccuracy is in a SQL comment in an already-applied migration. Editing pushed migrations violates database-migrations skill rule even though the proposed fix is semantically safe. Codex itself rates P3. Document for future migrations to use the correct verification syntax.
+
+- **Light-touch F4 over heavyweight refactor.** Bot's recommendation could have been spun into "refactor `detect-duplicates` to make the filter-or-not choice an explicit parameter" but a 1-line intent comment per query site is cheap insurance and matches the existing ReviewDetail hardening pattern. Refactor is out of scope for foundation-phase PR 4.
+
+- **No DB-affecting commits this round** — fix-up touches only TS source / test / scripts / edge fn body comments + intent comments. Per-round TEST DB re-verification is therefore a quick spot-check rather than full reprobe (round 0 probes remain load-bearing). One concrete data point for `feedback_per_round_test_db_verification.md`: rounds with zero DB-affecting changes get a relaxed verification rubric.
+
+**Process notes for Session 50+:**
+
+- **Push fix-up `bfb3786` + this session-end docs commit together** per `feedback_no_docs_push_during_pr.md`. CI re-runs on the new HEAD; bots emit round 2 reviews after that.
+
+- **Round 2 bot review expected.** Bots may push back on the rejects (F2/F5/F6). Default-reject re-applies; document if they re-flag. F7 is verifiably moot — TEST DB probes prove zero array-shape archives.
+
+- **Round-cap after round 2** per kickoff hard rule. If a 3rd round comes in, fix only critical bugs, document the rest, ship.
+
+- **Pre-PROD-apply MCP probe pattern** (Session 46 + 47 + 48 precedent) — same probes via `mcp__supabase-remote__execute_sql` AS A READ before approving PROD migration workflow. Belt-and-braces: TEST↔PROD diff via same query body to spot-check both surfaces.
+
+- **Watch the migrate-production.yml SASL flake on apply step.** PR 4 has 4 migrations applying together. If the apply step flakes, `gh run rerun --failed <run_id>` re-runs only the failed slot; approval gate re-fires for re-approval. Migrations are idempotent so retry is safe.
 
 ### Session 48 — 2026-05-08 — PR 4 follow-up: 8 filter surfaces + view migration + P0 fix from pre-push review (ready to push)
 

--- a/scripts/generate-embeddings.mjs
+++ b/scripts/generate-embeddings.mjs
@@ -130,6 +130,7 @@ async function generateEmbeddings() {
       .select('*')
       .not('content_text', 'is', null)  // Must have content
       .is('content_embedding', null)     // But no embedding yet
+      .is('retired_at', null)            // PR 4: skip soft-retired imports
       .order('lesson_id');
 
     if (fetchError) throw fetchError;
@@ -235,16 +236,19 @@ async function generateEmbeddings() {
       }
     }
 
-    // Verify results
+    // Verify results (live corpus only — soft-retired rows are intentionally
+    // skipped per PR 4 so they don't inflate denominators).
     console.log('\n🔍 Verifying embeddings...');
     const { count: totalCount } = await supabase
       .from('lessons')
-      .select('*', { count: 'exact', head: true });
+      .select('*', { count: 'exact', head: true })
+      .is('retired_at', null);
 
     const { count: embeddedCount } = await supabase
       .from('lessons')
       .select('*', { count: 'exact', head: true })
-      .not('content_embedding', 'is', null);
+      .not('content_embedding', 'is', null)
+      .is('retired_at', null);
 
     const totalTime = (Date.now() - startTime) / 1000;
     const actualCost = ((processed * (totalTokens / lessons.length)) / 1000) * 0.00002;

--- a/scripts/generate-embeddings.mjs
+++ b/scripts/generate-embeddings.mjs
@@ -130,7 +130,7 @@ async function generateEmbeddings() {
       .select('*')
       .not('content_text', 'is', null)  // Must have content
       .is('content_embedding', null)     // But no embedding yet
-      .is('retired_at', null)            // PR 4: skip soft-retired imports
+      .is('retired_at', null)            // Skip soft-retired imports
       .order('lesson_id');
 
     if (fetchError) throw fetchError;
@@ -237,7 +237,7 @@ async function generateEmbeddings() {
     }
 
     // Verify results (live corpus only — soft-retired rows are intentionally
-    // skipped per PR 4 so they don't inflate denominators).
+    // skipped so they don't inflate denominators).
     console.log('\n🔍 Verifying embeddings...');
     const { count: totalCount } = await supabase
       .from('lessons')

--- a/scripts/regenerate-all-embeddings.mjs
+++ b/scripts/regenerate-all-embeddings.mjs
@@ -67,11 +67,12 @@ async function regenerateAllEmbeddings() {
   console.log('=' .repeat(60));
 
   try {
-    // 1. Get all lessons
+    // 1. Get all live lessons (skip soft-retired imports per PR 4)
     console.log('📋 Fetching all lessons...');
     const { data: lessons, error: fetchError } = await supabase
       .from('lessons')
       .select('lesson_id, title, content_text, content_embedding')
+      .is('retired_at', null)
       .order('created_at', { ascending: false });
     
     if (fetchError) throw fetchError;
@@ -150,11 +151,12 @@ async function regenerateAllEmbeddings() {
     console.log(`❌ Failed: ${failCount} embeddings failed`);
     console.log(`⏭️  Skipped: ${skipCount} (no content)`);
     
-    // 6. Verify
+    // 6. Verify (live corpus only — soft-retired rows excluded per PR 4)
     const { data: finalCheck } = await supabase
       .from('lessons')
       .select('lesson_id')
-      .is('content_embedding', null);
+      .is('content_embedding', null)
+      .is('retired_at', null);
     
     if (finalCheck && finalCheck.length > 0) {
       console.log(`\n⚠️  ${finalCheck.length} lessons still missing embeddings`);
@@ -202,11 +204,12 @@ async function createMockEmbeddings() {
   console.log('=' .repeat(60));
   
   try {
-    // Get all lessons
+    // Get all live lessons (skip soft-retired imports per PR 4)
     const { data: lessons } = await supabase
       .from('lessons')
       .select('lesson_id, title, content_text')
-      .not('content_text', 'is', null);
+      .not('content_text', 'is', null)
+      .is('retired_at', null);
     
     console.log(`Found ${lessons.length} lessons to process\n`);
     

--- a/scripts/regenerate-all-embeddings.mjs
+++ b/scripts/regenerate-all-embeddings.mjs
@@ -67,7 +67,7 @@ async function regenerateAllEmbeddings() {
   console.log('=' .repeat(60));
 
   try {
-    // 1. Get all live lessons (skip soft-retired imports per PR 4)
+    // 1. Get all live lessons (skip soft-retired imports)
     console.log('📋 Fetching all lessons...');
     const { data: lessons, error: fetchError } = await supabase
       .from('lessons')
@@ -151,7 +151,7 @@ async function regenerateAllEmbeddings() {
     console.log(`❌ Failed: ${failCount} embeddings failed`);
     console.log(`⏭️  Skipped: ${skipCount} (no content)`);
     
-    // 6. Verify (live corpus only — soft-retired rows excluded per PR 4)
+    // 6. Verify (live corpus only — soft-retired rows excluded)
     const { data: finalCheck } = await supabase
       .from('lessons')
       .select('lesson_id')
@@ -204,7 +204,7 @@ async function createMockEmbeddings() {
   console.log('=' .repeat(60));
   
   try {
-    // Get all live lessons (skip soft-retired imports per PR 4)
+    // Get all live lessons (skip soft-retired imports)
     const { data: lessons } = await supabase
       .from('lessons')
       .select('lesson_id, title, content_text')

--- a/src/components/LessonSearchPicker.test.tsx
+++ b/src/components/LessonSearchPicker.test.tsx
@@ -246,7 +246,7 @@ describe('LessonSearchPicker', () => {
     expect(screen.queryByText(/can't find it/i)).not.toBeInTheDocument();
   });
 
-  it('applies retired_at IS NULL filter when excludeRetired=true (PR 4)', async () => {
+  it('applies retired_at IS NULL filter when excludeRetired=true', async () => {
     const { supabase } = await import('@/lib/supabase');
     const isMock = vi.fn().mockReturnThis();
     (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({

--- a/src/components/LessonSearchPicker.test.tsx
+++ b/src/components/LessonSearchPicker.test.tsx
@@ -259,12 +259,7 @@ describe('LessonSearchPicker', () => {
 
     const user = userEvent.setup();
     render(
-      <LessonSearchPicker
-        selected={null}
-        onSelect={vi.fn()}
-        onClear={vi.fn()}
-        excludeRetired
-      />
+      <LessonSearchPicker selected={null} onSelect={vi.fn()} onClear={vi.fn()} excludeRetired />
     );
 
     await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'apple');

--- a/src/components/LessonSearchPicker.test.tsx
+++ b/src/components/LessonSearchPicker.test.tsx
@@ -3,11 +3,15 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LessonSearchPicker } from '@/components/LessonSearchPicker';
 
+// Mock chain shape: from → select → ilike → [is when excludeRetired=true] →
+// order → limit. `is` is included so the chain resolves regardless of
+// excludeRetired value (component conditionally invokes it).
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     from: vi.fn(() => ({
       select: vi.fn().mockReturnThis(),
       ilike: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({
         data: [
@@ -37,6 +41,7 @@ describe('LessonSearchPicker', () => {
     (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       select: vi.fn().mockReturnThis(),
       ilike: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({
         data: [
@@ -110,6 +115,7 @@ describe('LessonSearchPicker', () => {
     (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       select: vi.fn().mockReturnThis(),
       ilike: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({ data: [], error: null }),
     }));
@@ -192,6 +198,7 @@ describe('LessonSearchPicker', () => {
     (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       select: vi.fn().mockReturnThis(),
       ilike: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnValue(searchPromise),
     }));
@@ -237,5 +244,52 @@ describe('LessonSearchPicker', () => {
     await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'nonsense');
     await waitFor(() => {}, { timeout: 500 });
     expect(screen.queryByText(/can't find it/i)).not.toBeInTheDocument();
+  });
+
+  it('applies retired_at IS NULL filter when excludeRetired=true (PR 4)', async () => {
+    const { supabase } = await import('@/lib/supabase');
+    const isMock = vi.fn().mockReturnThis();
+    (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      is: isMock,
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }));
+
+    const user = userEvent.setup();
+    render(
+      <LessonSearchPicker
+        selected={null}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+        excludeRetired
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'apple');
+    await waitFor(() => expect(isMock).toHaveBeenCalledWith('retired_at', null), {
+      timeout: 1000,
+    });
+  });
+
+  it('does NOT apply retired_at filter when excludeRetired is unset (default false)', async () => {
+    const { supabase } = await import('@/lib/supabase');
+    const isMock = vi.fn().mockReturnThis();
+    (supabase.from as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      is: isMock,
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }));
+
+    const user = userEvent.setup();
+    render(<LessonSearchPicker selected={null} onSelect={vi.fn()} onClear={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText(/search by lesson title/i), 'apple');
+    // Wait for the debounced query to fire by waiting for `from` to be called.
+    await waitFor(() => expect(supabase.from).toHaveBeenCalled(), { timeout: 1000 });
+    expect(isMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/LessonSearchPicker.tsx
+++ b/src/components/LessonSearchPicker.tsx
@@ -17,6 +17,12 @@ interface LessonSearchPickerProps {
   onClear: () => void;
   cantFindOption?: boolean;
   onCantFind?: () => void;
+  // PR 4: when true, soft-retired imports are excluded from the dropdown.
+  // Submitter flows (RevisingSubmissionForm) opt in so teachers can't pick
+  // a retired lesson as their UPDATE target. Reviewer flows (ReviewDetail
+  // dup-review escape hatch) leave default false so the reviewer can still
+  // find any lesson, including retired competitors.
+  excludeRetired?: boolean;
 }
 
 const DEBOUNCE_MS = 300;
@@ -28,6 +34,7 @@ export function LessonSearchPicker({
   onClear,
   cantFindOption = false,
   onCantFind,
+  excludeRetired = false,
 }: LessonSearchPickerProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<LessonSearchResult[]>([]);
@@ -36,37 +43,42 @@ export function LessonSearchPicker({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const requestIdRef = useRef(0);
 
-  const runSearch = useCallback(async (q: string) => {
-    const myRequestId = ++requestIdRef.current;
-    if (!q.trim()) {
-      setResults([]);
-      setHasQueried(false);
-      setIsLoading(false);
-      return;
-    }
-    setIsLoading(true);
-    try {
-      const { data, error } = await supabase
-        .from('lessons')
-        .select('lesson_id, title, grade_levels, season_timing')
-        .ilike('title', `%${q}%`)
-        .order('title', { ascending: true })
-        .limit(MAX_RESULTS);
-      if (myRequestId !== requestIdRef.current) return;
-      if (error) throw error;
-      setResults((data ?? []) as LessonSearchResult[]);
-      setHasQueried(true);
-    } catch (err) {
-      if (myRequestId !== requestIdRef.current) return;
-      logger.debug('LessonSearchPicker query failed:', err);
-      setResults([]);
-      setHasQueried(true);
-    } finally {
-      if (myRequestId === requestIdRef.current) {
+  const runSearch = useCallback(
+    async (q: string) => {
+      const myRequestId = ++requestIdRef.current;
+      if (!q.trim()) {
+        setResults([]);
+        setHasQueried(false);
         setIsLoading(false);
+        return;
       }
-    }
-  }, []);
+      setIsLoading(true);
+      try {
+        let qry = supabase
+          .from('lessons')
+          .select('lesson_id, title, grade_levels, season_timing')
+          .ilike('title', `%${q}%`);
+        if (excludeRetired) {
+          qry = qry.is('retired_at', null);
+        }
+        const { data, error } = await qry.order('title', { ascending: true }).limit(MAX_RESULTS);
+        if (myRequestId !== requestIdRef.current) return;
+        if (error) throw error;
+        setResults((data ?? []) as LessonSearchResult[]);
+        setHasQueried(true);
+      } catch (err) {
+        if (myRequestId !== requestIdRef.current) return;
+        logger.debug('LessonSearchPicker query failed:', err);
+        setResults([]);
+        setHasQueried(true);
+      } finally {
+        if (myRequestId === requestIdRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [excludeRetired]
+  );
 
   useEffect(() => {
     if (selected) return;

--- a/src/components/LessonSearchPicker.tsx
+++ b/src/components/LessonSearchPicker.tsx
@@ -17,7 +17,7 @@ interface LessonSearchPickerProps {
   onClear: () => void;
   cantFindOption?: boolean;
   onCantFind?: () => void;
-  // PR 4: when true, soft-retired imports are excluded from the dropdown.
+  // When true, soft-retired imports are excluded from the dropdown.
   // Submitter flows (RevisingSubmissionForm) opt in so teachers can't pick
   // a retired lesson as their UPDATE target. Reviewer flows (ReviewDetail
   // dup-review escape hatch) leave default false so the reviewer can still

--- a/src/hooks/useLessonStats.test.ts
+++ b/src/hooks/useLessonStats.test.ts
@@ -116,7 +116,7 @@ describe('useLessonStats', () => {
       });
 
       expect(mock).toHaveBeenCalledWith('*', { count: 'exact', head: true });
-      // PR 4: live-corpus filter excludes soft-retired imports.
+      // Live-corpus filter excludes soft-retired imports.
       expect(isMock).toHaveBeenCalledWith('retired_at', null);
     });
   });

--- a/src/hooks/useLessonStats.test.ts
+++ b/src/hooks/useLessonStats.test.ts
@@ -18,18 +18,22 @@ vi.mock('@/utils/logger', () => ({
   },
 }));
 
-// Typed mock helper for Supabase select queries
+// Typed mock helper for Supabase select queries.
+// Chain shape (post-PR-4): from(...).select(...).is('retired_at', null)
+// The `is()` call is the terminal awaited call; select returns an object
+// with `is`, and `is` returns the Promise.
 interface MockSelectResult {
   count: number | null;
   error: { message: string } | null;
 }
 
 function createMockSelectQuery(result: MockSelectResult | Promise<MockSelectResult>) {
-  const selectMock = vi
-    .fn()
-    .mockReturnValue(result instanceof Promise ? result : Promise.resolve(result));
+  const promise = result instanceof Promise ? result : Promise.resolve(result);
+  const isMock = vi.fn().mockReturnValue(promise);
+  const selectMock = vi.fn().mockReturnValue({ is: isMock });
   return {
     mock: selectMock,
+    isMock,
     chain: { select: selectMock } as unknown as ReturnType<typeof supabase.from>,
   };
 }
@@ -102,7 +106,7 @@ describe('useLessonStats', () => {
     });
 
     it('calls supabase with correct parameters', async () => {
-      const { mock, chain } = createMockSelectQuery({ count: 100, error: null });
+      const { mock, isMock, chain } = createMockSelectQuery({ count: 100, error: null });
       mockSupabase.from.mockReturnValue(chain);
 
       renderHook(() => useLessonStats());
@@ -112,6 +116,8 @@ describe('useLessonStats', () => {
       });
 
       expect(mock).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+      // PR 4: live-corpus filter excludes soft-retired imports.
+      expect(isMock).toHaveBeenCalledWith('retired_at', null);
     });
   });
 
@@ -166,7 +172,9 @@ describe('useLessonStats', () => {
     });
 
     it('handles thrown exceptions', async () => {
-      const selectMock = vi.fn().mockRejectedValue(new Error('Network error'));
+      // Rejection happens at the terminal `is()` call (post-PR-4 chain shape).
+      const isMock = vi.fn().mockRejectedValue(new Error('Network error'));
+      const selectMock = vi.fn().mockReturnValue({ is: isMock });
       mockSupabase.from.mockReturnValue({ select: selectMock } as unknown as ReturnType<
         typeof supabase.from
       >);
@@ -181,7 +189,8 @@ describe('useLessonStats', () => {
     });
 
     it('handles non-Error exceptions with fallback message', async () => {
-      const selectMock = vi.fn().mockRejectedValue('string error');
+      const isMock = vi.fn().mockRejectedValue('string error');
+      const selectMock = vi.fn().mockReturnValue({ is: isMock });
       mockSupabase.from.mockReturnValue({ select: selectMock } as unknown as ReturnType<
         typeof supabase.from
       >);
@@ -197,7 +206,8 @@ describe('useLessonStats', () => {
 
     it('logs error when fetch fails', async () => {
       const testError = new Error('Network error');
-      const selectMock = vi.fn().mockRejectedValue(testError);
+      const isMock = vi.fn().mockRejectedValue(testError);
+      const selectMock = vi.fn().mockReturnValue({ is: isMock });
       mockSupabase.from.mockReturnValue({ select: selectMock } as unknown as ReturnType<
         typeof supabase.from
       >);

--- a/src/hooks/useLessonStats.test.ts
+++ b/src/hooks/useLessonStats.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/utils/logger', () => ({
 }));
 
 // Typed mock helper for Supabase select queries.
-// Chain shape (post-PR-4): from(...).select(...).is('retired_at', null)
+// Chain shape: from(...).select(...).is('retired_at', null)
 // The `is()` call is the terminal awaited call; select returns an object
 // with `is`, and `is` returns the Promise.
 interface MockSelectResult {
@@ -172,7 +172,7 @@ describe('useLessonStats', () => {
     });
 
     it('handles thrown exceptions', async () => {
-      // Rejection happens at the terminal `is()` call (post-PR-4 chain shape).
+      // Rejection happens at the terminal `is()` call.
       const isMock = vi.fn().mockRejectedValue(new Error('Network error'));
       const selectMock = vi.fn().mockReturnValue({ is: isMock });
       mockSupabase.from.mockReturnValue({ select: selectMock } as unknown as ReturnType<

--- a/src/hooks/useLessonStats.ts
+++ b/src/hooks/useLessonStats.ts
@@ -21,7 +21,7 @@ export function useLessonStats(): LessonStats {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        // Get total LIVE lesson count (excludes soft-retired imports per PR 4).
+        // Get total LIVE lesson count (excludes soft-retired imports).
         const { count, error } = await supabase
           .from('lessons_with_metadata')
           .select('*', { count: 'exact', head: true })

--- a/src/hooks/useLessonStats.ts
+++ b/src/hooks/useLessonStats.ts
@@ -21,10 +21,11 @@ export function useLessonStats(): LessonStats {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        // Get total lesson count
+        // Get total LIVE lesson count (excludes soft-retired imports per PR 4).
         const { count, error } = await supabase
           .from('lessons_with_metadata')
-          .select('*', { count: 'exact', head: true });
+          .select('*', { count: 'exact', head: true })
+          .is('retired_at', null);
 
         if (error) throw error;
 

--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -1316,7 +1316,7 @@ export function ReviewDetail() {
               {showSearch && (
                 <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
                   <p className="text-xs text-gray-600 mb-2">{searchHelpText}</p>
-                  {/* PR 4: intentionally NOT passing excludeRetired so the
+                  {/* Intentionally NOT passing excludeRetired so the
                       reviewer can find retired competitors during dup-review
                       escape-hatch search (e.g., "this submission is a
                       re-import of retired Stone Soup"). Submitter flows

--- a/src/pages/ReviewDetail.tsx
+++ b/src/pages/ReviewDetail.tsx
@@ -1316,6 +1316,12 @@ export function ReviewDetail() {
               {showSearch && (
                 <div className="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg">
                   <p className="text-xs text-gray-600 mb-2">{searchHelpText}</p>
+                  {/* PR 4: intentionally NOT passing excludeRetired so the
+                      reviewer can find retired competitors during dup-review
+                      escape-hatch search (e.g., "this submission is a
+                      re-import of retired Stone Soup"). Submitter flows
+                      (RevisingSubmissionForm) opt in via excludeRetired;
+                      reviewer flows leave the default false. */}
                   <LessonSearchPicker
                     selected={selectedSearchLesson}
                     onSelect={(l) => {

--- a/src/pages/RevisingSubmissionForm.tsx
+++ b/src/pages/RevisingSubmissionForm.tsx
@@ -180,6 +180,7 @@ export function RevisingSubmissionForm() {
               onClear={() => setSelectedLesson(null)}
               cantFindOption
               onCantFind={() => setCantFind(true)}
+              excludeRetired
             />
           )}
         </div>

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -577,6 +577,8 @@ export type Database = {
           original_submission_id: string | null;
           part_number: number | null;
           processing_notes: string | null;
+          retired_at: string | null;
+          retired_reason: string | null;
           review_notes: string | null;
           search_vector: unknown;
           season_timing: string[] | null;
@@ -620,6 +622,8 @@ export type Database = {
           original_submission_id?: string | null;
           part_number?: number | null;
           processing_notes?: string | null;
+          retired_at?: string | null;
+          retired_reason?: string | null;
           review_notes?: string | null;
           search_vector?: unknown;
           season_timing?: string[] | null;
@@ -663,6 +667,8 @@ export type Database = {
           original_submission_id?: string | null;
           part_number?: number | null;
           processing_notes?: string | null;
+          retired_at?: string | null;
+          retired_reason?: string | null;
           review_notes?: string | null;
           search_vector?: unknown;
           season_timing?: string[] | null;
@@ -1086,6 +1092,8 @@ export type Database = {
           original_submission_id: string | null;
           prep_time_minutes_meta: string | null;
           processing_notes: string | null;
+          retired_at: string | null;
+          retired_reason: string | null;
           review_notes: string | null;
           search_vector: unknown;
           season_meta: string | null;
@@ -1143,6 +1151,8 @@ export type Database = {
           original_submission_id?: string | null;
           prep_time_minutes_meta?: never;
           processing_notes?: string | null;
+          retired_at?: string | null;
+          retired_reason?: string | null;
           review_notes?: string | null;
           search_vector?: unknown;
           season_meta?: never;
@@ -1200,6 +1210,8 @@ export type Database = {
           original_submission_id?: string | null;
           prep_time_minutes_meta?: never;
           processing_notes?: string | null;
+          retired_at?: string | null;
+          retired_reason?: string | null;
           review_notes?: string | null;
           search_vector?: unknown;
           season_meta?: never;

--- a/supabase/functions/detect-duplicates/index.ts
+++ b/supabase/functions/detect-duplicates/index.ts
@@ -217,7 +217,9 @@ serve(async (req) => {
     // Generate content hash
     const contentHash = await generateContentHash(content, metadata);
 
-    // First, check for exact hash matches
+    // First, check for exact hash matches.
+    // Intentionally queries the full corpus (no retired filter) so reviewers
+    // catch a future re-submission of a previously retired import.
     const { data: hashMatches, error: hashError } = await supabase.rpc('find_lessons_by_hash', {
       hash_value: contentHash,
     });
@@ -248,7 +250,8 @@ serve(async (req) => {
     if (embedding && embedding.length === 1536) {
       const vectorString = `[${embedding.join(',')}]`;
 
-      // Use the SQL function for semantic search
+      // Use the SQL function for semantic search.
+      // Intentionally unfiltered — see comment at the hash check above.
       const { data: semanticMatches, error: semanticError } = await supabase.rpc(
         'find_similar_lessons_by_embedding',
         {
@@ -263,7 +266,9 @@ serve(async (req) => {
           // Skip if already found as exact match
           if (duplicates.some((d) => d.lessonId === match.lesson_id)) continue;
 
-          // Get full lesson data for metadata
+          // Get full lesson data for metadata.
+          // Intentionally unfiltered — if `match.lesson_id` is a retired row,
+          // we still want its metadata so the dup-check report surfaces it.
           const { data: lesson } = await supabase
             .from('lessons_with_metadata')
             .select('metadata')
@@ -293,7 +298,8 @@ serve(async (req) => {
         }
       }
     } else {
-      // Fallback to title-based search if no embedding
+      // Fallback to title-based search if no embedding.
+      // Intentionally unfiltered — see comment at the hash check above.
       const { data: allLessons, error: lessonsError } = await supabase
         .from('lessons_with_metadata')
         .select('lesson_id, title, metadata')

--- a/supabase/functions/process-submission/index.ts
+++ b/supabase/functions/process-submission/index.ts
@@ -208,7 +208,7 @@ serve(async (req) => {
       // rows on the error path. The DB-level FK serves as the TOCTOU
       // backstop; this check provides fast user feedback.
       //
-      // PR 4: also reject UPDATEs targeting soft-retired imports. The
+      // Also reject UPDATEs targeting soft-retired imports. The
       // submitter UI (RevisingSubmissionForm + LessonSearchPicker
       // excludeRetired prop) hides retired rows, but a hand-typed or
       // direct-API call could still send a retired lesson_id; defense in

--- a/supabase/functions/process-submission/index.ts
+++ b/supabase/functions/process-submission/index.ts
@@ -207,11 +207,18 @@ serve(async (req) => {
       // Phase 8b: validate originalLessonId BEFORE INSERT to avoid orphan
       // rows on the error path. The DB-level FK serves as the TOCTOU
       // backstop; this check provides fast user feedback.
+      //
+      // PR 4: also reject UPDATEs targeting soft-retired imports. The
+      // submitter UI (RevisingSubmissionForm + LessonSearchPicker
+      // excludeRetired prop) hides retired rows, but a hand-typed or
+      // direct-API call could still send a retired lesson_id; defense in
+      // depth at the server boundary.
       if (normalizedSubmissionType === 'update' && normalizedOriginalLessonId) {
         const { count: lessonCount, error: lessonCheckError } = await supabaseAdmin
           .from('lessons')
           .select('lesson_id', { count: 'exact', head: true })
-          .eq('lesson_id', normalizedOriginalLessonId);
+          .eq('lesson_id', normalizedOriginalLessonId)
+          .is('retired_at', null);
         if (lessonCheckError) {
           throw lessonCheckError;
         }

--- a/supabase/functions/search-lessons/index.ts
+++ b/supabase/functions/search-lessons/index.ts
@@ -61,7 +61,7 @@ serve(async (req) => {
     let supabaseQuery = supabaseClient
       .from('lessons_with_metadata')
       .select('*', { count: 'exact' })
-      // PR 4: exclude soft-retired imports from user-facing search.
+      // Exclude soft-retired imports from user-facing search.
       // Note: this edge fn has no live front-end caller today (front-end
       // uses the search_lessons RPC + smart-search edge fn); kept in sync
       // for symmetry since the function is still deployed.

--- a/supabase/functions/search-lessons/index.ts
+++ b/supabase/functions/search-lessons/index.ts
@@ -60,7 +60,12 @@ serve(async (req) => {
     // Build the base query
     let supabaseQuery = supabaseClient
       .from('lessons_with_metadata')
-      .select('*', { count: 'exact' });
+      .select('*', { count: 'exact' })
+      // PR 4: exclude soft-retired imports from user-facing search.
+      // Note: this edge fn has no live front-end caller today (front-end
+      // uses the search_lessons RPC + smart-search edge fn); kept in sync
+      // for symmetry since the function is still deployed.
+      .is('retired_at', null);
 
     // Apply text search if query exists
     if (query && query.trim()) {

--- a/supabase/functions/smart-search/index.ts
+++ b/supabase/functions/smart-search/index.ts
@@ -153,7 +153,12 @@ serve(async (req) => {
     // Build the base query
     let supabaseQuery = supabaseClient
       .from('lessons_with_metadata')
-      .select('*', { count: 'exact' });
+      .select('*', { count: 'exact' })
+      // PR 4: exclude soft-retired imports from user-facing search.
+      // The `lessons_with_metadata` view is intentionally not filtered;
+      // detect-duplicates / get_lesson_details_for_review need to keep
+      // seeing retired rows so reviewers catch future re-submissions.
+      .is('retired_at', null);
 
     // Apply smart text search if query exists
     if (query && query.trim()) {

--- a/supabase/functions/smart-search/index.ts
+++ b/supabase/functions/smart-search/index.ts
@@ -154,7 +154,7 @@ serve(async (req) => {
     let supabaseQuery = supabaseClient
       .from('lessons_with_metadata')
       .select('*', { count: 'exact' })
-      // PR 4: exclude soft-retired imports from user-facing search.
+      // Exclude soft-retired imports from user-facing search.
       // The `lessons_with_metadata` view is intentionally not filtered;
       // detect-duplicates / get_lesson_details_for_review need to keep
       // seeing retired rows so reviewers catch future re-submissions.

--- a/supabase/migrations/20260520000000_corpus_cleanup_retire_imports.sql
+++ b/supabase/migrations/20260520000000_corpus_cleanup_retire_imports.sql
@@ -1,0 +1,147 @@
+-- =====================================================
+-- Migration: 20260520000000_corpus_cleanup_retire_imports.sql
+-- =====================================================
+-- Metadata-rebuild foundation phase, PR 4, Tasks 4.3 + 4.5:
+-- Soft-retire 21 wholesale third-party-curriculum imports + FSA Pt 1 retitle.
+--
+-- Per project memory `project_imported_non_esynyc_drops.md`: 21 lessons
+-- in the corpus are wholesale third-party curriculum imports in non-ESYNYC
+-- format (5 PFLP 2003 vintage + 11 FoodCorps 2017 vintage + 5 one-offs).
+-- All 21 created 2025-07-10 via batch import; all have NULL
+-- original_submission_id (no submission-flow provenance); all have NULL
+-- authored_by metadata. Foundation-phase corpus shrinks from 788 to 767
+-- effective rows after retirement.
+--
+-- Note on count: prior tracking docs cited "23 lessons"; actual scan of
+-- the locked drop list (memory + PROD/TEST audit 2026-05-08) is 21. The
+-- "23" was a stale early estimate; not investigated further because the
+-- structural-signature sweep against PROD found no obvious additional
+-- candidates. If 2 more candidates are surfaced later, a follow-up
+-- migration can extend the retirement set; the soft-delete mechanism
+-- generalizes.
+--
+-- Approach: SOFT-DELETE via `retired_at timestamptz` + `retired_reason
+-- text`. Cluster-key reasons enable forward audit ("show all FoodCorps
+-- imports we retired"). Rows stay in lessons table; downstream search
+-- RPCs + views filter `WHERE retired_at IS NULL` to hide them. This
+-- preserves any FK references intact: 2 historical dup_resolutions + 2
+-- lesson_archive rows reference Leaves We Eat / Stone Soup as canonical
+-- winners of merge-and-archive resolutions on 2025-09-01 (per PROD MCP
+-- audit 2026-05-08). Soft-delete keeps those FKs valid. Reversible
+-- via `UPDATE lessons SET retired_at = NULL` (un-retirement).
+--
+-- N1 retitle (Task 4.5): "Food System Advocates (Part 1 & 2)" →
+-- "Food System Advocates (Part 1)". Pt 2 was byte-identical to Pt 1
+-- minus one worksheet-link change; "& 2" misled teachers into expecting
+-- a second lesson that didn't really exist. Per N1 cross-cutting
+-- decision (decision journal lines 558-572).
+--
+-- Filter surfaces (search RPCs / view / smart-search / facetCounts.ts /
+-- embedding regen) ship in PR 4 follow-up commits this same branch.
+-- detect-duplicates and process-submission content-hash dedup are
+-- intentionally NOT filtered (cross-checking against retired imports is
+-- useful at submission time).
+
+-- =====================================================
+-- SCHEMA: add soft-retirement columns
+-- =====================================================
+
+ALTER TABLE lessons
+  ADD COLUMN IF NOT EXISTS retired_at timestamptz DEFAULT NULL;
+
+ALTER TABLE lessons
+  ADD COLUMN IF NOT EXISTS retired_reason text DEFAULT NULL;
+
+COMMENT ON COLUMN lessons.retired_at IS
+  'Soft-delete marker. NULL = live (default); non-NULL = retired (excluded from search/lookup queries). Foundation-phase PR 4 retired 21 wholesale third-party imports here. Reversible via UPDATE retired_at = NULL.';
+
+COMMENT ON COLUMN lessons.retired_reason IS
+  'Audit-trail key for retirement reason. Foundation-phase PR 4 uses "import:<source>" namespace (e.g., "import:pflp_2003", "import:foodcorps_2017"). Future retirement reasons can use other namespaces. NULL when retired_at IS NULL.';
+
+-- =====================================================
+-- DATA: retire 21 third-party-curriculum imports
+-- =====================================================
+-- Each UPDATE is idempotent via `AND retired_at IS NULL` guard — re-running
+-- the migration is a no-op for already-retired rows.
+
+-- PFLP (Project Food, Land & People), 2003 vintage — 5 lessons
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:pflp_2003'
+WHERE lesson_id IN (
+  '1uZ2Vdg-_jH_m9Vg6PljJVzMFrkOOTAbI', -- Breads Around the World
+  '1m0vPeiqyk0SxMDN0hrRu14v4aZhiFb7X', -- What Piece of the Pie?
+  '1--bRQYkbtZm3ojqd501cWL57PgcLWLVk', -- Amazing Grazing
+  '1-De8P7-cEQ-rKyuKep2788ximpiKfh2Q', -- Seasons Through the Year
+  '1FUwdpwK2fgb900qo2vSlsg6m-O2ybW7x'  -- The Plant and Me
+)
+AND retired_at IS NULL;
+
+-- FoodCorps, 2017 vintage — 11 lessons (8 explicit copyright + 3 template-match)
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:foodcorps_2017'
+WHERE lesson_id IN (
+  '1uHYXPurqWPHRJQ4DjT46s7sjLoN09W61',                 -- Plant Part Mystery!
+  '1Jbc2TvhQH-mzikeBiRoyCgR21EgQdbGq',                 -- Tortilla Time!
+  '1thI8cD1bcZPG5VLzu4N5rlEBVYO4VedV',                 -- If Our Class Were a Soup...
+  '1gOciyeX1nRaOL27Vkl_sCXnBFwHZMV5n',                 -- What the World Eats
+  '1tKktUwEqYymTjYXXmVBOc2RR7tH5HHUy',                 -- Rainbow Grain Salad
+  '1Y6tHYm3Hh2vLCBCDaM36_TO1EuM61ofd',                 -- Choose-Your-Own Flavor Popcorn
+  '11QlN-din-a8-xf_lTOzkZt8O54P_Xt2T',                 -- Summer Sun Risin'
+  '1o4Ru6FVLFcC766HrQNta0BiZ_1MNl1qlWf8dk362Skw',      -- Teas around the World (stub, 971 chars)
+  '1kwWC4upXrmfxeOgu2OCwFOcKoowZZuwW',                 -- Green Sauce Around the World (template-match)
+  '1syFNS-FUiVWUvkZRhfyxfXc0ukDrwnkO',                 -- Stone Soup (template-match; canonical of dedup group_82)
+  '14_2kozPIy22gxK6I2Lu5vrbcwUfhu5ul'                  -- Our Food Traditions (template-match)
+)
+AND retired_at IS NULL;
+
+-- One-off imports — 5 lessons
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:cas_food_justice'
+WHERE lesson_id = '15T4wU94xT3r-dRx-WJq9XD2-ySg2HKaz' -- Children's Aid Society: Food Justice Program
+  AND retired_at IS NULL;
+
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:nyc_doe_colonial_ny'
+WHERE lesson_id = '0BzjqiKCWBLWeYVlta0lkVXJfajg' -- COLONIAL AND REVOLUTIONARY PERIOD NEW YORK
+  AND retired_at IS NULL;
+
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:city_blossoms_botanical_artists'
+WHERE lesson_id = '1c_1EanckKI1w98qNtO0JCp9fF35PdrSi' -- Botanical Artists
+  AND retired_at IS NULL;
+
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:nyc_dep_watershed'
+WHERE lesson_id = '1eO20OF8EOBOUwK1bXMY2AVAK9jN52F9h' -- What is a Watershed?
+  AND retired_at IS NULL;
+
+UPDATE lessons SET retired_at = now(), retired_reason = 'import:oregon_doe_leaves'
+WHERE lesson_id = '0B1MDYcmyESHgWDIyelRWbHljZ1k' -- Leaves We Eat (canonical of dedup group_6)
+  AND retired_at IS NULL;
+
+-- =====================================================
+-- DATA: N1 retitle — Food System Advocates
+-- =====================================================
+-- Idempotent via title equality guard.
+
+UPDATE lessons
+SET title = 'Food System Advocates (Part 1)'
+WHERE lesson_id = '1iqGFHrQ0rWfyoLo4R4n8FO9N-S7LW1ZpalaLNF5_Tmk'
+  AND title = 'Food System Advocates (Part 1 & 2)';
+
+-- =====================================================
+-- VERIFICATION (informational; not enforcement)
+-- =====================================================
+-- Expected post-apply state:
+--   SELECT count(*) FROM lessons WHERE retired_at IS NOT NULL;             -- 21
+--   SELECT count(DISTINCT retired_reason) FROM lessons WHERE retired_at IS NOT NULL;  -- 7
+--   SELECT title FROM lessons WHERE lesson_id = '1iqGFHrQ0rWfyoLo4R4n8FO9N-S7LW1ZpalaLNF5_Tmk';
+--                                                                          -- 'Food System Advocates (Part 1)'
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- -- Restore FSA title:
+-- UPDATE lessons SET title = 'Food System Advocates (Part 1 & 2)'
+-- WHERE lesson_id = '1iqGFHrQ0rWfyoLo4R4n8FO9N-S7LW1ZpalaLNF5_Tmk'
+--   AND title = 'Food System Advocates (Part 1)';
+-- -- Un-retire all 21 import drops:
+-- UPDATE lessons SET retired_at = NULL, retired_reason = NULL
+-- WHERE retired_reason LIKE 'import:%';
+-- -- Drop columns (idempotent):
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS retired_reason;
+-- ALTER TABLE lessons DROP COLUMN IF EXISTS retired_at;

--- a/supabase/migrations/20260520010000_recover_archive_only_concepts.sql
+++ b/supabase/migrations/20260520010000_recover_archive_only_concepts.sql
@@ -1,0 +1,109 @@
+-- =====================================================
+-- Migration: 20260520010000_recover_archive_only_concepts.sql
+-- =====================================================
+-- Metadata-rebuild foundation phase, PR 4, Task 4.4:
+-- Recover academicConcepts from `lesson_versions` archive into live
+-- `lessons.metadata` for 7 lesson_ids whose live row lost the data
+-- during Phase 6.2 corpus cleanup (2026-04-27 archive timestamp).
+--
+-- Discovered during foundation-phase walkthrough (memory:
+-- `project_metadata_cleanup_candidates.md` — "16 concepts surviving only
+-- in lesson_versions archive"). PROD MCP audit 2026-05-08 confirms 7
+-- distinct lesson_ids with non-empty concepts in archive but
+-- NULL/missing live `metadata.academicConcepts`. Concept count tally
+-- 2026-05-08 is 19 across the 7 rows — a slight ~16-vs-19 drift from
+-- the memory's tally, but the same population.
+--
+-- 7 affected lesson_ids (live titles + concept subjects):
+--   1Dkx1Q--fGzGDCAu3kx5OTsuRa_lRY2agdiMqyfn2VpI — All About Compost (Science: 3)
+--   1hwLrvv9CUTx2rw2UMTDhqmLXQTd0hEsxan3HvNpPwa8 — Applesauce (Health: 1, Science: 1)
+--   1K1tlc3--Dv061Qi1A1AKOGW6_L19VXSTRtKHfe73bjY — Meet The Food System (Science: 1, Social Studies: 2)
+--   1uwZRLYoxThlJxDq-vV3cePHmEMGMCpj5Opk0nHVvqqI — African American Food Traditions – Museum (Literacy/ELA: 2, Social Studies: 3)
+--   1YX8Dv7UWeg1JG_ZsBPBTDCap5JOXpbhE — Ladybugs (Arts: 1, Science: 2)
+--   1zrKohaoXxvEe86HLnOvjUED_Am_-ETNw — A Visit to Mashama Bailey's Restaurant (Social Studies: 2)
+--   11oY-EaKF7FTeNxSE_xbsCmSytnBmjc9WPlyBF11Chz0 — Green "Acai" Bowls (Mobile Education) (Science: 1)
+--     (archive title is "Unknown" but concept content is plausible — only the
+--      concept blob is recovered; the title field is left untouched)
+--
+-- Source shape (lesson_versions.metadata.academicIntegration.concepts):
+--   {"Subject": ["concept1", "concept2"], ...}
+-- Target shape (lessons.metadata.academicConcepts):
+--   {"Subject": ["concept1", "concept2"], ...}
+-- Direct copy; same JSONB shape.
+--
+-- Why before Stage 2 re-tag (PR 6+): foundation-phase Stage 2 re-tags
+-- the corpus via Opus on the post-cleanup state. Restoring the orphan
+-- concepts now means Stage 2 has full pre-existing context as input
+-- (and any Opus-rewritten concepts will land on a row with reviewer-
+-- authored history rather than a NULL field). Recovery happens at the
+-- substrate layer, not the Stage 2 layer.
+
+-- =====================================================
+-- DATA: recover concepts
+-- =====================================================
+-- Idempotent via `WHERE l.metadata->'academicConcepts' IS NULL OR ...`
+-- guard. Re-running the migration is a no-op for rows where concepts are
+-- already populated. Picks the most-recent archive version per lesson_id
+-- (DISTINCT ON + ORDER BY version_number DESC) defensively, even though
+-- the current corpus has 1 archive row per affected lesson_id.
+
+UPDATE lessons l
+SET metadata = jsonb_set(
+  COALESCE(l.metadata, '{}'::jsonb),
+  '{academicConcepts}',
+  lv.concepts,
+  true  -- create_missing
+)
+FROM (
+  SELECT DISTINCT ON (lesson_id)
+         lesson_id,
+         metadata->'academicIntegration'->'concepts' AS concepts
+  FROM lesson_versions
+  WHERE metadata->'academicIntegration'->'concepts' IS NOT NULL
+    AND jsonb_typeof(metadata->'academicIntegration'->'concepts') = 'object'
+    AND metadata->'academicIntegration'->'concepts' <> '{}'::jsonb
+  ORDER BY lesson_id, version_number DESC
+) lv
+WHERE l.lesson_id = lv.lesson_id
+  -- Idempotency: only set if live row is missing concepts
+  AND (
+    l.metadata IS NULL
+    OR l.metadata->'academicConcepts' IS NULL
+    OR jsonb_typeof(l.metadata->'academicConcepts') = 'null'
+    OR l.metadata->'academicConcepts' = '{}'::jsonb
+  );
+
+-- =====================================================
+-- VERIFICATION (informational)
+-- =====================================================
+-- Expected post-apply state:
+--   SELECT count(*) FROM lessons l
+--   WHERE EXISTS (
+--     SELECT 1 FROM lesson_versions lv
+--     WHERE lv.lesson_id = l.lesson_id
+--       AND jsonb_typeof(lv.metadata->'academicIntegration'->'concepts') = 'object'
+--       AND lv.metadata->'academicIntegration'->'concepts' <> '{}'::jsonb
+--   )
+--   AND (l.metadata->'academicConcepts' IS NULL
+--        OR l.metadata->'academicConcepts' = '{}'::jsonb);
+--                                          -- 0 (no more orphan concepts)
+-- And spot-check the 7 lesson_ids — academicConcepts populated with
+-- the same JSONB shape as the archive.
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- -- Per-row revert is the safest path — this migration only touches
+-- -- rows whose live `academicConcepts` was NULL/empty pre-recovery, so
+-- -- removing the key blindly is correct for the targeted population:
+-- UPDATE lessons l
+-- SET metadata = l.metadata - 'academicConcepts'
+-- WHERE l.lesson_id IN (
+--   '1Dkx1Q--fGzGDCAu3kx5OTsuRa_lRY2agdiMqyfn2VpI',
+--   '1hwLrvv9CUTx2rw2UMTDhqmLXQTd0hEsxan3HvNpPwa8',
+--   '1K1tlc3--Dv061Qi1A1AKOGW6_L19VXSTRtKHfe73bjY',
+--   '1uwZRLYoxThlJxDq-vV3cePHmEMGMCpj5Opk0nHVvqqI',
+--   '1YX8Dv7UWeg1JG_ZsBPBTDCap5JOXpbhE',
+--   '1zrKohaoXxvEe86HLnOvjUED_Am_-ETNw',
+--   '11oY-EaKF7FTeNxSE_xbsCmSytnBmjc9WPlyBF11Chz0'
+-- );

--- a/supabase/migrations/20260520020000_search_lessons_filter_retired.sql
+++ b/supabase/migrations/20260520020000_search_lessons_filter_retired.sql
@@ -1,0 +1,233 @@
+-- =====================================================
+-- Migration: 20260520020000_search_lessons_filter_retired.sql
+-- =====================================================
+-- Description:
+--   PR 4 follow-up — add `AND l.retired_at IS NULL` to the WHERE clauses of
+--   `public.search_lessons` so soft-retired imports (added by sibling migration
+--   `20260520000000_corpus_cleanup_retire_imports.sql`) are excluded from
+--   user-facing search results.
+--
+--   This is the SQL surface in PR 4's per-consumer-filter approach for
+--   soft-retirement. Companion edits to the other 7 consumer surfaces
+--   (smart-search, search-lessons, useLessonStats, LessonSearchPicker,
+--   process-submission, generate-embeddings, regenerate-all-embeddings)
+--   land as TS edits in the same PR cycle.
+--
+--   `lessons_with_metadata` view is intentionally NOT changed: detect-duplicates
+--   + ReviewDetail similar-lessons + ReviewDashboard queue badges + the
+--   `get_lesson_details_for_review` RPC all read from `lessons` (or the view)
+--   and need to keep seeing retired rows so reviewers catch a future
+--   re-submission of a retired import. Per-consumer filter preserves that
+--   asymmetry; baking the filter into the view would not.
+--
+-- Why CREATE OR REPLACE (not DROP+CREATE):
+--   Body-only change. The 15-argument signature established at
+--   `20260514000000_search_lessons_filter_tags.sql:72-88` is preserved exactly.
+--   No GRANT re-issue needed — CREATE OR REPLACE preserves the existing
+--   grants on the same function identity.
+--
+-- What's NEW vs `20260514000000`:
+--   In BOTH the count query and the paginated result query, append:
+--       AND l.retired_at IS NULL
+--   immediately after the `filter_tags` overlap clause.
+--
+-- =====================================================
+-- CREATE OR REPLACE search_lessons (body-only change: +retired_at filter)
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.search_lessons(
+  search_query           text    DEFAULT NULL,
+  filter_grade_levels    text[]  DEFAULT NULL,
+  filter_themes          text[]  DEFAULT NULL,
+  filter_seasons         text[]  DEFAULT NULL,
+  filter_competencies    text[]  DEFAULT NULL,
+  filter_cultures        text[]  DEFAULT NULL,
+  filter_location        text[]  DEFAULT NULL,
+  filter_activity_type   text[]  DEFAULT NULL,
+  filter_lesson_format   text    DEFAULT NULL,         -- compat bridge; drops in Task 1.3a
+  filter_academic        text[]  DEFAULT NULL,
+  filter_sel             text[]  DEFAULT NULL,
+  filter_cooking_method  text[]  DEFAULT NULL,
+  filter_tags            text[]  DEFAULT NULL,
+  page_size              integer DEFAULT 20,
+  page_offset            integer DEFAULT 0
+)
+RETURNS TABLE (
+  lesson_id    text,
+  title        text,
+  summary      text,
+  file_link    text,
+  grade_levels text[],
+  metadata     jsonb,
+  confidence   jsonb,
+  rank         double precision,
+  total_count  bigint
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  expanded_query    text;
+  expanded_cultures text[];
+  total_results     bigint;
+BEGIN
+  -- Synonym expansion for FTS
+  IF search_query IS NOT NULL AND search_query <> '' THEN
+    expanded_query := expand_search_with_synonyms(search_query);
+  ELSE
+    expanded_query := NULL;
+  END IF;
+
+  -- Cultural heritage: alias FIRST, then expand to children.
+  IF filter_cultures IS NOT NULL AND array_length(filter_cultures, 1) > 0 THEN
+    expanded_cultures := expand_cultural_heritage(_alias_cultural_heritage(filter_cultures));
+  ELSE
+    expanded_cultures := NULL;
+  END IF;
+
+  -- Total count (count and result queries share WHERE)
+  SELECT COUNT(*) INTO total_results
+  FROM lessons l
+  WHERE
+    (search_query IS NULL OR search_query = '' OR (
+      l.search_vector @@ to_tsquery('english', expanded_query) OR
+      l.title   % search_query OR
+      l.summary % search_query
+    ))
+    AND (filter_grade_levels IS NULL OR array_length(filter_grade_levels, 1) IS NULL OR
+         l.grade_levels && filter_grade_levels)
+    AND (filter_themes IS NULL OR array_length(filter_themes, 1) IS NULL OR
+         l.thematic_categories && filter_themes)
+    AND (filter_seasons IS NULL OR array_length(filter_seasons, 1) IS NULL OR
+         l.season_timing && filter_seasons)
+    AND (filter_competencies IS NULL OR array_length(filter_competencies, 1) IS NULL OR
+         l.core_competencies && filter_competencies)
+    AND (expanded_cultures IS NULL OR array_length(expanded_cultures, 1) IS NULL OR
+         l.cultural_heritage && expanded_cultures)
+    AND (filter_location IS NULL OR array_length(filter_location, 1) IS NULL OR
+         l.location_requirements && filter_location)
+    AND (filter_activity_type IS NULL OR array_length(filter_activity_type, 1) IS NULL OR
+         l.activity_type && _alias_activity_type(filter_activity_type))
+    -- (filter_lesson_format WHERE clause removed — D3 lessonFormat field dropped.
+    --  Parameter retained as a compat bridge; ignored by this body.)
+    AND (filter_academic IS NULL OR array_length(filter_academic, 1) IS NULL OR
+         l.academic_integration && filter_academic)
+    AND (filter_sel IS NULL OR array_length(filter_sel, 1) IS NULL OR
+         l.social_emotional_learning && filter_sel)
+    AND (filter_cooking_method IS NULL OR array_length(filter_cooking_method, 1) IS NULL OR
+         _match_cooking_methods(l.cooking_methods, filter_cooking_method))
+    AND (filter_tags IS NULL OR array_length(filter_tags, 1) IS NULL OR
+         l.tags && filter_tags)
+    -- NEW (PR 4): exclude soft-retired imports from user-facing search.
+    AND l.retired_at IS NULL;
+
+  -- Paginated result rows
+  RETURN QUERY
+  SELECT
+    l.lesson_id,
+    l.title,
+    l.summary,
+    l.file_link,
+    l.grade_levels,
+    -- Per-field COALESCE metadata reconstruction. Same as 20260514000000.
+    --
+    -- COLUMNS INCLUDED (post-D3):
+    --   thematic_categories, season_timing, location_requirements,
+    --   core_competencies, cultural_heritage, activity_type,
+    --   cooking_methods, academic_integration, social_emotional_learning
+    COALESCE(l.metadata, '{}'::jsonb) || jsonb_strip_nulls(jsonb_build_object(
+      'thematicCategories',      CASE WHEN COALESCE(array_length(l.thematic_categories, 1), 0) > 0       THEN to_jsonb(l.thematic_categories)       END,
+      'seasonTiming',            CASE WHEN COALESCE(array_length(l.season_timing, 1), 0) > 0             THEN to_jsonb(l.season_timing)             END,
+      'locationRequirements',    CASE WHEN COALESCE(array_length(l.location_requirements, 1), 0) > 0     THEN to_jsonb(l.location_requirements)     END,
+      'coreCompetencies',        CASE WHEN COALESCE(array_length(l.core_competencies, 1), 0) > 0         THEN to_jsonb(l.core_competencies)         END,
+      'culturalHeritage',        CASE WHEN COALESCE(array_length(l.cultural_heritage, 1), 0) > 0         THEN to_jsonb(l.cultural_heritage)         END,
+      -- 'lessonFormat' overlay key removed — D3.
+      'activityType',            CASE WHEN COALESCE(array_length(l.activity_type, 1), 0) > 0             THEN to_jsonb(l.activity_type)             END,
+      'cookingMethods',          CASE WHEN COALESCE(array_length(l.cooking_methods, 1), 0) > 0           THEN to_jsonb(l.cooking_methods)           END,
+      'academicIntegration',     CASE WHEN COALESCE(array_length(l.academic_integration, 1), 0) > 0      THEN to_jsonb(l.academic_integration)      END,
+      'socialEmotionalLearning', CASE WHEN COALESCE(array_length(l.social_emotional_learning, 1), 0) > 0 THEN to_jsonb(l.social_emotional_learning) END,
+      'academicConcepts',        CASE
+                                   WHEN jsonb_typeof(l.metadata->'academicIntegration') = 'object'
+                                    AND l.metadata->'academicIntegration' ? 'concepts'
+                                   THEN l.metadata->'academicIntegration'->'concepts'
+                                 END
+    )) AS metadata,
+    l.confidence,
+    CASE
+      WHEN search_query IS NOT NULL AND search_query <> '' THEN
+        GREATEST(
+          COALESCE(ts_rank(l.search_vector, to_tsquery('english', expanded_query)), 0),
+          COALESCE(similarity(l.title,   search_query), 0),
+          COALESCE(similarity(l.summary, search_query), 0) * 0.8
+        )::double precision
+      ELSE 0::double precision
+    END AS rank,
+    total_results
+  FROM lessons l
+  WHERE
+    (search_query IS NULL OR search_query = '' OR (
+      l.search_vector @@ to_tsquery('english', expanded_query) OR
+      l.title   % search_query OR
+      l.summary % search_query
+    ))
+    AND (filter_grade_levels IS NULL OR array_length(filter_grade_levels, 1) IS NULL OR
+         l.grade_levels && filter_grade_levels)
+    AND (filter_themes IS NULL OR array_length(filter_themes, 1) IS NULL OR
+         l.thematic_categories && filter_themes)
+    AND (filter_seasons IS NULL OR array_length(filter_seasons, 1) IS NULL OR
+         l.season_timing && filter_seasons)
+    AND (filter_competencies IS NULL OR array_length(filter_competencies, 1) IS NULL OR
+         l.core_competencies && filter_competencies)
+    AND (expanded_cultures IS NULL OR array_length(expanded_cultures, 1) IS NULL OR
+         l.cultural_heritage && expanded_cultures)
+    AND (filter_location IS NULL OR array_length(filter_location, 1) IS NULL OR
+         l.location_requirements && filter_location)
+    AND (filter_activity_type IS NULL OR array_length(filter_activity_type, 1) IS NULL OR
+         l.activity_type && _alias_activity_type(filter_activity_type))
+    -- (filter_lesson_format WHERE clause removed — D3.)
+    AND (filter_academic IS NULL OR array_length(filter_academic, 1) IS NULL OR
+         l.academic_integration && filter_academic)
+    AND (filter_sel IS NULL OR array_length(filter_sel, 1) IS NULL OR
+         l.social_emotional_learning && filter_sel)
+    AND (filter_cooking_method IS NULL OR array_length(filter_cooking_method, 1) IS NULL OR
+         _match_cooking_methods(l.cooking_methods, filter_cooking_method))
+    AND (filter_tags IS NULL OR array_length(filter_tags, 1) IS NULL OR
+         l.tags && filter_tags)
+    -- NEW (PR 4): exclude soft-retired imports from user-facing search.
+    AND l.retired_at IS NULL
+  ORDER BY
+    rank DESC,
+    COALESCE((l.confidence->>'overall')::float, 0) DESC,
+    l.title ASC
+  LIMIT page_size
+  OFFSET page_offset;
+END;
+$$;
+
+
+-- Force PostgREST to reload its schema cache so the new body is picked up
+-- immediately. Body-only changes don't strictly require this, but explicit is
+-- safer and matches the precedent set by `20260514000000`.
+NOTIFY pgrst, 'reload schema';
+
+
+-- =====================================================
+-- VERIFICATION (informational)
+-- =====================================================
+-- Expected post-apply behavior:
+--   SELECT count(*) FROM (SELECT * FROM search_lessons() LIMIT 1000) sub;  -- 767 (live)
+--   -- vs raw `lessons` row count 788 (live + 21 retired)
+--   --
+--   SELECT * FROM search_lessons('Stone Soup');  -- returns ZERO rows (Stone Soup retired)
+--   --
+--   SELECT * FROM search_lessons('Plant');  -- returns no PFLP/FoodCorps imports
+
+-- =====================================================
+-- ROLLBACK (kept as comments)
+-- =====================================================
+-- To revert: re-apply `20260514000000_search_lessons_filter_tags.sql` Stage
+-- (CREATE) — that file's CREATE will re-establish the prior body byte-identical
+-- to pre-PR-4 state. CREATE OR REPLACE on the same signature is the
+-- mechanism; no DROP needed.
+--
+--   -- Re-run the CREATE block from `20260514000000_search_lessons_filter_tags.sql`
+--   -- (preserves the same signature; body reverts to without the retired_at filter).
+--   NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260520030000_lessons_with_metadata_expose_retired.sql
+++ b/supabase/migrations/20260520030000_lessons_with_metadata_expose_retired.sql
@@ -1,0 +1,142 @@
+-- =====================================================
+-- Migration: 20260520030000_lessons_with_metadata_expose_retired.sql
+-- =====================================================
+-- Description:
+--   PR 4 follow-up — recreate `public.lessons_with_metadata` view to expose
+--   `retired_at` and `retired_reason` columns (added to the base `lessons`
+--   table by sibling migration `20260520000000_corpus_cleanup_retire_imports.sql`).
+--
+--   Without this projection, the per-consumer `.is('retired_at', null)` filter
+--   added by sibling migration `20260520020000_search_lessons_filter_retired.sql`
+--   and the TS edits in commit `f522740` (smart-search edge fn / search-lessons
+--   edge fn / useLessonStats hook) would fail with PostgREST 400
+--   `column lessons_with_metadata.retired_at does not exist`. PostgreSQL views
+--   defined with explicit column lists do NOT auto-include columns added to the
+--   base table afterwards.
+--
+--   The 3 affected call sites are:
+--     - src/hooks/useLessonStats.ts:25-28 (homepage stat counter)
+--     - supabase/functions/smart-search/index.ts:154-161 (live front-end suggestions)
+--     - supabase/functions/search-lessons/index.ts:61-68 (deployed-but-not-called-from-front-end)
+--
+--   The `search_lessons` RPC body (also added in `20260520020000`) queries the
+--   underlying `lessons` table directly so it sees the new columns without any
+--   view change. The fix here is exclusively to surface those columns through
+--   the view for the `from('lessons_with_metadata').is(...)` chain shape.
+--
+-- Why CREATE OR REPLACE VIEW (not DROP+CREATE):
+--   PostgreSQL's `CREATE OR REPLACE VIEW` permits **appending** new columns to
+--   the end of an existing view's column list (existing column names / order /
+--   types must remain unchanged). The 2 new columns slot in at the end.
+--
+--   No view dependents (RLS policies, triggers, other views) exist that would
+--   require CASCADE; same as the precedent set in
+--   `20260512000000_drop_lesson_format.sql` for the `lesson_format` compat
+--   bridge change.
+--
+-- =====================================================
+-- CREATE OR REPLACE lessons_with_metadata (append retired_at + retired_reason)
+-- =====================================================
+-- The body below is byte-identical to the version established in
+-- `20260512000000_drop_lesson_format.sql:78-135` except for the 2 new
+-- columns appended after `materials_array`.
+CREATE OR REPLACE VIEW public.lessons_with_metadata AS
+  SELECT
+    l.id,
+    l.lesson_id,
+    l.title,
+    l.summary,
+    l.file_link,
+    l.grade_levels,
+    l.metadata,
+    l.confidence,
+    l.search_vector,
+    l.created_at,
+    l.updated_at,
+    l.content_text,
+    l.content_embedding,
+    l.content_hash,
+    l.canonical_id,
+    l.version_number,
+    l.has_versions,
+    l.original_submission_id,
+    l.last_modified,
+    l.thematic_categories,
+    l.cultural_heritage,
+    l.observances_holidays,
+    l.location_requirements,
+    l.season_timing,
+    l.academic_integration,
+    l.social_emotional_learning,
+    l.cooking_methods,
+    l.main_ingredients,
+    l.cultural_responsiveness_features,
+    l.garden_skills,
+    l.cooking_skills,
+    l.core_competencies,
+    NULL::text AS lesson_format,                       -- compat bridge; drops in Task 1.3a
+    l.processing_notes,
+    l.review_notes,
+    l.flagged_for_review,
+    l.tags,
+    (l.metadata ->> 'activity_type'::text) AS activity_type_meta,
+    (l.metadata ->> 'location'::text) AS location_meta,
+    (l.metadata ->> 'season'::text) AS season_meta,
+    (l.metadata ->> 'timing'::text) AS timing_meta,
+    (l.metadata ->> 'group_size'::text) AS group_size_meta,
+    (l.metadata ->> 'duration_minutes'::text) AS duration_minutes_meta,
+    (l.metadata ->> 'prep_time_minutes'::text) AS prep_time_minutes_meta,
+    ((l.metadata ->> 'grade_levels'::text))::jsonb AS grade_levels_array,
+    ((l.metadata ->> 'themes'::text))::jsonb AS themes_array,
+    ((l.metadata ->> 'core_competencies'::text))::jsonb AS core_competencies_array,
+    ((l.metadata ->> 'cultural_heritage'::text))::jsonb AS cultural_heritage_array,
+    ((l.metadata ->> 'academic_integration'::text))::jsonb AS academic_integration_array,
+    ((l.metadata ->> 'sel_competencies'::text))::jsonb AS sel_competencies_array,
+    ((l.metadata ->> 'observances'::text))::jsonb AS observances_array,
+    ((l.metadata ->> 'main_ingredients'::text))::jsonb AS main_ingredients_array,
+    ((l.metadata ->> 'garden_skills'::text))::jsonb AS garden_skills_array,
+    ((l.metadata ->> 'cooking_skills'::text))::jsonb AS cooking_skills_array,
+    ((l.metadata ->> 'materials'::text))::jsonb AS materials_array,
+    -- NEW (PR 4): soft-delete columns. Live consumers filter `WHERE
+    -- retired_at IS NULL` via PostgREST `.is('retired_at', null)`. The
+    -- view itself does not bake a filter — detect-duplicates and the
+    -- review queue's lesson-title lookup still need to see retired rows
+    -- so future re-submissions are caught.
+    l.retired_at,
+    l.retired_reason
+  FROM public.lessons l;
+
+COMMENT ON VIEW public.lessons_with_metadata IS
+  'View of lessons with metadata fields extracted. Uses INVOKER security (respects RLS). lesson_format projection is a NULL::text compat bridge as of 20260512000000_drop_lesson_format.sql; the bridge drops in the Task 1.3a follow-up migration. retired_at + retired_reason added by 20260520030000 (PR 4) — view stays unfiltered; consumers apply the filter at the query site so detect-duplicates + reviewer dup-flow can keep seeing retired rows.';
+
+
+-- Force PostgREST to reload its schema cache so the new column names are
+-- picked up immediately. Without this, PostgREST may continue to return 400
+-- on `.is('retired_at', null)` until its periodic cache refresh fires.
+NOTIFY pgrst, 'reload schema';
+
+
+-- =====================================================
+-- VERIFICATION (informational)
+-- =====================================================
+-- Expected post-apply behavior:
+--   SELECT column_name FROM information_schema.columns
+--    WHERE table_schema='public' AND table_name='lessons_with_metadata'
+--      AND column_name IN ('retired_at','retired_reason')
+--    ORDER BY column_name;
+--   -- Returns 2 rows.
+--
+--   SELECT count(*) FROM lessons_with_metadata WHERE retired_at IS NULL;
+--   -- Returns the live-corpus count (e.g., 767 on PROD post-PR-4).
+
+-- =====================================================
+-- ROLLBACK (kept as comments)
+-- =====================================================
+-- To revert: re-apply `20260512000000_drop_lesson_format.sql` view body verbatim
+-- (without the 2 new columns at the end). The CREATE OR REPLACE preserves the
+-- view identity; consumer queries that reference `retired_at` would then start
+-- failing — only do this if also reverting the consumer edits.
+--
+--   -- Re-run the CREATE OR REPLACE VIEW block from `20260512000000`
+--   -- minus the trailing `l.retired_at, l.retired_reason` lines.
+--   NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

PR 4 of the metadata-rebuild foundation phase: soft-retire 21 wholesale third-party-curriculum imports (5 PFLP 2003 + 11 FoodCorps 2017 + 5 one-offs) so they stop appearing in user-facing search, while keeping them visible to detect-duplicates + reviewer dup-flow so future re-submissions of the same content get caught.

- **4 migrations:**
  1. `20260520000000_corpus_cleanup_retire_imports.sql` — adds `retired_at timestamptz` + `retired_reason text` columns; UPDATEs 21 rows with cluster-key reasons (`import:pflp_2003`, `import:foodcorps_2017`, 5 one-off keys); UPDATEs FSA Pt 1 to drop "& 2"; idempotent guards.
  2. `20260520010000_recover_archive_only_concepts.sql` — restores `academicConcepts` from `lesson_versions` archive into 7 live rows that lost concepts during prior Phase 6.2 cleanup.
  3. `20260520020000_search_lessons_filter_retired.sql` — `CREATE OR REPLACE FUNCTION search_lessons` body adds `AND l.retired_at IS NULL` to count + select WHERE clauses.
  4. `20260520030000_lessons_with_metadata_expose_retired.sql` — `CREATE OR REPLACE VIEW lessons_with_metadata` appends `retired_at` + `retired_reason` columns at the end so view-based callers can apply the filter.
- **Per-consumer filter approach** (not view-bake) for the 8 user-facing surfaces. View stays unfiltered so dup-checking + reviewer dup-flow still see retired rows for future re-submission catch.
- **`LessonSearchPicker.excludeRetired` prop** with submitter-vs-reviewer asymmetry: submitter caller (`RevisingSubmissionForm`) passes `true`; reviewer caller (`ReviewDetail` dup escape-hatch) leaves default `false`.

## What's filtered vs unfiltered

**Filtered (8 surfaces):**
- `search_lessons` RPC body (count + select WHERE)
- `smart-search` edge fn `:155`
- `search-lessons` edge fn `:62` (defensive — dead front-end caller today)
- `useLessonStats` hook (homepage stat)
- `LessonSearchPicker` via `excludeRetired={true}` from `RevisingSubmissionForm`
- `process-submission` `:212` update-target validation (defense-in-depth)
- `generate-embeddings.mjs` + `regenerate-all-embeddings.mjs` (don't burn OpenAI cost)

**Unfiltered (intentional asymmetry — see retired rows):**
- `detect-duplicates` edge fn (cross-check against retired catches re-submissions)
- `get_lesson_details_for_review` RPC (reviewer dup-flow)
- `ReviewDetail.tsx:332,366` (similar-lesson + off-list submitter target)
- `ReviewDashboard.tsx:143` (queue-badge title lookup)
- `LessonSearchPicker` via default `excludeRetired={false}` from `ReviewDetail` dup escape-hatch
- `lessons_with_metadata` view itself
- `src/lib/supabase.ts:27` (connectivity test, count unused)

## Pre-push review

Pre-push code-reviewer agent (Opus) caught 1 P0 latent bug: the 3 view-based `.is('retired_at', null)` calls would have failed with PostgREST 400 because `lessons_with_metadata` view (last redefined `20260512000000`) uses an explicit column list that doesn't auto-include columns added later. Fix: migration `20260520030000` recreates the view with `retired_at` + `retired_reason` appended.

Also added a hardening comment at `ReviewDetail.tsx:1319` (P1 #4 finding) documenting why reviewer flow intentionally does NOT pass `excludeRetired`, preventing silent drift if a future refactor flips the prop default.

## Empirical state at commit time

TEST DB probe pre-commit: 0 current submissions / 0 similarities / 0 reviews / 0 bookmarks reference any of the 21 retired IDs. Only 2 historical dedup-winner rows in `duplicate_resolutions` (Leaves We Eat / Stone Soup, resolved 2025-09-01). Soft-delete preserves these FK references intact. PR 4 is forward-looking, not backfilling broken state.

## Test plan

- [ ] CI applies all 4 migrations cleanly to TEST DB
- [ ] Round 0 verification on TEST DB (via `mcp__supabase-test__execute_sql`):
  - 21 retired count (`WHERE retired_at IS NOT NULL`)
  - 7 distinct cluster-key reasons (`COUNT DISTINCT retired_reason`)
  - FSA new title (`'Food System Advocates (Part 1)'`)
  - View exposes `retired_at` + `retired_reason` (information_schema)
  - View live count ≈ 767 (TEST corpus 788 minus 21)
  - 7 archive concept rows recovered (`metadata->'academicConcepts' IS NOT NULL`)
- [ ] Search RPC excludes retired (`SELECT total_count FROM search_lessons() LIMIT 1` < base table count)
- [ ] Smart-search / search-lessons edge fns return correct counts
- [ ] Homepage stat reflects live corpus count
- [ ] `LessonSearchPicker` in `RevisingSubmissionForm` doesn't surface retired imports
- [ ] `LessonSearchPicker` in `ReviewDetail` dup escape-hatch DOES surface retired imports
- [ ] `process-submission` rejects UPDATE submissions targeting retired IDs (defense-in-depth)
- [ ] No regressions in detect-duplicates / get_lesson_details_for_review (still see retired)

Local verification clean: `supabase db reset` applies cleanly; toggle test confirms view filtered/unfiltered + RPC behave correctly; `npm run type-check` + `npm run lint` clean; vitest 577/577 (was 575/575; +2 new tests for `excludeRetired` prop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)