### PR TITLE
docs(metadata-foundation): Stage 1 — Asian cluster per-value entries

### DIFF
--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,6 +1,6 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-10 — Session 62 (Stage 1 heritage worksheet — Asian cluster per-value entries populated, PR opening; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
+**Last updated:** 2026-05-10 — Session 63 (Stage 1 PR #482 round-1 fix-up applied; substantive Stage 1 progress lives in peer status doc; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-51 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
@@ -145,7 +145,7 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 
 **Stage 1 work track continues at peer status doc** — see `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md` for substantive Session 62 entry (decisions, process notes) + next-session pointer (Americas cluster per-value fill).
 
-**For next session:** Americas cluster per-value fill (~22 entries — largest cluster: cluster root + 3 sub-regions + 14 country-specifics including 3 v3-absent `new` candidates + 4 kebab-case drift variants). Per-cluster fill schedule remaining after Asian: Americas → African → European → Middle Eastern → cross-cluster diaspora.
+**For next session:** Americas cluster per-value fill (~22 entries — largest cluster; see Stage 1 status doc's "For next session" block + worksheet §12 for the per-bucket breakdown). Per-cluster fill schedule remaining after Asian: Americas → African → European → Middle Eastern → cross-cluster diaspora.
 
 ### Session 61 — 2026-05-10 — PR #481 ship cycle complete (round-1 + round-2 + Notes fix-up; squash-merge in progress)
 

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,6 +1,6 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-10 — Session 63 (Stage 1 PR #482 round-1 fix-up applied; substantive Stage 1 progress lives in peer status doc; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
+**Last updated:** 2026-05-10 — Session 63 (Stage 1 PR #482 round-1 + round-2 fix-ups applied; substantive Stage 1 progress lives in peer status doc; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-51 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 

--- a/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
+++ b/docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md
@@ -1,12 +1,12 @@
 # Metadata Rebuild — Foundation Phase — Execution Status
 
-**Last updated:** 2026-05-10 — Session 61 (PR #481 ship cycle — round-1 + round-2 + Notes fix-up, squash-merge in progress; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
+**Last updated:** 2026-05-10 — Session 62 (Stage 1 heritage worksheet — Asian cluster per-value entries populated, PR opening; foundation-phase code track has no unblocked next PR — see Stage 1 execution status doc for per-cluster fill schedule).
 
 > **About this file.** Active status carrying forward only what the next 1-2 sessions need to orient. Full per-session journal for Sessions 1-51 lives in `2026-05-03-metadata-rebuild-foundation-execution-status-archive.md` (read on demand via grep). When a new PR cycle begins, that PR's session entries move to the archive at the start of the following PR; the active file always reflects current PR + a small carry-forward roll-up.
 
 ## Current State
 
-**Stage 1 heritage worksheet — scaffold SHIPPED Sessions 60-61 (2026-05-10); PR #481 squash-merge in progress. Per-value fill (Asian cluster first, 18 entries — see Stage 1 status doc for breakdown) opens next session.** Session 60 created the 2-file scaffold (worksheet + execution status doc); Session 61 ran PR #481 through round-1 (5 accepted + 1 rejected of 6 bot findings — local v3 path → Appendix A; `####` heading depth standardized; root parent encoding standardized on `null`; Dominican added to Americas v3-corpus-absent set; alias_map clarified) + round-2 (1 accepted + 3 rejected of 4 findings — Notes-field parsing convention clarified; diaspora placeholder, data snapshot anchor, and ToC §1-§8 note all rejected per round-cap + default-reject hardening). Foundation-phase code track has no unblocked next PR — PR 3b / 5 / 6 all gate on Stage 1 / Stage 2 outputs.
+**Stage 1 heritage worksheet — Asian cluster ✅ Session 62 (2026-05-10); PR opening. Per-value fill schedule: Asian (✅) → Americas (next, ~22 entries) → African (~9) → European (~9) → Middle Eastern (~6) → cross-cluster diaspora.** Sessions 60-61 shipped the scaffold (PR #481, squash `e05556a`); Session 62 populated the Asian cluster's 18 per-value entries (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have integrated Opus-corpus-read `<details>` blocks (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural per §4 methodology. Audit signal surfaced: Bánh Mì East-Asian mis-tag, 4 missing country tags on South Asian, 2 missing on Southeast Asian, Sri Lanka geography error in lesson body — all flagged for Stage 2 re-tag. Foundation-phase code track has no unblocked next PR — PR 3b / 5 / 6 all gate on Stage 1 / Stage 2 outputs.
 
 **Stage 1 work track lives at its own peer status doc:**
 - **Worksheet:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` — curriculum-team-facing deliverable. Header sections (purpose / methodology / hierarchy rules / verdict vocab / per-entry shape / cluster framing pattern / filter-UI tier conventions / parsing convention) complete; cluster framing blocks pre-populated with corpus distribution data; per-value entries TBD subsequent sessions.
@@ -19,7 +19,7 @@
 - **PR 4** (#478 → squash `03970d0`, 2026-05-08): 21 third-party imports retired (`retired_at` soft-delete); 7 archive-only concept-recovery rows; FSA Pt 1 retitle; 8 filter surfaces gate retired rows.
 - **PR 3a** (#479 → squash `bb3372b`, 2026-05-08): `academicConcepts` in FTS + embeddings; `smart-search` reads `search_synonyms` from DB at request time; CHECK constraint locks multi-word values; 6 historically-broken queries (christmas / thanksgiving / halloween / easter / latino / hispanic) functional.
 - **PR #480** (squash `ab9f857`, 2026-05-09): Session 58 status doc refresh, docs-only.
-- **PR #481** (squash `<TBD — fill at next session>`, 2026-05-10): Stage 1 heritage worksheet scaffold (2-file pattern: worksheet + execution status doc; v3 baseline embedded as Appendix A); Sessions 60-61.
+- **PR #481** (squash `e05556a`, 2026-05-10): Stage 1 heritage worksheet scaffold (2-file pattern: worksheet + execution status doc; v3 baseline embedded as Appendix A); Sessions 60-61.
 
 **5/5 PROD verification probes for PR 3a + 3-signal `smart-search` edge fn deploy verification — ALL PASS** Session 58 (full record in that session's log entry below).
 
@@ -33,8 +33,8 @@
 **PR-cycle archival deferred:** Sessions 52-58 (PR 3a) entries remain in this active file for now. They'll move to `...-execution-status-archive.md` at the start of the next PR cycle on the foundation-phase code track (likely PR 5+, far in the future). Until then, the active file is a tolerable size and the entries are useful reference for any foundation-phase work that picks up before Stage 1 closes.
 
 **Branches:**
-- `main` at `<TBD — PR #481 squash-merge in progress>` (or `ab9f857` if not yet merged); origin matches.
-- **Active:** none. PR #481 squash-merge in progress; scaffold SHIPPED.
+- `main` at `e05556a` (PR #481 squash-merge); origin matches.
+- **Active:** `docs/stage1-heritage-asian-cluster` (Stage 1 Session 62 — Asian cluster per-value entries; PR opening).
 - All foundation-phase feature branches deletable at convenience: `feat/metadata-foundation-search-infra-3a`, `feat/metadata-foundation-corpus-cleanup`, `feat/metadata-foundation-llm-tagging`, `backup/feat-metadata-foundation-llm-tagging-pre-rebase`, `docs/session-36-pr1b-shipped`, `feat/metadata-foundation-activity-type-multi`, `feat/metadata-foundation-schema`. Plus `docs/session-58-pr3a-shipped` (PR #480 origin-deleted via `--delete-branch`; local kept for traceability). Plus `docs/stage1-heritage-scaffold` (PR #481 origin-deleted via `--delete-branch`; local kept for traceability).
 
 ## Recent decisions worth carrying forward (PR 1 → PR 1b → PR 2)
@@ -131,6 +131,21 @@ Auto-loaded MEMORY (already in conversation context, do not re-read by default):
 - Project-specific memories: `project_metadata_three_regimes.md` / `project_vocabulary_drift_scope.md` / `project_lesson_format_conflated.md` / `project_dedup_third_state.md` / `project_metadata_cleanup_candidates.md` / `project_crf_stamp_theater.md` / `project_teacher_zero_metadata_model.md` / `project_imported_non_esynyc_drops.md`
 
 ## Recent session log
+
+### Session 62 — 2026-05-10 — Stage 1 heritage Asian cluster per-value entries
+
+**Branch:** `docs/stage1-heritage-asian-cluster` (off `main` at `e05556a`, the PR #481 squash-merge).
+
+**Done:**
+
+- Backfilled PR #481 squash-merge hash (`e05556a`) in this status doc's PRs-SHIPPED list and Branches block + in the Stage 1 status doc's Session 61 entry.
+- Populated 18 per-value entries for the Asian cluster in `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` §11 (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge entries).
+- Dispatched 7 parallel Opus corpus-read agents (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian) producing `<details>` corpus-evidence blocks integrated into the worksheet entries.
+- Audit signal surfaced for Stage 2 re-tag: Bánh Mì lesson mis-tagged as `Vietnamese + East Asian + Asian` (correct: Southeast Asian); 4 of 15 South Asian lessons missing country tags (Aloo Gobi names Indian + Pakistani; Black Bean Burgers anchors on India); 2 of 5 Southeast Asian lessons missing country tags (Khao Soi → Thai/Lao; Lumpia → Filipino); Sri Lankan Curry body geographically mis-locates Sri Lanka as "Southeast Asia" (correct: South Asia; lesson tagging itself is correct).
+
+**Stage 1 work track continues at peer status doc** — see `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md` for substantive Session 62 entry (decisions, process notes) + next-session pointer (Americas cluster per-value fill).
+
+**For next session:** Americas cluster per-value fill (~22 entries — largest cluster: cluster root + 3 sub-regions + 14 country-specifics including 3 v3-absent `new` candidates + 4 kebab-case drift variants). Per-cluster fill schedule remaining after Asian: Americas → African → European → Middle Eastern → cross-cluster diaspora.
 
 ### Session 61 — 2026-05-10 — PR #481 ship cycle complete (round-1 + round-2 + Notes fix-up; squash-merge in progress)
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -1,6 +1,6 @@
 # Stage 1 Heritage Worksheet — Execution Status
 
-**Last updated:** 2026-05-10 — Session 62 (Asian cluster per-value entries populated; PR opening next; Americas cluster fill is next-session work).
+**Last updated:** 2026-05-10 — Session 63 (PR #482 round-1 fix-up applied — Americas next-session bullet regenerated from §12 + worksheet status banner SCAFFOLD → PRE-HANDOFF; Americas cluster fill is next-session work).
 
 > **About this file.** Project-internal progress tracker for the Stage 1 heritage worksheet initiative. Peer to (not folded into) the foundation-phase status doc at `2026-05-03-metadata-rebuild-foundation-execution-status.md`. The foundation-phase status doc carries a one-line pointer here.
 >
@@ -10,7 +10,7 @@
 
 ## Current state
 
-**Asian cluster ✅ Session 62 (2026-05-10).** Worksheet §11 has all 18 per-value entries populated (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have Opus-corpus-read `<details>` blocks integrated (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural populations per the §4 methodology. PR opening; squash-merge expected this session or next.
+**Asian cluster ✅ Session 62 (2026-05-10).** Worksheet §11 has all 18 per-value entries populated (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have Opus-corpus-read `<details>` blocks integrated (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural populations per the §4 methodology. **PR #482 in review cycle — round-1 fix-up applied Session 63 (Americas next-session bullet regenerated from §12; worksheet banner SCAFFOLD → PRE-HANDOFF; foundation-phase status doc Session 62 line tightened); awaiting next round or merge.**
 
 **What's done:**
 
@@ -31,12 +31,16 @@
 **For next session (Stage 1 Session 63 = Americas cluster):**
 
 1. Branch off `main` at the merge commit for this session's PR.
-2. Populate Americas cluster's 22 per-value entries per §12 framing block:
-   - Cluster root: Americas (170)
+2. Populate Americas cluster's per-value entries per §12 framing block. Total: **22 entries** (or 23 if Cajun/Creole gets an Americas entry per §12 cluster decision #5 — default is to leave it in cross-cluster §9.1):
+   - Cluster root (1): Americas (170)
    - Sub-regions (3): North American (83), Latin American (77), Caribbean (17)
-   - Country-specifics ≥3 lessons (1): Mexican (38)
-   - Country-specifics 2 lessons (5): Puerto Rican, Salvadoran, Honduran, Cuban, Jamaican, Peruvian (Puerto Rican is 4)
-   - Country-specifics 1 lesson (4): Brazilian, Ecuadorian, Guyanese; plus 3 v3-absent `new` candidates (Central American, South American, Southern United States)
+   - Country-specifics by frequency (10):
+     - ≥3 lessons (1): Mexican (38)
+     - 4 lessons (1): Puerto Rican (4)
+     - 2 lessons (5): Salvadoran, Honduran, Cuban, Jamaican, Peruvian (each 2)
+     - 1 lesson (3): Brazilian, Ecuadorian, Guyanese (each 1)
+   - New sub-region candidates — v3-absent (3): Central American (1), South American (1), Southern United States (1)
+   - v3-canonical corpus-absent (1): Dominican (Latin American). [Cajun/Creole pending §12 decision #5; default cross-cluster §9.1]
    - Kebab-case drift (4): `americas`, `north-american`, `latin-american`, `caribbean`
 3. Dispatch Opus corpus-read agents for high-frequency / ambiguous values per §4 threshold (≥5 OR ambiguous). Strong candidates by frequency:
    - Americas (170 — cluster root; §12 decision #1 asks whether tag is meaningful or under-tagged default)

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -1,6 +1,6 @@
 # Stage 1 Heritage Worksheet — Execution Status
 
-**Last updated:** 2026-05-10 — Session 63 (PR #482 round-1 fix-up applied — Americas next-session bullet regenerated from §12 + worksheet status banner SCAFFOLD → PRE-HANDOFF; Americas cluster fill is next-session work).
+**Last updated:** 2026-05-10 — Session 63 (PR #482 round-1 + round-2 fix-ups applied — Americas bullet regenerated from §12 + worksheet status banner SCAFFOLD → PRE-HANDOFF + §7 parser invariant note added + session-number collision corrected; awaiting merge; Americas cluster fill is next-session work).
 
 > **About this file.** Project-internal progress tracker for the Stage 1 heritage worksheet initiative. Peer to (not folded into) the foundation-phase status doc at `2026-05-03-metadata-rebuild-foundation-execution-status.md`. The foundation-phase status doc carries a one-line pointer here.
 >
@@ -10,7 +10,7 @@
 
 ## Current state
 
-**Asian cluster ✅ Session 62 (2026-05-10).** Worksheet §11 has all 18 per-value entries populated (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have Opus-corpus-read `<details>` blocks integrated (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural populations per the §4 methodology. **PR #482 in review cycle — round-1 fix-up applied Session 63 (Americas next-session bullet regenerated from §12; worksheet banner SCAFFOLD → PRE-HANDOFF; foundation-phase status doc Session 62 line tightened); awaiting next round or merge.**
+**Asian cluster ✅ Session 62 (2026-05-10).** Worksheet §11 has all 18 per-value entries populated (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have Opus-corpus-read `<details>` blocks integrated (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural populations per the §4 methodology. **PR #482 in review cycle — round-1 + round-2 fix-ups applied Session 63 (round-1: Americas bullet regenerated + banner SCAFFOLD → PRE-HANDOFF + foundation-phase line tightened; round-2: §7 parser invariant note added + session-number collision corrected + line 23 stale breakdown removed); awaiting merge.**
 
 **What's done:**
 
@@ -20,7 +20,7 @@
 
 **What's NOT done:**
 
-- §12 Americas cluster: per-value entries TBD (~22 entries — cluster root + 3 sub-regions + 14 country-specifics including 3 v3-absent `new` candidates + 4 kebab-case drift variants).
+- §12 Americas cluster: per-value entries TBD (~22 entries — see "For next session" block below for the per-bucket breakdown drawn from worksheet §12).
 - §13 African cluster: per-value entries TBD (~9 entries).
 - §14 European cluster: per-value entries TBD (~9 entries).
 - §15 Middle Eastern cluster: per-value entries TBD (~6 entries).
@@ -28,7 +28,7 @@
 - §16 end-summary canonical-vocab table: populates mechanically from filled entries; empty until per-value entries fill.
 - Cluster decision summary blocks: always TBD (curriculum team writes at handoff).
 
-**For next session (Stage 1 Session 63 = Americas cluster):**
+**For next session (Stage 1 Session 64 = Americas cluster):**
 
 1. Branch off `main` at the merge commit for this session's PR.
 2. Populate Americas cluster's per-value entries per §12 framing block. Total: **22 entries** (or 23 if Cajun/Creole gets an Americas entry per §12 cluster decision #5 — default is to leave it in cross-cluster §9.1):

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -141,6 +141,8 @@ Stage 1 is **content-shaping**: there's no implementation plan with file paths a
 
 - **Session boundary held at one cluster.** Stop-point heuristic from "For next session" felt right — 18 entries took the bulk of the session (corpus queries + 7 agent dispatches + entry drafting + Notes synthesis + integration). Americas at ~22 entries is naturally next-session scope; smaller clusters may fit 1-2 per session.
 
+- **Pre-push code-reviewer agent caught 2 P2 internal-consistency findings on Opus-agent-produced content.** §11.4 Southeast Asian details-block summary header read "3 with country tag, 2 without" while the tagging-pattern paragraph below it enumerated "only 2 of the 4 cuisine lessons carry a country tag" plus 1 non-cuisine near-miss (Bats & Banana Pancakes) — header reframed to "2 of 4 cuisine + 1 non-cuisine near-miss." §11.7 Japanese tagging-pattern arithmetic was internally inconsistent ("6 of the 7 sampled lessons" + "Two looser tags exist" = 8, not 7) — rephrased to drop the precise-sample-count framing. Both fix-up'd in commit before push. Reinforces the kickoff pattern: dispatch reviewer on docs-only PRs too — count/math/cross-reference consistency is exactly the class of bug a fresh-eyes agent catches and a self-reviewer misses. THIRD time on the Stage 1 track that the pre-push agent caught real bugs missed by self-review (Sessions 60 `da09777`, 61 `a5b584b`, 62 fix-up commit).
+
 **For next session (Stage 1 Session 63 = Americas cluster).**
 
 - Branch off `main` at this session's PR squash-merge (TBD until PR opens + merges).

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -35,12 +35,12 @@
    - Cluster root (1): Americas (170)
    - Sub-regions (3): North American (83), Latin American (77), Caribbean (17)
    - Country-specifics by frequency (10):
-     - ≥3 lessons (1): Mexican (38)
+     - ≥10 lessons (1): Mexican (38)
      - 4 lessons (1): Puerto Rican (4)
      - 2 lessons (5): Salvadoran, Honduran, Cuban, Jamaican, Peruvian (each 2)
      - 1 lesson (3): Brazilian, Ecuadorian, Guyanese (each 1)
    - New sub-region candidates — v3-absent (3): Central American (1), South American (1), Southern United States (1)
-   - v3-canonical corpus-absent (1): Dominican (Latin American). [Cajun/Creole pending §12 decision #5; default cross-cluster §9.1]
+   - v3-canonical corpus-absent (1): Dominican (Latin American). [Cajun/Creole — current home §9.1; §12 decision #5 may move to Americas]
    - Kebab-case drift (4): `americas`, `north-american`, `latin-american`, `caribbean`
 3. Dispatch Opus corpus-read agents for high-frequency / ambiguous values per §4 threshold (≥5 OR ambiguous). Strong candidates by frequency:
    - Americas (170 — cluster root; §12 decision #1 asks whether tag is meaningful or under-tagged default)

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -1,6 +1,6 @@
 # Stage 1 Heritage Worksheet — Execution Status
 
-**Last updated:** 2026-05-10 — Session 61 (PR #481 ship cycle complete: round-1 + round-2 + Notes fix-up; squash-merge in progress; Asian cluster per-value fill opens next session).
+**Last updated:** 2026-05-10 — Session 62 (Asian cluster per-value entries populated; PR opening next; Americas cluster fill is next-session work).
 
 > **About this file.** Project-internal progress tracker for the Stage 1 heritage worksheet initiative. Peer to (not folded into) the foundation-phase status doc at `2026-05-03-metadata-rebuild-foundation-execution-status.md`. The foundation-phase status doc carries a one-line pointer here.
 >
@@ -10,35 +10,44 @@
 
 ## Current state
 
-**Scaffold SHIPPED (Sessions 60-61, 2026-05-10).** PR #481 (round-1 + round-2 + Notes fix-up) squash-merge in progress. Two files shipped:
+**Asian cluster ✅ Session 62 (2026-05-10).** Worksheet §11 has all 18 per-value entries populated (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). 7 of those have Opus-corpus-read `<details>` blocks integrated (Asian, East Asian, South Asian, Southeast Asian, Chinese, Japanese, Indian); the remaining 11 entries are structural populations per the §4 methodology. PR opening; squash-merge expected this session or next.
 
-1. `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` — the worksheet itself. Header sections (purpose / methodology / hierarchy rules / verdict vocab / per-entry shape / cluster framing pattern / filter-UI tier conventions / parsing convention) complete and load-bearing. Per-cluster framing blocks pre-populated with corpus distribution data from Session 59 query. Per-value entry blocks TBD subsequent sessions before curriculum-team handoff.
-2. This file (`...-execution-status.md`).
+**What's done:**
+
+- §11 Asian cluster: 18 per-value entries ✅
+- Cluster framing blocks for all 5 regional clusters + cross-cluster (Session 60 scaffold) ✅
+- Header sections (purpose / methodology / hierarchy rules / verdict vocab / per-entry shape / cluster framing pattern / filter-UI tier conventions / parsing convention / Appendix A v3 baseline) ✅
 
 **What's NOT done:**
 
-- Per-value entry blocks within each cluster (Asian / Americas / African / European / Middle Eastern) — TBD.
-- Cross-cluster section (§9 of the worksheet) per-value entries — TBD.
-- Opus-corpus-read evidence (collapsible `<details>` excerpts) — TBD.
-- End summary canonical-vocab table (§16) populates mechanically from filled entries; empty until per-value entries fill.
+- §12 Americas cluster: per-value entries TBD (~22 entries — cluster root + 3 sub-regions + 14 country-specifics including 3 v3-absent `new` candidates + 4 kebab-case drift variants).
+- §13 African cluster: per-value entries TBD (~9 entries).
+- §14 European cluster: per-value entries TBD (~9 entries).
+- §15 Middle Eastern cluster: per-value entries TBD (~6 entries).
+- §9 cross-cluster section per-value entries (diaspora / indigenous identities, multi-parent canonicals): TBD.
+- §16 end-summary canonical-vocab table: populates mechanically from filled entries; empty until per-value entries fill.
+- Cluster decision summary blocks: always TBD (curriculum team writes at handoff).
 
-**For next session:**
+**For next session (Stage 1 Session 63 = Americas cluster):**
 
-1. **Pick a starting cluster.** Recommendation: **Asian** — has the cleanest hierarchical structure (5 sub-regions + ~9 country-specifics + 3 kebab-case drift values; total ~17 per-value entries). Tests the per-value entry format on a complete cluster before scaling. Alternatives: Americas (most corpus-heavy, but biggest scope, ~22 entries); Middle Eastern (smallest scope, ~6 entries, but mostly-new sub-regions which are less typical work).
-2. **For each per-value entry in the chosen cluster:**
-   - Populate `canonical_key` (kebab-case slug from surface label)
-   - Populate `surface_label` proposal (from v3 baseline OR best-fit Title Case)
-   - Populate `frequency_count` (already in cluster framing block; copy down)
-   - Populate `parent` proposal (from v3 baseline OR first-principles cluster fit)
-   - Populate `filter_ui_tier` proposal (frequency-based default per §6 guideline)
-   - Populate `aliases` candidate list (kebab-case drift variants from cluster framing block)
-   - For frequency ≥5 OR ambiguous: launch Opus-corpus-read agent to read sample lesson bodies tagged with the value; capture 2-3 excerpts in collapsible `<details>` block.
-   - For mechanical canonical-vs-kebab drift (`asian` → `Asian`): no Opus read needed; the call is structural.
-   - Leave `verdict` and `notes` for curriculum-team fill at handoff.
-3. **Repeat for remaining clusters** in subsequent sessions. Order: Asian → Americas → African → European → Middle Eastern → cross-cluster section.
-4. **Cross-cluster section (§9 of the worksheet)** populates last, after regional clusters are filled — multi-parent decisions are easier to land once each cluster's home options are visible.
+1. Branch off `main` at the merge commit for this session's PR.
+2. Populate Americas cluster's 22 per-value entries per §12 framing block:
+   - Cluster root: Americas (170)
+   - Sub-regions (3): North American (83), Latin American (77), Caribbean (17)
+   - Country-specifics ≥3 lessons (1): Mexican (38)
+   - Country-specifics 2 lessons (5): Puerto Rican, Salvadoran, Honduran, Cuban, Jamaican, Peruvian (Puerto Rican is 4)
+   - Country-specifics 1 lesson (4): Brazilian, Ecuadorian, Guyanese; plus 3 v3-absent `new` candidates (Central American, South American, Southern United States)
+   - Kebab-case drift (4): `americas`, `north-american`, `latin-american`, `caribbean`
+3. Dispatch Opus corpus-read agents for high-frequency / ambiguous values per §4 threshold (≥5 OR ambiguous). Strong candidates by frequency:
+   - Americas (170 — cluster root; §12 decision #1 asks whether tag is meaningful or under-tagged default)
+   - North American (83)
+   - Latin American (77)
+   - Caribbean (17)
+   - Mexican (38)
+   - Plus optionally one of the `new` candidates if curriculum team wants verification before canonicalizing (Central American 1, South American 1, Southern United States 1)
+4. Stop at end of Americas cluster (one-cluster-per-session heuristic).
 
-**Stop-point heuristic:** populate ONE cluster per session (or one cluster's complex per-value entries + simple ones, if the cluster is small). Don't bundle multiple clusters in one session — corpus-read is the time-consuming part and one cluster's worth is a natural session boundary.
+**Stop-point heuristic confirmed Session 62:** one cluster per session is the right scope. The Asian cluster (18 entries, 7 Opus reads) fit the session boundary cleanly. Americas at ~22 entries is naturally similar scope; African / European / Middle Eastern are smaller (~6-9 entries each) and may fit 1-2 clusters per session if Opus-read load is light.
 
 ## Locked design decisions
 
@@ -96,6 +105,49 @@ Stage 1 is **content-shaping**: there's no implementation plan with file paths a
 
 ## Session log
 
+### Session 62 — 2026-05-10 — Asian cluster per-value entries populated
+
+**Branch:** `docs/stage1-heritage-asian-cluster` (off `main` at `e05556a`, the PR #481 squash-merge).
+
+**Done:**
+
+- Backfilled PR #481 squash-merge hash (`e05556a`) in this doc's Session 61 entry + in foundation-phase status doc's PRs-SHIPPED list and Branches block.
+- Verified Asian cluster's 18 corpus values against TEST DB. Counts match the Session 59 framing block exactly (Asian 63, East Asian 35, Chinese 15, South Asian 15, Japanese 9, Indian 7, Southeast Asian 5, Central Asian 4, Pakistani 4, Uzbek 4, Korean 3, south-asian 3, east-asian 2, Vietnamese 2, asian 1, Malaysian 1, Sri Lankan 1, Taiwanese 1).
+- Populated worksheet §11 with all 18 per-value entry blocks: 1 cluster root (Asian) + 4 sub-regions (East Asian, South Asian, Southeast Asian, Central Asian) + 10 country-specifics (Chinese, Japanese, Indian, Pakistani, Uzbek, Korean, Vietnamese, Sri Lankan, Malaysian, Taiwanese) + 3 kebab-case drift merge entries (`asian`, `east-asian`, `south-asian`).
+- Dispatched 7 parallel Opus corpus-read agents — Asian (63), East Asian (35), South Asian (15), Southeast Asian (5), Chinese (15), Japanese (9), Indian (7). Each returned a worksheet-ready collapsible `<details>` block with 2-3 representative excerpts + a tagging-pattern observation. All 7 integrated into the corresponding §11 entries.
+- Lower-frequency entries (Pakistani 4, Uzbek 4, Korean 3, Vietnamese 2, Sri Lankan 1, Malaysian 1, Taiwanese 1) populated structurally per §4 methodology with Notes-block proposals; no Opus read needed.
+
+**Decisions made this session:**
+
+- **Filter-UI tier proposals — frequency default with v3-canonical override.** §6 defaults: `top` if ≥40 OR cluster root; `sub` if ≥5 with clear parent `top`; `internal` if <5. I proposed `sub` for the 4 sub-regions despite East Asian (35) sitting under the `top` threshold and Southeast Asian (5) at the `sub` threshold, and for Central Asian (4) + Pakistani (4) + Uzbek (4) below the threshold — rationale: v3 canonical status + clear hierarchical role + sole-parent-for-child-country status. For country-specifics ≤2 lessons (Vietnamese, Sri Lankan, Malaysian, Taiwanese), proposed `internal` per §11 cluster-decision-#2's pre-handoff bar (`sub` at ≥3 lessons). Notes per entry flag deviations and rationale for curriculum-team override.
+
+- **Kebab-case drift entries as separate `merge` records (Convention B).** Per Session 61's planning, drift variants `asian` / `east-asian` / `south-asian` get their own per-value entries with `verdict: merge` rather than being captured as `aliases` on the canonical entries (Convention A). Canonical entries' `aliases: []` accordingly. Tradeoff: Convention B makes the drift visible as first-class corpus content (parser shows drift counts directly); Convention A would have been more compact (one fewer entry per drift). The `alias_map` output is identical under both conventions. Followed Session 61's named count of 18.
+
+- **Verdict left as `<to_fill>` for all canonical entries.** Per §4 spec, verdict is curriculum-team-fill territory. Pre-populating verdict (e.g., `keep` for v3 canonicals, `new` for Sri Lankan) would short-circuit the team's judgment process. Notes per entry flag the strongest candidate verdicts where corpus evidence supports a specific call (e.g., Sri Lankan as `new` candidate based on substantive single-lesson body content).
+
+**Process notes / observations:**
+
+- **Parallel Opus agent dispatch landed cleanly.** 7 agents finished within a single round-trip (~20-45 sec each, ~40-50K total tokens per agent including DB queries). Each returned a worksheet-ready `<details>` block; integration was mechanical Edit work. Pattern is generalizable — Americas (~22 entries, ~6 Opus reads), African (~9 entries, ~3 reads), European (~9 entries, ~3 reads), Middle Eastern (~6 entries, ~2 reads).
+
+- **Corpus-read evidence surfaced real audit signal beyond verdict-input data.** Specifically:
+  - **Bánh Mì lesson mis-tagged as `Vietnamese + East Asian + Asian`.** Correct parent chain is Southeast Asian. Flagged in §11.2 East Asian + §11.12 Vietnamese notes.
+  - **4 of 15 `South Asian` lessons missing country tags** (Aloo Gobi names Indian + Pakistani; Black Bean Burgers anchors on India). Flagged in §11.3 + §11.9 Pakistani notes.
+  - **2 of 5 `Southeast Asian` lessons missing country tags** (Khao Soi → Thai/Lao; Lumpia → Filipino). Flagged in §11.4.
+  - **Sri Lankan Curry lesson body geographically mis-locates Sri Lanka as "Southeast Asia"** (it's South Asia). Lesson tagging is correct; body content has factual error. Flagged in §11.3 + §11.13 notes.
+
+  Stage 2 re-tag should pick up the missing country tags. Body-content errors are outside Stage 1's scope but worth surfacing for curriculum-team review.
+
+- **`Asian` cluster root is meaningful — not under-tagging.** 4 of 63 lessons are genuinely pan-Asian (multi-country comparison, world-foods units). 59 are hierarchically-tagged with `Asian` as redundant parent. Cluster framing decision #4 ("Asian-as-default fallback") asked whether 63 includes under-tagging — Opus read confirms no. Worth recording as a confirmed corpus characteristic.
+
+- **Session boundary held at one cluster.** Stop-point heuristic from "For next session" felt right — 18 entries took the bulk of the session (corpus queries + 7 agent dispatches + entry drafting + Notes synthesis + integration). Americas at ~22 entries is naturally next-session scope; smaller clusters may fit 1-2 per session.
+
+**For next session (Stage 1 Session 63 = Americas cluster).**
+
+- Branch off `main` at this session's PR squash-merge (TBD until PR opens + merges).
+- Populate Americas cluster per §12 framing block — ~22 entries (cluster root + 3 sub-regions + 14 country-specifics including 3 v3-absent `new` candidates + 4 kebab-case drift variants).
+- Dispatch ~5-6 Opus corpus-read agents for high-frequency / ambiguous values: Americas (170 — cluster root; ambiguity question #1 about under-tagging), North American (83), Latin American (77), Caribbean (17), Mexican (38). Optionally one of the `new` candidates (Central American 1, South American 1, Southern United States 1) if curriculum team wants verification before canonicalizing.
+- Stop at end of Americas cluster.
+
 ### Session 61 — 2026-05-10 — PR #481 ship cycle complete (round-1 + round-2 + Notes fix-up; squash-merge in progress)
 
 PR #481 (Stage 1 heritage worksheet scaffold) shipped through the standard review cycle:
@@ -103,7 +155,7 @@ PR #481 (Stage 1 heritage worksheet scaffold) shipped through the standard revie
 - **Round-1:** 5 accepted bot findings (F1 v3 path → Appendix A; F2 `####` heading depth standardized; F3 `null` root parent encoding; F4 Dominican added to Americas; F5 alias_map clarified), 1 rejected (F6 TOC §1-§8 note — defensible design). Includes the v3 baseline embedded as Appendix A — worksheet now self-contained for curriculum-team handoff. (`0c2e138`)
 - **Pre-push agent post-round-1** caught one F2-sweep miss in §5.2 prose (`### <cluster>...` left as 3-hash); separate fix-up commit. (`a5b584b`)
 - **Round-2:** 1 accepted (R2.2 Notes-field parsing convention clarified in §7), 3 rejected per round-cap + default-reject hardening (R2.1 diaspora placeholder; R2.3 data snapshot anchor; R2.4 ToC §1-§8 read-linearly note). (`b5c0020`)
-- **PR #481 squash-merge in progress** (commit hash TBD — backfill at start of Session 62).
+- **PR #481 squash-merged 2026-05-10 as `e05556a`** (backfilled Session 62).
 
 **Worksheet state at ship.** Header sections complete (§1 purpose, §2 hierarchy rules, §3 verdict vocab, §4 per-entry shape, §5 cluster framing pattern, §6 filter-UI tier conventions, §7 parsing convention). Cluster framing blocks pre-populated with Session 59 corpus distribution. Cross-cluster section §9.1-§9.4 stubbed. Cluster template §10. Cluster sections §11-§15 framing complete; per-value entries deliberately TBD. End-summary canonical-vocab table §16 templated empty. Appendix A v3 baseline reference embedded. **Per-value entries are the next track of work.**
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -556,7 +556,7 @@ The following block is a **template** showing the shape of a cluster section. Pe
 - **verdict:** `<to_fill>`
 - **aliases:** `[]`
 
-<details><summary>Corpus evidence (5 active lessons; 3 with country tag, 2 without)</summary>
+<details><summary>Corpus evidence (5 active lessons — 4 SE-Asian cuisine + 1 non-cuisine near-miss; 2 of the 4 cuisine lessons carry an SE-Asian country tag, 2 don't)</summary>
 
 - **`1pjRERorBS4k4iil9VRgiRzjDHZtunwn3v-NFt7xTuwQ` — "Mushroom Khao Soi":** "Students will make khao soi, a dish from Thailand, Myanmar, and Laos... we are continuing this month to explore recipes that come from Asia and the Pacific Islands, as a way of celebrating AAPI Heritage Month. Show a map and point out Thailand, Myanmar, and Laos." (Tagged `Southeast Asian + Asian` only — no country tag despite explicit Thai/Lao/Burmese framing.)
 - **`1vtacAdf80q9FyZ4dEEzWmVLdycRmgJ7_MSRbrweoGwA` — "AAPI Heritage Month - Philippines & Lumpia":** "A lesson focusing on the Philippines... Students will also prepare lumpia, which is a popular Filipino recipe... Because of both its location and history of colonization (especially by Spain), culture and food in the Philippines is a mixture of Asian and Spanish flavors." (Tagged `Southeast Asian + Asian` only — explicitly Filipino but no Filipino country tag.)
@@ -621,7 +621,7 @@ The following block is a **template** showing the shape of a cluster section. Pe
 - **`1d1KP9lfI6jQdF9sBU74ncPv36OZZbTfm` — "Vegetable Ramen":** "Ramen is a Japanese dish (show Japan on Map). The word ramen means 'pulled noodles'. Noodles came from China 4000 years ago... We're going to cook up some ramen noodles today, add them to broth, and top them with fresh vegetables." Toppings include mushrooms, scallions, ginger, mirin-style aromatics; chopsticks listed in materials.
 - **`1R6DqXH9XvSvZq9B0106w0CHtS3kvuJNX53taROiZZBE` — "Daikon Pickles & Furikake":** "The recipes we are creating today are from Japan and Korea. We will be cooking the leaves to make a recipe called..." Lesson uses daikon radish + furikake (a canonical Japanese rice seasoning); CR section explicitly invites students to connect to family heritage and home country.
 
-**Tagging pattern:** Tagging is mostly semantically consistent — 6 of the 7 sampled lessons feature core Japanese dishes/ingredients (sushi, nori, ramen, daikon, furikake, miso) with explicit Japan framing in the lesson body. Two looser tags exist — "Food Preservation" only mentions sushi as one example among many global preservation techniques, and "Spring and Summer Plants" centers Mexican amaranth with mizuna as a secondary tasting. Both feel weaker than the cuisine-focused majority.
+**Tagging pattern:** Tagging is mostly semantically consistent — most sampled lessons feature core Japanese dishes/ingredients (sushi, nori, ramen, daikon, furikake, miso) with explicit Japan framing in the lesson body. Two looser tags exist — "Food Preservation" only mentions sushi as one example among many global preservation techniques, and "Spring and Summer Plants" centers Mexican amaranth with mizuna as a secondary tasting. Both feel weaker than the cuisine-focused majority.
 
 </details>
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -1,6 +1,6 @@
 # Stage 1 Heritage Worksheet
 
-> **Status: SCAFFOLD (Session 60, 2026-05-10).** Header sections (purpose, methodology, hierarchy rules, verdict vocabulary, per-entry shape, cluster framing pattern, filter-UI tier conventions, parsing convention) are complete and load-bearing. Per-cluster framing blocks contain corpus distribution data from the Session 59 query. **Per-value entries are not yet populated** — that work happens in subsequent sessions before curriculum-team handoff. End-summary canonical-vocab table fills only as per-value verdicts close.
+> **Status: PRE-HANDOFF (last update Session 62, 2026-05-10).** Header sections (purpose, methodology, hierarchy rules, verdict vocabulary, per-entry shape, cluster framing pattern, filter-UI tier conventions, parsing convention) are complete and load-bearing. Per-cluster framing blocks contain corpus distribution data from the Session 59 query. **Per-value entries: Asian cluster ✅ Session 62 (§11); Americas onward TBD subsequent sessions before curriculum-team handoff.** End-summary canonical-vocab table fills only as per-value verdicts close.
 >
 > **Owner during scaffold/pre-handoff phase:** project maintainer (Claude + user). **Owner at handoff:** ESYNYC curriculum team.
 >
@@ -55,7 +55,7 @@ Three inputs converge into each verdict:
 ### Worksheet hand-off model
 
 ```
-SCAFFOLD (this session)        PRE-HANDOFF (subsequent sessions)        HANDOFF (curriculum team)
+SCAFFOLD (Session 60)          PRE-HANDOFF (Sessions 62+)               HANDOFF (curriculum team)
        │                                  │                                       │
        ▼                                  ▼                                       ▼
 Header sections written        Per-value entries populated:           Curriculum team fills:
@@ -1011,4 +1011,4 @@ This table serves as the **hand-off artifact** to PR 5+ (D4 vocab canonicalizati
 
 ---
 
-*End of worksheet scaffold (Session 60, 2026-05-10).*
+*End of worksheet (last update Session 62, 2026-05-10 — Asian cluster per-value entries populated).*

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -478,7 +478,310 @@ The following block is a **template** showing the shape of a cluster section. Pe
 
 ### Per-value entries
 
-*(TBD — per-value entry blocks for Asian cluster populated in subsequent session before handoff)*
+#### 11.1. Asian (63)
+
+- **canonical_key:** `asian`
+- **surface_label:** `Asian`
+- **parent:** `null`
+- **filter_ui_tier:** `top`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (63 active lessons; 4 without sub-region/country, 59 with at least one child tag)</summary>
+
+- **`1puemyxDt0Cy3w5acFa9bjZGdfWEsZLs5` — "Tastes Around the World":** Tagged `[Asian, Latin American, Mediterranean]`. A gallery-walk lesson with six country stations spanning continents — "Dominican Republic: tostones and oregano / Japan: green tea and seaweed / Ecuador: pickled onions and cilantro / India: chai and garam masala / Colombia: arepas and dragon fruit / Ethiopia: dates and turmeric." `Asian` carries two distinct countries (Japan + India) inside one comparative lesson.
+- **`1lv-gM8xprEt5t1YVLxvBN8eYI0uabXRN8XETqJVOJZQ` — "5th Grade Food Cultures Unit Overview":** Tagged `[Latin American, Asian, African, European]`. Summary — "Through this series of six lessons students will learn about food cultures from around the world. These lessons will cover the countries Ukraine, Uzbekistan, Mexico, China, and some Caribbean Island nations." `Asian` is the umbrella for both Uzbekistan (Central Asian) and China (East Asian) inside a single curated unit.
+- **`1iTH3kooXMEVDsZaV1wqVGLvgXO3c55lrxtsIHGlaz28` — "India / Aloo Gobi":** Tagged `[Indian, South Asian, Asian]`. Single-country lesson — "Introduce country of India: map, flag, language, food facts / India is a large country in Asia... Indian dishes often have many flavorful spices and seasonings / Introduce recipe: Aloo Gobi." `Asian` here is a redundant ancestor in the 3-level chain Indian → South Asian → Asian, not an independent signal.
+
+**Tagging pattern:** Cohort A (4/63) is genuinely pan-Asian — all four are around-the-world comparison or multi-country curriculum lessons where `Asian` carries 2+ unrelated countries (Japan+India, China+Uzbekistan, etc.) and there is no single sub-region to assign. Cohort B (59/63) uses `Asian` as the redundant root of a Country → Sub-region → `Asian` ancestry chain (e.g., Vietnamese/Southeast Asian/Asian, Japanese/East Asian/Asian, Uzbek/Central Asian/Asian); the `Asian` tag adds no information beyond what the children already encode. No under-tagged Cohort A cases surfaced — when a country is identifiable, the writer tagged the country.
+
+</details>
+
+**Notes:** Cluster root for the Asian cluster. Cohort A's 4 lessons demonstrate `Asian` as a meaningful pan-region tag (not under-tagging) — multi-country comparison and world-foods unit lessons. Cohort B's 59 lessons use `Asian` as redundant hierarchical-parent ancestry; the worksheet's parent-chain shape preserves this without requiring it to carry independent information. Filter-UI tier `top` is the cluster-root default and the corpus signal supports it.
+
+---
+
+#### 11.2. East Asian (35)
+
+- **canonical_key:** `east-asian`
+- **surface_label:** `East Asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (35 active lessons; 9 without a country tag, 26 with at least one)</summary>
+
+- **`16ZNi4Oeu5j4mMOZrEk7OYlrqIhSsqj_f` — "Agar Jelly - MS"** (no-country cohort; tagged `East Asian + Asian` only): Lesson explicitly disclaims country specificity — "We are making a dessert that many people enjoy during the lunar new year. Note: some students may know this holiday as Chinese new year, but it is celebrated in many countries throughout Asia. The main ingredient, agar, comes from seaweed — similar to what we used to make sushi last week." Genuinely pan-East-Asian framing (Lunar New Year as multi-country holiday + agar dessert + cross-reference to Japanese sushi).
+- **`1HPlsYxxlLedPhVzJETkI62iz3JW9q7ytnVMKXAswiHM` — "Rice Paddy Modeling"** (no-country cohort; tagged `East Asian + Asian` only): Body is unambiguously China-specific — "Ask students to tell you what they already know about the ancient Chinese empire. Explain that today is all about one of the foods that first came from Ancient China: rice!" No mention of Japan, Korea, or other East Asian rice cultures — this is a missing-country tag (should also carry `Chinese`).
+- **`1-1T0a4pCECA5e0ek7pcvFoTRa3-piEGwGHKWrsnxtUs` — "Chinese Scrambled Eggs and Soybean Dumplings"** (with-country cohort; tagged `Chinese + East Asian + Asian`): Summary — "Students will learn to make scrambled eggs and vegetable dumplings in the Chinese tradition..." — clean hierarchical chain (country + sub-region + region all present).
+
+**Tagging pattern:** Cohort B (26 lessons) is consistent — each carries one country tag plus `East Asian + Asian` as parent-chain redundancy. Cohort A (9 lessons without a country) is mixed — some are genuinely pan-East-Asian (Agar Jelly explicitly cross-references Chinese/Japanese traditions), but others are clearly missing a country tag (Rice Paddy Modeling is explicitly Chinese in the body; "Ancient China Bingo" is in the title itself). One Cohort A lesson — "Bánh Mì" — is tagged `Vietnamese + East Asian + Asian`, which is a mis-tag (Vietnam is Southeast Asian, not East Asian). Net: `East Asian` legitimately exists as a sub-region for genuine multi-country lessons, but at least 3-4 of the 9 Cohort A rows need a country tag added during re-tagging.
+
+</details>
+
+**Notes:** v3 canonical sub-region. Filter-UI tier `sub` proposed by frequency default (35 lessons; just under the ≥40 `top` threshold). Curriculum team may promote to `top` given near-threshold count and cluster significance. Corpus surfaces one mis-tagged lesson (Bánh Mì should be Southeast Asian, not East Asian) — flag for Stage 2 re-tag fix-up.
+
+---
+
+#### 11.3. South Asian (15)
+
+- **canonical_key:** `south-asian`
+- **surface_label:** `South Asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (15 active lessons; 4 without a country tag, 11 with at least one)</summary>
+
+- **`0BwC8Pf3ZwAXjNnhsOUZNLVRIUE0` — "Aloo Gobi (3rd-5th)":** "Welcome back to your kitchen, everyone! Today we will make an Indian and Pakistani dish called Aloo Gobi... It is a dish made with spices, potatoes, and cauliflower. Aloo is the Hindu word for potato and gobi means cauliflower." (Tagged `[South Asian, Asian]` only — no Indian or Pakistani country tag despite the lesson explicitly naming both.)
+- **`1aqSoaGDAVFvSWjZJeKAEIkHvPdrWKsxq` — "Black Bean Burgers":** "One of the countries mentioned in the article was India. Many people in India are vegetarians... because their religion considers cows a sacred animal... So instead of eating the hamburgers made of meat that you are used to, they eat veggie burgers instead." (Tagged `[North American, South Asian, Americas]` — India-anchored but no Indian country tag.)
+- **`1V7feFPt6bZc0b695g_3Qe_U4AAE-xO5s` — "Sri Lankan Curry":** "This month we are making food from Southeast Asia from a small country called Sri Lanka (show on map). Sri Lanka is close to India and has a lot of influences from other countries that have colonized them in the past (Britain, Portugal, Amsterdam). This is a reason there are now many more countries that eat curry. One of the most important ingredients in our Sri Lankan curry is coconut milk!" (Tagged `[Sri Lankan, South Asian, Asian]`.)
+
+**Tagging pattern:** The 4 no-country `South Asian` lessons are not genuinely pan-South-Asian — they explicitly name India and/or Pakistan in the body and look like missing country tags. The single `Sri Lankan` lesson is substantive (map activity, geography, colonial history, regional curry comparison) and reads as a strong candidate for `Sri Lankan` as a `new` canonical child of `South Asian`.
+
+</details>
+
+**Notes:** v3 canonical sub-region. The Sri Lankan Curry lesson body mis-locates Sri Lanka as "Southeast Asia" (it's geographically South Asia); the tagging itself is correct (`Sri Lankan + South Asian + Asian`). The 4 no-country `South Asian` lessons look like missing-country tags (Aloo Gobi mentions Indian AND Pakistani; Black Bean Burgers anchors on India explicitly) — flag for Stage 2 re-tag.
+
+---
+
+#### 11.4. Southeast Asian (5)
+
+- **canonical_key:** `southeast-asian`
+- **surface_label:** `Southeast Asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (5 active lessons; 3 with country tag, 2 without)</summary>
+
+- **`1pjRERorBS4k4iil9VRgiRzjDHZtunwn3v-NFt7xTuwQ` — "Mushroom Khao Soi":** "Students will make khao soi, a dish from Thailand, Myanmar, and Laos... we are continuing this month to explore recipes that come from Asia and the Pacific Islands, as a way of celebrating AAPI Heritage Month. Show a map and point out Thailand, Myanmar, and Laos." (Tagged `Southeast Asian + Asian` only — no country tag despite explicit Thai/Lao/Burmese framing.)
+- **`1vtacAdf80q9FyZ4dEEzWmVLdycRmgJ7_MSRbrweoGwA` — "AAPI Heritage Month - Philippines & Lumpia":** "A lesson focusing on the Philippines... Students will also prepare lumpia, which is a popular Filipino recipe... Because of both its location and history of colonization (especially by Spain), culture and food in the Philippines is a mixture of Asian and Spanish flavors." (Tagged `Southeast Asian + Asian` only — explicitly Filipino but no Filipino country tag.)
+- **`1xA88OeHAL5csyB1zfUwvQaibMNdryE7c` — "Bats & Banana Pancakes":** "Bananas originated in Southeast Asia, in the jungles of Malaysia, Indonesia or the Philippines where many varieties of wild bananas still grow today." (Tagged `Southeast Asian + Asian + Caribbean + Latin American + Americas` — Southeast Asia surfaces only as an origin-story aside in a bat-pollinator lesson.)
+
+**Tagging pattern:** `Southeast Asian` has a coherent corpus signal — 4 of 5 lessons cook a genuinely SE-Asian dish (Thai/Lao khao soi, Malaysian ABC shaved ice, Filipino lumpia, Vietnamese summer rolls) and frame the region explicitly. The 5th (Bats & Banana Pancakes) is a near-miss using SE Asia only as a banana-origin reference. Country-tag coverage is incomplete — only 2 of the 4 cuisine lessons carry a country tag; Khao Soi and Lumpia should but don't. Implication — keep `Southeast Asian` as a canonical sub-region. The cluster is real and pedagogically used (AAPI Heritage Month framing); collapsing to Asian would lose the deliberate regional grouping. Stage 2 should add missing country tags (Thai/Lao for Khao Soi, Filipino for Lumpia) and re-evaluate whether Bats & Banana Pancakes should drop the SE-Asian tag entirely.
+
+</details>
+
+**Notes:** v3 canonical sub-region. At the ≥5 corpus-read threshold; included. Signal supports keeping the sub-region (4/5 lessons are genuine SE-Asian cuisine with AAPI Heritage Month framing). Country-tag coverage issues noted for Stage 2.
+
+---
+
+#### 11.5. Central Asian (4)
+
+- **canonical_key:** `central-asian`
+- **surface_label:** `Central Asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical sub-region. Below the ≥5 corpus-read threshold; structural call. The single country canonical under Central Asian is `Uzbek` (4 lessons); the sub-region + country combine to 8 lessons of Central Asian content. Filter-UI tier `sub` proposed despite frequency 4 (below the default `sub` threshold of 5) — v3 canonical status and sole-parent-for-Uzbek role support sub-tier. Curriculum team may demote to `internal` if they prefer the strict frequency default.
+
+---
+
+#### 11.6. Chinese (15)
+
+- **canonical_key:** `chinese`
+- **surface_label:** `Chinese`
+- **parent:** `east-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (15 active lessons tagged with `Chinese`)</summary>
+
+- **`1JCT_JOaWRCF_-9M_0P3VVVU_seTz8xcr7VKzkdA8rLk` — "Smashed Cucumber Salad":** "China is the 3rd biggest country in the world... The weather and food also changes in different areas of China. Today we are making a recipe from the Sichuan region, which is near the middle of China." Show students China and the Sichuan region on the map.
+- **`1FUV91GHRSx5T0w2VYJgZlZjqid4vU7-Ic-Hra6rV5Q8` — "Lucky 8 Stir Fry":** "Eight is a lucky number in Chinese culture, especially around Lunar New Year. The word in Chinese for the number 'eight' is the same as the word for 'prosperity'... Today we are going to be making a Chinese dish that has eight vegetables in it..." (bok choy, snow peas, bean sprouts, mushroom).
+- **`1eViPJBz9xeqq8o3U3e3MTaccETv6n2C1Q-w6DhG1E-I` — "3rd Grade Chinese-Style Dumplings":** Soybean dumplings with wonton wrappers, scallion, ginger, garlic, white pepper, rice wine vinegar, sesame oil, soy sauce; steamed in bamboo baskets, eaten with chopsticks. "Today we are traveling to China to make Chinese style dumplings... Play Chinese music as students come into classroom."
+
+**Tagging pattern:** Tagging is semantically consistent — every sampled lesson shows recognizable Chinese-heritage cuisine, ingredients, or cultural framing. The cluster is dumpling/Lunar-New-Year heavy (~7 of 15 — vegetable dumplings, fortune cookies, Lucky 8 stir fry, dumplings-for-LNY), with the remainder being other clearly Chinese dishes (Sichuan smashed cucumber, fried rice, sesame cauliflower, Chinese roasted carrots, scrambled eggs with soybeans, plant-part stir fry) plus one Grace Lin read-aloud ("The Ugly Vegetables") which is China-themed via the author and story content. Regional specificity appears once (Sichuan); otherwise lessons frame China at the country level. No false positives in the sample.
+
+</details>
+
+**Notes:** v3 canonical country, parent = East Asian. Highest-frequency country in the Asian cluster. Clean tagging signal; no candidates for `merge` / `drop`.
+
+---
+
+#### 11.7. Japanese (9)
+
+- **canonical_key:** `japanese`
+- **surface_label:** `Japanese`
+- **parent:** `east-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (9 active lessons tagged with `Japanese`)</summary>
+
+- **`1fR_VcTO7V1OWM7qp2EweRBN9Zl9z1e3N7pQuvZhJO1k` — "Vegetable Sushi":** "Today we are going to make a special recipe from Japan. Can someone come up and point out Japan on a map?... The recipe from today is made with rice, vegetables and rolled up using a seaweed wrap called 'nori'... in Japan, sushi is traditionally made using fish, which is abundant in Japan because it is an island country surrounded by water... learn how to use chopsticks to eat our sushi with!"
+- **`1d1KP9lfI6jQdF9sBU74ncPv36OZZbTfm` — "Vegetable Ramen":** "Ramen is a Japanese dish (show Japan on Map). The word ramen means 'pulled noodles'. Noodles came from China 4000 years ago... We're going to cook up some ramen noodles today, add them to broth, and top them with fresh vegetables." Toppings include mushrooms, scallions, ginger, mirin-style aromatics; chopsticks listed in materials.
+- **`1R6DqXH9XvSvZq9B0106w0CHtS3kvuJNX53taROiZZBE` — "Daikon Pickles & Furikake":** "The recipes we are creating today are from Japan and Korea. We will be cooking the leaves to make a recipe called..." Lesson uses daikon radish + furikake (a canonical Japanese rice seasoning); CR section explicitly invites students to connect to family heritage and home country.
+
+**Tagging pattern:** Tagging is mostly semantically consistent — 6 of the 7 sampled lessons feature core Japanese dishes/ingredients (sushi, nori, ramen, daikon, furikake, miso) with explicit Japan framing in the lesson body. Two looser tags exist — "Food Preservation" only mentions sushi as one example among many global preservation techniques, and "Spring and Summer Plants" centers Mexican amaranth with mizuna as a secondary tasting. Both feel weaker than the cuisine-focused majority.
+
+</details>
+
+**Notes:** v3 canonical country, parent = East Asian. Clean signal for cuisine-focused lessons; two looser tags are not misuse but worth flagging if Stage 2 wants tighter `Japanese` semantics.
+
+---
+
+#### 11.8. Indian (7)
+
+- **canonical_key:** `indian`
+- **surface_label:** `Indian`
+- **parent:** `south-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+<details><summary>Corpus evidence (7 active lessons tagged with `Indian`)</summary>
+
+- **`1gLuwRIEfiYyfqztlMGAEOeAuJI1flmj7` — "Aloo Gobi":** "Explain that today, we are going to make a recipe from Northern India. It is called Aloo Gobi. It uses some flavors and ingredients that you may already know, and some flavors that are new."
+- **`1a4viRwOePhno2u67vPKhHza4Aj-CMpRQ` — "World Religions - Hinduism":** "Those who practice Hinduism believe that cows are a sacred animal, so they don't eat beef. But many hindus don't eat meat at all!... Today we are going to make a vegetarian dish called biryani. Biryani is a rice dish filled with vegetables that is popular in India where a lot of people who practice Hinduism live."
+- **`1jiYzGtxroLR7lpqAWGQTIroLh3Gr13XbcxWhTLDR_Ec` — "Navdanya & The Importance of Seed Saving":** "Explain that today we are going to be learning about a movement called Navdanya that began in India... This lesson encourages learning within the context of culture by providing an example of leadership and resistance in the South Asian community."
+
+**Tagging pattern:** All 7 lessons are unambiguously South-Asian-Indian — 4 Aloo Gobi variants (potato-cauliflower dish from northern India/Pakistan with Hindi vocab and Bollywood music cues), a Hinduism/biryani lesson, a Navdanya seed-sovereignty lesson explicitly framed "South Asian community," and a Food Preservation lesson that references India once for pickle history. No American Indian / Indigenous framing appears anywhere; the Food Preservation tag is the weakest fit (India is one of several cultural examples, not the focus) but not a misuse.
+
+</details>
+
+**Notes:** v3 canonical country, parent = South Asian. No `Indian` / American-Indian ambiguity in the corpus — every sampled lesson is unambiguously South-Asian-Indian. (The cross-cluster section §9.1 separately handles American-Indian / Indigenous canonicals.)
+
+---
+
+#### 11.9. Pakistani (4)
+
+- **canonical_key:** `pakistani`
+- **surface_label:** `Pakistani`
+- **parent:** `south-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country, parent = South Asian. Below the ≥5 corpus-read threshold; structural call. Note — the §11.3 South Asian corpus read surfaced an Aloo Gobi lesson tagged `South Asian` only that explicitly names Pakistani heritage; under-tagging suggests the actual `Pakistani` corpus footprint is larger than 4. Stage 2 re-tag should pick up the missing country tags. Filter-UI tier `sub` proposed despite frequency 4 (below the default sub threshold of 5) — v3 canonical status plus corroborating under-tagged evidence supports sub-tier.
+
+---
+
+#### 11.10. Uzbek (4)
+
+- **canonical_key:** `uzbek`
+- **surface_label:** `Uzbek`
+- **parent:** `central-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country and the only canonical child of Central Asian. Below the ≥5 corpus-read threshold; structural call. Filter-UI tier `sub` proposed despite frequency 4 — sole-child-of-Central-Asian status supports it.
+
+---
+
+#### 11.11. Korean (3)
+
+- **canonical_key:** `korean`
+- **surface_label:** `Korean`
+- **parent:** `east-asian`
+- **filter_ui_tier:** `sub`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country, parent = East Asian. Just at the ≥3-lesson sub-tier bar per §11 cluster decision #2 (pre-handoff proposal — all ≥3 lessons get sub-tier). Below the ≥5 corpus-read threshold; structural call. The §11.7 Japanese corpus read surfaced a lesson tagged with both Japan and Korea (Daikon Pickles & Furikake), so Korean tagging extends beyond the 3 explicit Korean-only rows.
+
+---
+
+#### 11.12. Vietnamese (2)
+
+- **canonical_key:** `vietnamese`
+- **surface_label:** `Vietnamese`
+- **parent:** `southeast-asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country, parent = Southeast Asian. Below the ≥3-lesson sub-tier bar per §11 cluster decision #2 — `internal`-tier proposed (filter-searchable via FTS / embeddings but not surfaced as a clickable filter chip). Curriculum team may promote to `sub` given v3 canonical status. The §11.2 East Asian corpus read surfaced a Bánh Mì lesson mis-tagged as `Vietnamese + East Asian + Asian`; the correct parent chain is `Vietnamese + Southeast Asian + Asian` — flag for Stage 2 fix-up.
+
+---
+
+#### 11.13. Sri Lankan (1)
+
+- **canonical_key:** `sri-lankan`
+- **surface_label:** `Sri Lankan`
+- **parent:** `south-asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** NOT in v3 baseline (Appendix A South Asian lists Indian / Bengali / Pakistani only). 1 corpus lesson, but the §11.3 South Asian corpus read found the single Sri Lankan Curry lesson substantive — map activity, geographic locator, colonial-history context, ingredient specificity around coconut milk. Candidate for `new` verdict if curriculum team agrees; otherwise `merge → south-asian` is the structural alternative. `internal`-tier proposed regardless given the 1-lesson frequency.
+
+---
+
+#### 11.14. Malaysian (1)
+
+- **canonical_key:** `malaysian`
+- **surface_label:** `Malaysian`
+- **parent:** `southeast-asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country, parent = Southeast Asian. 1 corpus lesson. Below the ≥3-lesson sub-tier bar per §11 cluster decision #2 — `internal`-tier proposed. Curriculum team may promote to `sub` given v3 canonical status.
+
+---
+
+#### 11.15. Taiwanese (1)
+
+- **canonical_key:** `taiwanese`
+- **surface_label:** `Taiwanese`
+- **parent:** `east-asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `<to_fill>`
+- **aliases:** `[]`
+
+**Notes:** v3 canonical country, parent = East Asian. 1 corpus lesson. Below the ≥3-lesson sub-tier bar — `internal`-tier proposed. Curriculum team may promote to `sub` given v3 canonical status.
+
+---
+
+#### 11.16. `asian` (drift literal — 1 corpus appearance)
+
+- **canonical_key:** `asian`
+- **surface_label:** `asian`
+- **parent:** `null`
+- **filter_ui_tier:** `internal`
+- **verdict:** `merge`
+- **merge_into:** `asian`
+- **aliases:** `[]`
+
+**Notes:** Kebab-case-lowercase drift literal observed in 1 corpus row. Surfaced explicitly as a `merge` entry for parser-and-reader clarity. The `canonical_key` field matches the merge target's slug (both are kebab-case-lowercase by slug convention applied to the same underlying value — see §7 alias_map identity-shaped entries). This entry contributes `"asian" → "asian"` to the `alias_map` output (literal-to-canonical-key); verdict `merge` excludes it from the canonical vocabulary list.
+
+---
+
+#### 11.17. `east-asian` (drift literal — 2 corpus appearances)
+
+- **canonical_key:** `east-asian`
+- **surface_label:** `east-asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `merge`
+- **merge_into:** `east-asian`
+- **aliases:** `[]`
+
+**Notes:** Kebab-case-lowercase drift literal observed in 2 corpus rows. Same convention as §11.16. Contributes `"east-asian" → "east-asian"` to `alias_map`.
+
+---
+
+#### 11.18. `south-asian` (drift literal — 3 corpus appearances)
+
+- **canonical_key:** `south-asian`
+- **surface_label:** `south-asian`
+- **parent:** `asian`
+- **filter_ui_tier:** `internal`
+- **verdict:** `merge`
+- **merge_into:** `south-asian`
+- **aliases:** `[]`
+
+**Notes:** Kebab-case-lowercase drift literal observed in 3 corpus rows. Same convention as §11.16. Contributes `"south-asian" → "south-asian"` to `alias_map`.
 
 ### Cluster decision summary
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -290,7 +290,7 @@ When the worksheet is filled and ready for hand-off, the next-stage tool parses 
 
 **Skipped entries:** if a `verdict` line is missing or blank, the parser warns but does not fail. Unparsed entries are excluded from the canonical vocabulary output until filled.
 
-**Identity-shaped drift entries:** drift entries (`verdict: merge`) can carry a `canonical_key` value identical to their `merge_into` target's `canonical_key` — e.g., the kebab-case drift `asian` and the canonical `Asian` both have `canonical_key: asian`. Parsers MUST filter on `verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by `canonical_key`, otherwise drift entries silently collide with (or de-duplicate) their canonical sources. Drift entries contribute only to the `alias_map` output; identity entries like `"asian" → "asian"` in `alias_map` are harmless.
+**Identity-shaped drift entries:** drift entries (`verdict: merge`) can carry a `canonical_key` value identical to their `merge_into` target's `canonical_key` — e.g., the kebab-case drift `asian` and the canonical `Asian` both have `canonical_key: asian`. Parsers MUST filter on `verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by `canonical_key`, otherwise drift entries silently collide with (or de-duplicate) their canonical sources. Drift entries contribute only to the `alias_map` output (not to the `canonical` array); identity entries like `"asian" → "asian"` in `alias_map` are harmless.
 
 **Output shape (handed to PR 5+ migration):**
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -290,6 +290,8 @@ When the worksheet is filled and ready for hand-off, the next-stage tool parses 
 
 **Skipped entries:** if a `verdict` line is missing or blank, the parser warns but does not fail. Unparsed entries are excluded from the canonical vocabulary output until filled.
 
+**Identity-shaped drift entries:** drift entries (`verdict: merge`) can carry a `canonical_key` value identical to their `merge_into` target's `canonical_key` — e.g., the kebab-case drift `asian` and the canonical `Asian` both have `canonical_key: asian`. Parsers MUST filter on `verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by `canonical_key`, otherwise drift entries silently collide with (or de-duplicate) their canonical sources. Drift entries contribute only to the `alias_map` output; identity entries like `"asian" → "asian"` in `alias_map` are harmless.
+
 **Output shape (handed to PR 5+ migration):**
 
 ```json


### PR DESCRIPTION
## Summary

- **Worksheet §11 populated:** all 18 per-value entries for the Asian cluster (1 cluster root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift merge records). Each entry has `canonical_key` / `surface_label` / `parent` / `filter_ui_tier` / `aliases` pre-populated; `verdict` left as `<to_fill>` for curriculum-team fill at handoff (except the 3 drift entries, which are structurally `merge`).
- **7 parallel Opus corpus-read agents** produced `<details>` evidence blocks for high-frequency / ambiguous values: Asian (63), East Asian (35), South Asian (15), Southeast Asian (5), Chinese (15), Japanese (9), Indian (7). Lower-frequency entries populated structurally per §4 methodology.
- **PR #481 squash-merge hash (`e05556a`) backfilled** in both foundation-phase + Stage 1 status docs.
- **Audit signal surfaced** for Stage 2 re-tag: Bánh Mì lesson mis-tagged as East-Asian (correct: Southeast Asian); 4 of 15 South Asian lessons missing country tags; 2 of 5 Southeast Asian lessons missing country tags; Sri Lankan Curry lesson body geographically mis-locates Sri Lanka as "Southeast Asia." All flagged in worksheet Notes blocks + status doc Session 62 entry.

## Commits

- `d3dff1f` — Session 62 main work (worksheet entries + status docs + hash backfill)
- `df39f07` — Pre-push fix-up for §11.4 header / §11.7 math (2 P2 findings from pre-push code-reviewer agent)

## Test plan

- [x] Pre-push code-reviewer agent dispatched against `git diff main...HEAD`; 2 P2 findings caught and fix-up'd before push (§11.4 Southeast Asian header reframed to match paragraph; §11.7 Japanese sample-count math rephrased)
- [x] All 18 frequency counts verified against TEST DB on 2026-05-10 — match Session 59 framing block exactly
- [x] All canonical_keys follow kebab-case-lowercase slug convention per §9.4
- [x] Parent references form a valid forest within the Asian cluster (cluster root → `null`; sub-regions → `asian`; country-specifics → `east-asian`/`south-asian`/`southeast-asian`/`central-asian`)
- [x] Headings use `####` (4-hash) depth per Session 61 F2 fix-up
- [x] `**Notes:**` blocks have no leading bullet per §7 R2.2 fix-up
- [x] No type-check / lint impact (docs-only PR)
- [ ] External bot review (CodeRabbit, Claude Review) — will pick up after open
- [ ] Round 1 triage + fix-ups as needed

## Stage 1 progress

Asian cluster ✅. Remaining per-cluster fill schedule: **Americas (~22 entries, next) → African (~9) → European (~9) → Middle Eastern (~6) → cross-cluster diaspora**. Foundation-phase code track (PR 3b / 5 / 6) remains gated on Stage 1 closure + Stage 2 outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)