### PR TITLE
docs(metadata-foundation): structure Stage 1 status tracking

### DIFF
--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md
@@ -2,14 +2,14 @@
 
 **Last updated:** 2026-05-11 (extracted from Stage 1 execution status doc Sessions 62-67 and worksheet §11-§13 Notes blocks).
 
-> **Purpose.** Open audit signals surfaced during Stage 1 per-value fills, structured for Stage 2 corpus re-tag intake. Each entry is sourced from existing documentation (worksheet Notes blocks or status doc session entries). Do not invent new signals here; append from session work as it lands.
+> **Purpose.** Open audit signals surfaced during Stage 1 per-value fills, structured for Stage 2 corpus cleanup / reviewer-validation intake. Covers re-tag actions, body-content review, and reviewer-led judgment calls. Each entry is sourced from existing documentation (worksheet Notes blocks or status doc session entries). Do not invent new signals here; append from session work as it lands.
 >
 > **Status vocabulary.**
 > - `Open` — flagged, not yet addressed
-> - `Resolved` — closed by a Stage 2 re-tag action; record the closing PR or backfill query in the row
+> - `Resolved` — closed by a Stage 2 corpus cleanup, re-tag, or reviewer-validation action; record the closing PR, backfill query, or reviewer decision in the row
 > - `Deferred` — explicitly scoped out; record the reason in the row
 >
-> **Scope.** Stage 1 surfaces audit signals as a byproduct of per-value worksheet fills. Stage 2 (corpus re-tag + reviewer validation flow) is where signals close. This register is the bridge between the two stages.
+> **Scope.** Stage 1 surfaces audit signals as a byproduct of per-value worksheet fills. Stage 2 (corpus cleanup + reviewer-validation flow — including re-tag PRs, body-content reviews, and reviewer judgment) is where signals close. This register is the bridge between the two stages.
 
 ## Open signals
 
@@ -36,7 +36,7 @@
 
 ## Resolved signals
 
-(none yet — first resolutions land with Stage 2 corpus re-tag PRs)
+(none yet — first resolutions land with Stage 2 corpus cleanup, re-tag PRs, or reviewer-validation decisions)
 
 ## Deferred signals
 
@@ -49,7 +49,7 @@ When a session surfaces a new audit signal during a per-value fill or review cyc
 1. Assign an ID using the cluster prefix (`ASI` / `AME` / `AFR` / `EUR` / `ME` / `X` for cross-cluster) + the next available sequence number for that cluster.
 2. Append the row to the Open signals table above.
 3. Cite the source document (worksheet section + Notes line, status doc session entry, or both). Repo-facing evidence only — no private-memory citations (see Source-of-truth rules in the Stage 1 execution status doc).
-4. Do NOT mark `Resolved` until a Stage 2 re-tag PR or backfill query closes the gap; record the closing reference in the row when resolved.
+4. Do NOT mark `Resolved` until a Stage 2 corpus cleanup, re-tag PR, backfill query, or reviewer-validation decision closes the gap; record the closing reference in the row when resolved.
 
 ## See also
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md
@@ -1,0 +1,58 @@
+# Stage 1 Heritage — Audit Signal Register
+
+**Last updated:** 2026-05-11 (extracted from Stage 1 execution status doc Sessions 62-67 and worksheet §11-§13 Notes blocks).
+
+> **Purpose.** Open audit signals surfaced during Stage 1 per-value fills, structured for Stage 2 corpus re-tag intake. Each entry is sourced from existing documentation (worksheet Notes blocks or status doc session entries). Do not invent new signals here; append from session work as it lands.
+>
+> **Status vocabulary.**
+> - `Open` — flagged, not yet addressed
+> - `Resolved` — closed by a Stage 2 re-tag action; record the closing PR or backfill query in the row
+> - `Deferred` — explicitly scoped out; record the reason in the row
+>
+> **Scope.** Stage 1 surfaces audit signals as a byproduct of per-value worksheet fills. Stage 2 (corpus re-tag + reviewer validation flow) is where signals close. This register is the bridge between the two stages.
+
+## Open signals
+
+| ID | Cluster / source | Signal | Evidence already in docs | Stage 2 action | Status |
+|----|------------------|--------|---------------------------|----------------|--------|
+| ASI-01 | Asian §11.2 / §11.12 | Bánh Mì lesson tagged `Vietnamese + East Asian + Asian`; correct parent chain is Southeast Asian | Status doc Session 62 corpus-read; worksheet §11.2 + §11.12 Notes | Re-tag Bánh Mì to Southeast Asian | Open |
+| ASI-02 | Asian §11.3 / §11.9 | 4 of 15 `South Asian` lessons missing country tags (Aloo Gobi → Indian + Pakistani; Black Bean Burgers anchors on India) | Status doc Session 62 corpus-read; worksheet §11.3 + §11.9 Notes | Backfill country tags | Open |
+| ASI-03 | Asian §11.4 | 2 of 5 Southeast Asian lessons missing country tags (Khao Soi → Thai/Lao; Lumpia → Filipino) | Status doc Session 62 corpus-read; worksheet §11.4 Notes | Backfill country tags | Open |
+| ASI-04 | Asian §11.3 / §11.13 | Sri Lankan Curry lesson body geographically mis-locates Sri Lanka as "Southeast Asia" (tagging is correct; body content has factual error) | Status doc Session 62 corpus-read; worksheet §11.3 + §11.13 Notes | Outside Stage 1 scope (body content); flag for curriculum-team body-content review | Open |
+| AME-01 | Americas §12.1 / §12.2 | Inconsistent diaspora-to-North-American pairing (67% AA / 79% Indigenous / 43% Lenape / 60% Native American carry `North American`) | Status doc Session 64 + worksheet §12.1 / §12.2 Notes (TEST DB direct queries) | Decide: backfill `North American` on diaspora lessons (geographic-parent convention) OR leave as-is (identity-tag-anchors-placement convention) — curriculum-team-level call | Open |
+| AME-02 | Americas §12.4 (Puerto Rican) | 4/4 Puerto Rican lessons multi-parent dual-coded as `Caribbean + Latin American` | Worksheet §12.4 Notes; status doc Session 64 | Address multi-parent question at curriculum-team handoff; may surface schema/worksheet `parents:` plural decision | Open |
+| AME-03 | Americas (arepa-related) | `Three Sister Arepas` + `Three Sisters Empanadas` missing country tags (Colombian / Venezuelan dishes tagged only `Latin American + Americas`) | Status doc Session 64 corpus-read | Backfill country tags | Open |
+| AME-04 | Asian-cluster spurious carry into Americas | `Bats & Banana Pancakes`, `Flies & Fruit`, `Descriptive Language`, `Our Garden and Kitchen Community` over-tagged with `Caribbean + Latin American + Americas` (Asian-cluster lesson bodies; minimal Americas content) | Status doc Session 64 corpus-read | Drop spurious Americas-cluster tags | Open |
+| AME-05 | Americas §12.5 (Mexican) | `Monarch Migration` uses `Mexican` for geographic-place tagging rather than cuisine / culture (borderline use of `culturalHeritage`) | Status doc Session 64 corpus-read | Clarify country-tag scope OR re-tag | Open |
+| AME-06 | European §14 + Americas (Empanadas) | `Empanadas` lesson over-tagged with `Spanish + Mediterranean + European` based on a single body sentence about Spanish origins | Status doc Session 64 corpus-read | Drop European cluster tags OR re-anchor on Latin American depending on §9.2 Spanish multi-parent resolution | Open |
+| AFR-01 | African §13.1 / §13.2 (Carver siblings) | Inconsistent Carver content tagging — `In the Garden with Dr. Carver` tags `[African, African American, Americas]` correctly; sibling `Lotion & Agar Soap` K + MS tag `[African, North American]` (missing `African American` despite identical subject) | Status doc Session 66 audit-signals; worksheet §13.1 / §13.2 | Backfill `African American + Americas` on Carver siblings | Open |
+| AFR-02 | African §13.4 East African (Wangari Maathai) | `October Seed Saving` tags `[Kenyan, African]`; sibling `Wangari Maathai 4th/5th` tags only `[African]` despite same source body | Status doc Session 66 audit-signals; worksheet §13.4 / §13.8 | Backfill `Kenyan + East African` on sibling (post-East-African canonicalization) | Open |
+| AFR-03 | African §13.1 (African American cohort) | 7-8 lessons (Juneteenth × 4, BHM cornbread, Newly Freed Americans, BEP Stew, BEP Hummus) tag `West African + North American` but omit `African American` despite content alignment | Status doc Session 66 audit-signals; worksheet §13.1 / §13.2; cross-references §12.2 NA Cohort A finding | Backfill `African American` tag | Open |
+| AFR-04 | African §13.2 (Seed & Date Balls) | Over-tagged `[West African, African, Americas, Asian]` based on single body sentences about Carolina rice + Asian arid-region seed-ball use | Status doc Session 66 audit-signals; worksheet §13.2 | Drop both `West African` and `Asian` (lesson is springtime gardening + a date-ball snack) | Open |
+| AFR-05 | African §13.6 (Egyptian split) | 2 ful medames lessons use different cluster placements — 1 tags `[Egyptian, North African, African]`, 1 tags `[Egyptian, Middle Eastern, African]`. §9.2 pre-handoff = North African primary with Middle Eastern noted at Notes-level | Status doc Sessions 64 + 66 §9.2 multi-parent resolution; worksheet §13.6 Notes | Pick convention + re-tag the non-converging ful medames lesson | Open |
+| AFR-06 | African §13.4 East African (Edmond Albius) | Tags `[African, African American diaspora]` but body identifies Réunion (East African / Indian Ocean French colony) — missing East African sub-region + plausibly mis-labeled `African American diaspora` (Albius was Réunionnais) | Status doc Session 66 audit-signals; worksheet §13.4 | Backfill East African; review `African American diaspora` tag | Open |
+| AFR-07 | African §13.1 (5th Grade Food Cultures Unit Overview) | Heritage-array anomaly — tags `[Latin American, Asian, African, European]` but body keywords don't include any African country (plausible legacy auto-tagging artifact) | Status doc Session 66 audit-signals; worksheet §13.1 (Session 67 round-1 fix-up reframed citation as "plausible legacy auto-tagging artifact; flag for Stage 2 reviewer validation") | Reviewer validation; drop `African` unless 6 daughter lessons surface African content | Open |
+| AFR-08 | African §13.4 East African (sub-region under-tagging) | 0/2 Kenyan + 0/1 Ethiopian lessons currently carry `East African` | Status doc Session 66 audit-signals; worksheet §13.4 Notes | If §13.4 East African canonicalizes as `new`, backfill on all 3 rows | Open |
+
+## Resolved signals
+
+(none yet — first resolutions land with Stage 2 corpus re-tag PRs)
+
+## Deferred signals
+
+(none yet)
+
+## Adding a new signal
+
+When a session surfaces a new audit signal during a per-value fill or review cycle:
+
+1. Assign an ID using the cluster prefix (`ASI` / `AME` / `AFR` / `EUR` / `ME` / `X` for cross-cluster) + the next available sequence number for that cluster.
+2. Append the row to the Open signals table above.
+3. Cite the source document (worksheet section + Notes line, status doc session entry, or both). Repo-facing evidence only — no private-memory citations (see Source-of-truth rules in the Stage 1 execution status doc).
+4. Do NOT mark `Resolved` until a Stage 2 re-tag PR or backfill query closes the gap; record the closing reference in the row when resolved.
+
+## See also
+
+- Worksheet: `2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md`
+- Stage 1 execution status: `2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md`
+- Foundation status: `2026-05-03-metadata-rebuild-foundation-execution-status.md`

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -1,12 +1,82 @@
 # Stage 1 Heritage Worksheet — Execution Status
 
-**Last updated:** 2026-05-11 — Session 67 (PR #484 review cycle: round-1 fix-ups for 4 P3 findings [2-voice MEMORY.md citation + 3 Hermes doc-staleness nits] + round-2 default-reject for Claude's 3 forward-looking suggestions; PR #484 squash-merged 2026-05-11 02:54 UTC as `7894a47`; pre-push agent 0-findings on round-1 fix-up diff; next session = Session 68 European cluster).
+**Last updated:** 2026-05-11 — Stage 1 status-tracking structure added (Current state dashboard + Next session contract + PR closeout checklist + Source-of-truth rules + audit signal register pointer; no cluster-content advance). Prior cluster-content session = Session 67 (PR #484 review cycle: round-1 fix-ups for 4 P3 findings [2-voice MEMORY.md citation + 3 Hermes doc-staleness nits] + round-2 default-reject for Claude's 3 forward-looking suggestions; PR #484 squash-merged 2026-05-11 02:54 UTC as `7894a47`; pre-push agent 0-findings on round-1 fix-up diff; next cluster-content session = Session 68 European cluster).
 
 > **About this file.** Project-internal progress tracker for the Stage 1 heritage worksheet initiative. Peer to (not folded into) the foundation-phase status doc at `2026-05-03-metadata-rebuild-foundation-execution-status.md`. The foundation-phase status doc carries a one-line pointer here.
 >
 > **What lives here:** current state of the worksheet fill, locked design decisions and rationale, session log, next-session pointer.
 >
 > **What does NOT live here:** the worksheet content itself (lives in `2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md`); methodology and conventions intended for curriculum-team handoff (live in the worksheet header).
+
+## Current state dashboard
+
+| Area | Status | PR | Merge commit | Notes / next action |
+|------|--------|-----|---------------|---------------------|
+| Scaffold / §1-§10 | ✅ Shipped | #481 | `e05556a` | Header sections + cluster framing blocks + cross-cluster stubs + cluster template + end-summary table; v3 baseline as Appendix A |
+| Asian §11 | ✅ Shipped | #482 | `d58eb59` | 18 entries (1 root + 4 sub-regions + 10 country-specifics + 3 kebab-case drift); 7 Opus corpus-read `<details>` blocks integrated |
+| Americas §12 | ✅ Shipped | #483 | `fc45a96` | 22 entries (1 root + 3 sub-regions + 10 country-specifics + 3 NEW sub-region candidates + 1 v3-corpus-absent + 4 drift); 6 Opus corpus-read `<details>` blocks integrated |
+| African §13 | ✅ Shipped | #484 | `7894a47` | 10 entries (1 root + 3 sub-regions + 5 country-specifics + 1 drift); §9.2 Egyptian + Moroccan multi-parent resolved to North African primary; 2 Opus corpus-read `<details>` blocks integrated |
+| European §14 | Next session | TBD | TBD | ~12 entries planned (1 root + 2 sub-regions + 6 country-specifics + 3 drift); §9.2 Spanish multi-parent row |
+| Middle Eastern §15 | TBD | TBD | TBD | ~8 entries planned (1 root + 1 sub-region + 4 country-specifics + 2 drift) |
+| Cross-cluster §9 | TBD | TBD | TBD | Per-value entries for diaspora / indigenous identities + remaining §9.2 multi-parent rows (Persian, Israeli, Spanish) |
+| End summary §16 | TBD | TBD | TBD | Populates mechanically from filled per-value entries |
+
+Audit signal register (Stage 2 re-tag intake): `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`. Carries the audit signals surfaced during Stage 1 per-value fills (~18 open as of 2026-05-11). Append new signals there; do not duplicate into per-cluster status-doc narrative.
+
+## Next session contract
+
+Fixed-shape orientation for the next session. Update at PR closeout (see PR closeout checklist below).
+
+- **Session:** Stage 1 Session 68 — European cluster per-value fill
+- **Branch base:** `main` at `7894a47` (PR #484 squash-merge). Branch as `docs/stage1-heritage-european-cluster`.
+- **Primary objective:** Populate worksheet §14 with all European cluster per-value entries (~12 entries: 1 cluster root European 53 + 2 sub-regions [Mediterranean 39, Eastern European 3] + 6 country-specifics [Italian 24, Spanish 5, Ukrainian 3, Greek 2, Russian 1, Irish 2 NEW] + 3 kebab-case drift [`european` 1, `mediterranean` 2, `eastern-european` 1]); add the §9.2 multi-parent entry for Spanish in the cross-cluster section.
+- **Stop point:** End of European cluster (one cluster per session, per Sessions 62 / 64 / 66 stop-point heuristic). Do NOT start Middle Eastern §15.
+- **Expected files to touch:**
+  - `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` — §14 per-value entries, §9.2 Spanish row in cross-cluster section
+  - `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md` — Session 68 log entry; dashboard + contract refresh at PR closeout
+  - `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md` — append any new European-cluster audit signals as `EUR-NN`
+  - `docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md` — Current State header + PRs-SHIPPED list + Branches block on PR merge
+- **First task:** NO PR #484 hash backfill (Session 67 did it directly on main). Start with TEST DB corpus-distribution verification queries against `lessons.metadata.culturalHeritage` for the 12 European values plus any §9.2 Spanish cross-cluster checks.
+- **Must verify:**
+  - `git diff --check` clean
+  - No code / migration / package / Supabase / test file changes (`git diff --name-only origin/main...HEAD | grep -Ev '^docs/'` returns nothing)
+  - §14 framing decisions resolved (Russian/Ukrainian split; Mediterranean filter tier; Polish/French v3-corpus-absent disposition; Irish NEW candidate; Spanish multi-parent)
+  - Pre-push code-reviewer agent dispatched on the docs PR (Sessions 60-66 pattern; sixth-then-seventh consecutive Stage 1 catch)
+- **Do not do:**
+  - Touch source code, migrations, package files, Supabase files, or tests
+  - Pre-decide curriculum-team-facing verdicts (`<to_fill>` stays per §4 spec)
+  - Modify worksheet content outside §14 + the §9.2 Spanish cross-cluster row
+  - Start Middle Eastern §15
+
+## PR closeout checklist
+
+Reusable per-PR ritual for Stage 1 docs PRs. Tick each box as part of the merge cycle so the dashboard, contract, and pointer surfaces stay in sync with `main`.
+
+- [ ] Record PR number and squash commit in the dashboard row for the shipped cluster
+- [ ] Update Current state dashboard row (status `✅ Shipped`, PR number, merge commit, notes summary)
+- [ ] Update `Last updated` line in this doc
+- [ ] Update foundation status doc pointer (Current State header + PRs-SHIPPED list)
+- [ ] Update Branches block in foundation status doc (move branch from "Active" to traceability list)
+- [ ] Update Next session contract for the next cluster (session number, branch base, primary objective, expected files, first task, must verify, do not do)
+- [ ] Append new audit signals to `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`
+- [ ] Search for stale strings and replace:
+  - `squash-merge pending`
+  - `PR #NNN OPEN` for the just-merged PR
+  - `TBD until merge` for the just-merged PR
+  - the previous active branch name
+- [ ] Confirm no code / migration / package / Supabase / test files changed in the closing PR
+
+## Source-of-truth rules
+
+The Stage 1 work is split across multiple files; this block names which surface owns which fact.
+
+- **Worksheet** (`2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md`): curriculum-facing metadata decisions — verdicts, parent recommendations, canonical keys, aliases, corpus evidence, audit signals visible to handoff. The deliverable for curriculum-team review.
+- **Stage 1 execution status doc** (this file): current progress (dashboard), next-session contract, locked project-internal design decisions (Session 59), session log, audit-register pointer.
+- **Foundation status doc** (`2026-05-03-metadata-rebuild-foundation-execution-status.md`): summarizes Stage 1 + carries one-line pointer here. Does NOT carry Stage 1 narrative or per-cluster detail beyond what fits in the Current State header + PRs-SHIPPED list.
+- **Audit signal register** (`2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`): open audit signals queued for Stage 2 re-tag. Append-only during Stage 1; signals resolve in Stage 2.
+- **TEST DB facts** (corpus counts, value distributions, tag pairing rates): verify via the project's read-only TEST DB MCP access pattern (`mcp__supabase-test__execute_sql`). Do not cite agent recall or stale prior queries for new claims.
+- **Agent / private memory:** may guide workflow but must not be cited as repo-facing evidence in worksheet content. Cite a TEST DB query, corpus excerpt, or prior shipped PR's content instead. (See Session 67 round-1 fix-up precedent — bots converged on this finding.)
+- **PR comments**: review evidence, not durable source of truth unless copied into worksheet or status doc.
 
 ## Current state
 
@@ -415,6 +485,7 @@ PR #481 (Stage 1 heritage worksheet scaffold) shipped through the standard revie
 ## Pointers to durable context
 
 - **Worksheet:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` (the deliverable)
+- **Audit signal register:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md` (Stage 2 re-tag intake — open audit signals surfaced during per-value fills)
 - **Foundation-phase status doc:** `docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md` (peer status doc; carries one-line pointer here)
 - **Foundation-phase design doc:** `docs/plans/2026-05-03-metadata-rebuild-foundation-design.md` (§5 has the LLM-tagging methodology that informs per-field Opus-corpus-read approach)
 - **v3 baseline:** Worksheet Appendix A (verbatim §3 Cultural Heritage from `esynyc-taxonomy-schema-v2.md`) — canonical hypothesis going in

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -102,6 +102,8 @@ The Stage 1 work is split across multiple files; this block names which surface 
 
 **For next session (Stage 1 Session 68 = European cluster):**
 
+> See `## Next session contract` near the top of this doc for the structured authoritative summary (session, branch base, primary objective, expected files, first task, must verify, do not do). The numbered list below carries the procedural detail (per-entry breakdown, framing decisions, Opus-dispatch plan).
+
 1. Branch off latest `main` after PR #485 merges. PR #484 squash `7894a47` is the pre-#485 anchor; replace this branch-base note with the PR #485 squash commit during PR #485 closeout. NO PR #484 hash backfill needed in Session 68 — Session 67 did that directly on main (precedent break from Sessions 64/66's "first commit on next session's branch" pattern; user explicitly authorized in Session 67).
 2. Populate European cluster's per-value entries per §14 framing block. Total: **~12 entries**:
    - Cluster root (1): European (53)

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md
@@ -21,14 +21,14 @@
 | Cross-cluster §9 | TBD | TBD | TBD | Per-value entries for diaspora / indigenous identities + remaining §9.2 multi-parent rows (Persian, Israeli, Spanish) |
 | End summary §16 | TBD | TBD | TBD | Populates mechanically from filled per-value entries |
 
-Audit signal register (Stage 2 re-tag intake): `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`. Carries the audit signals surfaced during Stage 1 per-value fills (~18 open as of 2026-05-11). Append new signals there; do not duplicate into per-cluster status-doc narrative.
+Audit signal register (Stage 2 corpus cleanup / reviewer-validation intake): `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`. Carries the audit signals surfaced during Stage 1 per-value fills (~18 open as of 2026-05-11) — covers re-tag actions, body-content review, and reviewer-led judgment calls. Append new signals there; do not duplicate into per-cluster status-doc narrative.
 
 ## Next session contract
 
 Fixed-shape orientation for the next session. Update at PR closeout (see PR closeout checklist below).
 
 - **Session:** Stage 1 Session 68 — European cluster per-value fill
-- **Branch base:** `main` at `7894a47` (PR #484 squash-merge). Branch as `docs/stage1-heritage-european-cluster`.
+- **Branch base:** latest `main` after PR #485 merges. PR #484 squash `7894a47` is the pre-#485 anchor; replace this branch-base note with the PR #485 squash commit during PR #485 closeout. Branch as `docs/stage1-heritage-european-cluster`.
 - **Primary objective:** Populate worksheet §14 with all European cluster per-value entries (~12 entries: 1 cluster root European 53 + 2 sub-regions [Mediterranean 39, Eastern European 3] + 6 country-specifics [Italian 24, Spanish 5, Ukrainian 3, Greek 2, Russian 1, Irish 2 NEW] + 3 kebab-case drift [`european` 1, `mediterranean` 2, `eastern-european` 1]); add the §9.2 multi-parent entry for Spanish in the cross-cluster section.
 - **Stop point:** End of European cluster (one cluster per session, per Sessions 62 / 64 / 66 stop-point heuristic). Do NOT start Middle Eastern §15.
 - **Expected files to touch:**
@@ -58,6 +58,7 @@ Reusable per-PR ritual for Stage 1 docs PRs. Tick each box as part of the merge 
 - [ ] Update foundation status doc pointer (Current State header + PRs-SHIPPED list)
 - [ ] Update Branches block in foundation status doc (move branch from "Active" to traceability list)
 - [ ] Update Next session contract for the next cluster (session number, branch base, primary objective, expected files, first task, must verify, do not do)
+- [ ] For status-tracking / hygiene PRs, update the Next session contract branch base to this PR's squash commit after merge
 - [ ] Append new audit signals to `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`
 - [ ] Search for stale strings and replace:
   - `squash-merge pending`
@@ -73,8 +74,8 @@ The Stage 1 work is split across multiple files; this block names which surface 
 - **Worksheet** (`2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md`): curriculum-facing metadata decisions — verdicts, parent recommendations, canonical keys, aliases, corpus evidence, audit signals visible to handoff. The deliverable for curriculum-team review.
 - **Stage 1 execution status doc** (this file): current progress (dashboard), next-session contract, locked project-internal design decisions (Session 59), session log, audit-register pointer.
 - **Foundation status doc** (`2026-05-03-metadata-rebuild-foundation-execution-status.md`): summarizes Stage 1 + carries one-line pointer here. Does NOT carry Stage 1 narrative or per-cluster detail beyond what fits in the Current State header + PRs-SHIPPED list.
-- **Audit signal register** (`2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`): open audit signals queued for Stage 2 re-tag. Append-only during Stage 1; signals resolve in Stage 2.
-- **TEST DB facts** (corpus counts, value distributions, tag pairing rates): verify via the project's read-only TEST DB MCP access pattern (`mcp__supabase-test__execute_sql`). Do not cite agent recall or stale prior queries for new claims.
+- **Audit signal register** (`2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md`): open audit signals queued for Stage 2 corpus cleanup / reviewer validation (re-tag, body-content review, reviewer-led judgment calls). Append-only during Stage 1; signals resolve in Stage 2.
+- **TEST DB facts** (corpus counts, value distributions, tag pairing rates): verify via an approved read-only TEST DB access path before making new claims. Use the configured Supabase TEST read-only MCP where available, or the project-approved read-only SQL wrapper where configured. Do not cite agent recall or stale prior queries for new claims.
 - **Agent / private memory:** may guide workflow but must not be cited as repo-facing evidence in worksheet content. Cite a TEST DB query, corpus excerpt, or prior shipped PR's content instead. (See Session 67 round-1 fix-up precedent — bots converged on this finding.)
 - **PR comments**: review evidence, not durable source of truth unless copied into worksheet or status doc.
 
@@ -101,7 +102,7 @@ The Stage 1 work is split across multiple files; this block names which surface 
 
 **For next session (Stage 1 Session 68 = European cluster):**
 
-1. Branch off `main` at the PR #484 squash-merge commit (`7894a47`). NO hash backfill needed in Session 68 — Session 67 did the backfill directly on main (precedent break from Sessions 64/66's "first commit on next session's branch" pattern; user explicitly authorized in Session 67).
+1. Branch off latest `main` after PR #485 merges. PR #484 squash `7894a47` is the pre-#485 anchor; replace this branch-base note with the PR #485 squash commit during PR #485 closeout. NO PR #484 hash backfill needed in Session 68 — Session 67 did that directly on main (precedent break from Sessions 64/66's "first commit on next session's branch" pattern; user explicitly authorized in Session 67).
 2. Populate European cluster's per-value entries per §14 framing block. Total: **~12 entries**:
    - Cluster root (1): European (53)
    - Sub-regions (2): Mediterranean (39, v3 — heavier than cluster root), Eastern European (3, v3)
@@ -485,7 +486,7 @@ PR #481 (Stage 1 heritage worksheet scaffold) shipped through the standard revie
 ## Pointers to durable context
 
 - **Worksheet:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` (the deliverable)
-- **Audit signal register:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md` (Stage 2 re-tag intake — open audit signals surfaced during per-value fills)
+- **Audit signal register:** `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md` (Stage 2 corpus cleanup / reviewer-validation intake — open audit signals surfaced during per-value fills)
 - **Foundation-phase status doc:** `docs/plans/2026-05-03-metadata-rebuild-foundation-execution-status.md` (peer status doc; carries one-line pointer here)
 - **Foundation-phase design doc:** `docs/plans/2026-05-03-metadata-rebuild-foundation-design.md` (§5 has the LLM-tagging methodology that informs per-field Opus-corpus-read approach)
 - **v3 baseline:** Worksheet Appendix A (verbatim §3 Cultural Heritage from `esynyc-taxonomy-schema-v2.md`) — canonical hypothesis going in


### PR DESCRIPTION
## Summary

Docs-only status-tracking hygiene for Stage 1 heritage worksheet work. Future Stage 1 sessions can orient quickly without reading long narrative paragraphs.

Adds to `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-execution-status.md`:
- **Current state dashboard** — per-area shipped/PR/commit table (Scaffold + Asian/Americas/African shipped; European next; Middle Eastern / cross-cluster / end-summary TBD)
- **Next session contract** — fixed-shape orientation for Session 68 (European cluster); session, branch base, primary objective, stop point, expected files, first task, must verify, do not do
- **PR closeout checklist** — reusable per-PR ritual
- **Source-of-truth rules** — which file owns which fact (worksheet / status doc / foundation status / audit register / TEST DB / private memory / PR comments)
- Pointer to the new audit signal register

New file: `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-audit-signal-register.md` — populated from existing worksheet Notes blocks and status doc session entries; 18 open signals (4 Asian, 6 Americas, 8 African). Bridges Stage 1 surfacing to Stage 2 re-tag intake.

This PR does **not** advance worksheet content, taxonomy decisions, canonical keys, parent recommendations, verdicts, aliases, counts, or corpus evidence. No code, migrations, package files, Supabase files, or tests touched.

Foundation status doc is intentionally not modified — the existing pointer already directs readers to the Stage 1 status doc, where the new structure now lives.

## Validation

- [x] `git diff --check` clean
- [x] Changed files limited to `docs/plans/` (`git diff --name-only origin/main...HEAD | grep -Ev '^docs/plans/'` returns nothing)
- [x] No code / migration / package / Supabase / test files changed
- [x] No new curriculum-facing taxonomy decisions introduced
- [x] No new `MEMORY.md` / private-memory citations added (remaining mentions are intentional Session 67 historical references in the log + the Last updated line; new Source-of-truth rule references the convention without naming the file)
- [x] Existing session log entries preserved verbatim
- [x] Locked design decisions preserved
- [x] All dashboard / contract facts sourced from existing doc content