### PR TITLE
Stage 1 — §16 end-summary parser-driven regeneration (Session 76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ pids
 coverage/
 *.lcov
 
+# Python bytecode (for scripts/*.py utilities)
+__pycache__/
+*.pyc
+
 # nyc test coverage
 .nyc_output
 

--- a/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+++ b/docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
@@ -2044,105 +2044,105 @@ The following block is a **template** showing the shape of a cluster section. Pe
 
 ## 16. End summary: canonical vocabulary table
 
-**Mechanically regenerated** from parsed per-value entries (§11-§15) and the cross-cluster diaspora cluster (§9.1). Do not hand-edit.
+**Mechanically regenerated** from parsed per-value entries (§11-§15) and the cross-cluster diaspora cluster (§9.1) via `scripts/parse-heritage-worksheet.py`. Do not hand-edit — changes are clobbered on re-parse.
 
 **Row count:** 88 total — Asian §11 (18) + Americas §12 (22) + African §13 (10) + European §14 (14) + Middle Eastern §15 (11) + cross-cluster §9.1 (13).
 
-**Columns:** `canonical_key | surface_label | parent | filter_ui_tier | frequency | aliases | verdict`. Drift entries' `surface_label` is the corpus literal (lowercase kebab-case) while their `canonical_key` matches the merge target's slug per §7 alias_map identity-shaped entries; consumers MUST filter on `verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by `canonical_key` to avoid drift / canonical collision (§7 parser invariant). The `verdict` cell encodes any merge target inline as `merge → <target_canonical_key>`; underlying per-value entries carry the structured `merge_into` field separately (§7 parsing convention).
+**Verdict distribution:** 51 keep + 17 merge + 20 new = 88 (post curriculum-team fill, Session 75 PR #491; regenerated Session 76). **Tier distribution:** 12 top + 19 sub + 57 internal = 88.
 
-**`<to_fill>`** placeholders mirror the per-value entries — they cover §9.1 cross-cluster framing decisions still pending curriculum-team verdict (cluster-root `canonical_key` + `surface_label` per Decision 1; Indigenous `canonical_key` + `surface_label` per Decision 3; per-value `parent` reroute targets dependent on the cluster-root resolution).
+**Columns:** `canonical_key | surface_label | parent | filter_ui_tier | frequency | aliases | verdict`. Drift entries' `surface_label` is the corpus literal (lowercase kebab-case) while their `canonical_key` matches the merge target's slug per §7 alias_map identity-shaped entries; consumers MUST filter on `verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by `canonical_key` to avoid drift / canonical collision (§7 parser invariant). The `verdict` cell encodes any merge target inline as `merge → <target_canonical_key>`; underlying per-value entries carry the structured `merge_into` field separately (§7 parsing convention).
 
 ```
 | canonical_key | surface_label | parent | filter_ui_tier | frequency | aliases | verdict |
 |---|---|---|---|---|---|---|
-| asian | Asian | null | top | 63 | [] | <to_fill> |
-| east-asian | East Asian | asian | sub | 35 | [] | <to_fill> |
-| south-asian | South Asian | asian | sub | 15 | [] | <to_fill> |
-| southeast-asian | Southeast Asian | asian | sub | 5 | [] | <to_fill> |
-| central-asian | Central Asian | asian | sub | 4 | [] | <to_fill> |
-| chinese | Chinese | east-asian | sub | 15 | [] | <to_fill> |
-| japanese | Japanese | east-asian | sub | 9 | [] | <to_fill> |
-| indian | Indian | south-asian | sub | 7 | [] | <to_fill> |
-| pakistani | Pakistani | south-asian | sub | 4 | [] | <to_fill> |
-| uzbek | Uzbek | central-asian | sub | 4 | [] | <to_fill> |
-| korean | Korean | east-asian | sub | 3 | [] | <to_fill> |
-| vietnamese | Vietnamese | southeast-asian | internal | 2 | [] | <to_fill> |
-| sri-lankan | Sri Lankan | south-asian | internal | 1 | [] | <to_fill> |
-| malaysian | Malaysian | southeast-asian | internal | 1 | [] | <to_fill> |
-| taiwanese | Taiwanese | east-asian | internal | 1 | [] | <to_fill> |
+| asian | Asian | null | top | 63 | [] | keep |
+| east-asian | East Asian | asian | sub | 35 | [] | keep |
+| south-asian | South Asian | asian | sub | 15 | [] | keep |
+| southeast-asian | Southeast Asian | asian | sub | 5 | [] | keep |
+| central-asian | Central Asian | asian | sub | 4 | [] | keep |
+| chinese | Chinese | east-asian | sub | 15 | [] | keep |
+| japanese | Japanese | east-asian | sub | 9 | [] | keep |
+| indian | Indian | south-asian | sub | 7 | [] | keep |
+| pakistani | Pakistani | south-asian | sub | 4 | [] | keep |
+| uzbek | Uzbek | central-asian | sub | 4 | [] | keep |
+| korean | Korean | east-asian | sub | 3 | [] | keep |
+| vietnamese | Vietnamese | southeast-asian | internal | 2 | [] | keep |
+| sri-lankan | Sri Lankan | south-asian | internal | 1 | [] | new |
+| malaysian | Malaysian | southeast-asian | internal | 1 | [] | keep |
+| taiwanese | Taiwanese | east-asian | internal | 1 | [] | keep |
 | asian | asian | null | internal | 1 | [] | merge → asian |
 | east-asian | east-asian | asian | internal | 2 | [] | merge → east-asian |
 | south-asian | south-asian | asian | internal | 3 | [] | merge → south-asian |
-| americas | Americas | null | top | 170 | [] | <to_fill> |
-| north-american | North American | americas | top | 83 | [] | <to_fill> |
-| latin-american | Latin American | americas | top | 77 | [] | <to_fill> |
-| caribbean | Caribbean | americas | sub | 17 | [] | <to_fill> |
-| mexican | Mexican | latin-american | sub | 38 | [] | <to_fill> |
-| puerto-rican | Puerto Rican | latin-american | sub | 4 | [] | <to_fill> |
-| salvadoran | Salvadoran | latin-american | internal | 2 | [] | <to_fill> |
-| honduran | Honduran | latin-american | internal | 2 | [] | <to_fill> |
-| cuban | Cuban | caribbean | internal | 2 | [] | <to_fill> |
-| jamaican | Jamaican | caribbean | internal | 2 | [] | <to_fill> |
-| peruvian | Peruvian | latin-american | internal | 2 | [] | <to_fill> |
-| brazilian | Brazilian | latin-american | internal | 1 | [] | <to_fill> |
-| ecuadorian | Ecuadorian | latin-american | internal | 1 | [] | <to_fill> |
-| guyanese | Guyanese | latin-american | internal | 1 | [] | <to_fill> |
-| central-american | Central American | americas | internal | 1 | [] | <to_fill> |
-| south-american | South American | americas | internal | 1 | [] | <to_fill> |
-| southern-united-states | Southern United States | north-american | internal | 1 | [] | <to_fill> |
-| dominican | Dominican | latin-american | internal | 0 | [] | <to_fill> |
+| americas | Americas | null | top | 170 | [] | keep |
+| north-american | North American | americas | top | 83 | [] | keep |
+| latin-american | Latin American | americas | top | 77 | [] | keep |
+| caribbean | Caribbean | americas | sub | 17 | [] | keep |
+| mexican | Mexican | latin-american | sub | 38 | [] | keep |
+| puerto-rican | Puerto Rican | latin-american | sub | 4 | [] | keep |
+| salvadoran | Salvadoran | latin-american | internal | 2 | [] | keep |
+| honduran | Honduran | latin-american | internal | 2 | [] | new |
+| cuban | Cuban | caribbean | internal | 2 | [] | new |
+| jamaican | Jamaican | caribbean | internal | 2 | [] | keep |
+| peruvian | Peruvian | latin-american | internal | 2 | [] | new |
+| brazilian | Brazilian | latin-american | internal | 1 | [] | new |
+| ecuadorian | Ecuadorian | latin-american | internal | 1 | [] | new |
+| guyanese | Guyanese | latin-american | internal | 1 | [] | new |
+| central-american | Central American | americas | internal | 1 | [] | new |
+| south-american | South American | americas | internal | 1 | [] | new |
+| southern-united-states | Southern United States | north-american | internal | 1 | [] | new |
+| dominican | Dominican | latin-american | internal | 0 | [] | keep |
 | americas | americas | null | internal | 1 | [] | merge → americas |
 | north-american | north-american | americas | internal | 13 | [] | merge → north-american |
 | latin-american | latin-american | americas | internal | 4 | [] | merge → latin-american |
 | caribbean | caribbean | americas | internal | 1 | [] | merge → caribbean |
-| african | African | null | top | 41 | [] | <to_fill> |
-| west-african | West African | african | sub | 15 | [] | <to_fill> |
-| north-african | North African | african | sub | 2 | [] | <to_fill> |
-| east-african | East African | african | sub | 1 | [] | <to_fill> |
-| nigerian | Nigerian | west-african | internal | 2 | [] | <to_fill> |
-| egyptian | Egyptian | north-african | internal | 2 | [] | <to_fill> |
-| kenyan | Kenyan | east-african | internal | 2 | [] | <to_fill> |
-| ethiopian | Ethiopian | east-african | internal | 1 | [] | <to_fill> |
-| moroccan | Moroccan | north-african | internal | 1 | [] | <to_fill> |
+| african | African | null | top | 41 | [] | keep |
+| west-african | West African | african | sub | 15 | [] | keep |
+| north-african | North African | african | sub | 2 | [] | new |
+| east-african | East African | african | sub | 1 | [] | new |
+| nigerian | Nigerian | west-african | internal | 2 | [] | keep |
+| egyptian | Egyptian | north-african | internal | 2 | [] | new |
+| kenyan | Kenyan | east-african | internal | 2 | [] | new |
+| ethiopian | Ethiopian | east-african | internal | 1 | [] | keep |
+| moroccan | Moroccan | north-african | internal | 1 | [] | new |
 | african | african | null | internal | 1 | [] | merge → african |
-| european | European | null | top | 53 | [] | <to_fill> |
-| mediterranean | Mediterranean | european | top | 39 | [] | <to_fill> |
-| eastern-european | Eastern European | european | sub | 3 | [] | <to_fill> |
-| italian | Italian | mediterranean | sub | 24 | [] | <to_fill> |
-| spanish | Spanish | mediterranean | internal | 5 | [] | <to_fill> |
-| ukrainian | Ukrainian | eastern-european | internal | 3 | [] | <to_fill> |
-| greek | Greek | mediterranean | internal | 2 | [] | <to_fill> |
-| irish | Irish | european | internal | 2 | [] | <to_fill> |
-| russian | Russian | eastern-european | internal | 1 | [] | <to_fill> |
-| french | French | european | internal | 0 | [] | <to_fill> |
-| polish | Polish | eastern-european | internal | 0 | [] | <to_fill> |
+| european | European | null | top | 53 | [] | keep |
+| mediterranean | Mediterranean | european | top | 39 | [] | keep |
+| eastern-european | Eastern European | european | sub | 3 | [] | keep |
+| italian | Italian | mediterranean | sub | 24 | [] | keep |
+| spanish | Spanish | mediterranean | internal | 5 | [] | keep |
+| ukrainian | Ukrainian | eastern-european | internal | 3 | [] | keep |
+| greek | Greek | mediterranean | internal | 2 | [] | keep |
+| irish | Irish | european | internal | 2 | [] | new |
+| russian | Russian | eastern-european | internal | 1 | [] | keep |
+| french | French | european | internal | 0 | [] | keep |
+| polish | Polish | eastern-european | internal | 0 | [] | keep |
 | european | european | null | internal | 1 | [] | merge → european |
 | mediterranean | mediterranean | european | internal | 2 | [] | merge → mediterranean |
 | eastern-european | eastern-european | european | internal | 1 | [] | merge → eastern-european |
-| middle-eastern | Middle Eastern | null | top | 23 | [] | <to_fill> |
-| levantine | Levantine | middle-eastern | top | 14 | [] | <to_fill> |
-| yemeni | Yemeni | middle-eastern | internal | 3 | [] | <to_fill> |
-| persian | Persian | middle-eastern | internal | 1 | [] | <to_fill> |
-| palestinian | Palestinian | levantine | internal | 1 | [] | <to_fill> |
-| israeli | Israeli | middle-eastern | internal | 1 | [] | <to_fill> |
-| lebanese | Lebanese | levantine | internal | 0 | [] | <to_fill> |
-| syrian | Syrian | levantine | internal | 0 | [] | <to_fill> |
-| jordanian | Jordanian | levantine | internal | 0 | [] | <to_fill> |
+| middle-eastern | Middle Eastern | null | top | 23 | [] | keep |
+| levantine | Levantine | middle-eastern | top | 14 | [] | keep |
+| yemeni | Yemeni | middle-eastern | internal | 3 | [] | new |
+| persian | Persian | middle-eastern | internal | 1 | [] | new |
+| palestinian | Palestinian | levantine | internal | 1 | [] | keep |
+| israeli | Israeli | middle-eastern | internal | 1 | [] | keep |
+| lebanese | Lebanese | levantine | internal | 0 | [] | keep |
+| syrian | Syrian | levantine | internal | 0 | [] | keep |
+| jordanian | Jordanian | levantine | internal | 0 | [] | keep |
 | middle-eastern | middle-eastern | null | internal | 1 | [] | merge → middle-eastern |
 | levantine | levantine | middle-eastern | internal | 2 | [] | merge → levantine |
-| <to_fill> | <to_fill> | null | top | 57 | [] | new |
-| african-american | African American | <to_fill> | top | 24 | ["African American diaspora"] | <to_fill> |
-| african-american-diaspora | African American diaspora | <to_fill> | internal | 2 | ["African American"] | <to_fill> |
-| <to_fill> | <to_fill> | <to_fill> | top | 24 | ["Native American", "Indigenous/Native American", "Indigenous Peoples"] | <to_fill> |
-| native-american | Native American | <to_fill> | internal | 5 | [] | <to_fill> |
-| indigenous-native-american | Indigenous/Native American | <to_fill> | internal | 1 | [] | <to_fill> |
-| indigenous-peoples | Indigenous Peoples | <to_fill> | internal | 1 | [] | merge → indigenous |
-| lenape | Lenape | <to_fill> | sub | 7 | [] | keep |
-| haudenosaunee | Haudenosaunee | <to_fill> | internal | 3 | [] | new |
-| soul-food | Soul Food | <to_fill> | internal | 0 | [] | <to_fill> |
-| three-sisters-traditions | Three Sisters traditions | <to_fill> | internal | 0 | [] | <to_fill> |
-| black-culinary-history | Black culinary history | <to_fill> | internal | 0 | [] | <to_fill> |
-| cajun-creole | Cajun/Creole | <to_fill> | internal | 0 | [] | <to_fill> |
+| indigenous-and-diaspora | Indigenous and Diaspora | null | top | 57 | [] | new |
+| african-american | African American | indigenous-and-diaspora | top | 24 | ["African American diaspora"] | keep |
+| african-american-diaspora | African American diaspora | indigenous-and-diaspora | internal | 2 | ["African American"] | merge → african-american |
+| indigenous | Indigenous | indigenous-and-diaspora | top | 24 | ["Native American", "Indigenous/Native American", "Indigenous Peoples"] | keep |
+| native-american | Native American | indigenous-and-diaspora | internal | 5 | [] | merge → indigenous |
+| indigenous-native-american | Indigenous/Native American | indigenous-and-diaspora | internal | 1 | [] | merge → indigenous |
+| indigenous-peoples | Indigenous Peoples | indigenous-and-diaspora | internal | 1 | [] | merge → indigenous |
+| lenape | Lenape | indigenous | sub | 7 | [] | keep |
+| haudenosaunee | Haudenosaunee | indigenous | internal | 3 | [] | new |
+| soul-food | Soul Food | african-american | internal | 0 | [] | keep |
+| three-sisters-traditions | Three Sisters traditions | indigenous | internal | 0 | [] | keep |
+| black-culinary-history | Black culinary history | african-american | internal | 0 | [] | keep |
+| cajun-creole | Cajun/Creole | indigenous-and-diaspora | internal | 0 | [] | keep |
 ```
 
 This table serves as the **hand-off artifact** to PR 5+ (D4 vocab canonicalization migration) and PR 6+ (Stage 2 re-tag prompt closed-vocab constraint).

--- a/scripts/parse-heritage-worksheet.py
+++ b/scripts/parse-heritage-worksheet.py
@@ -100,7 +100,7 @@ def strip_backticks(text: str) -> str:
     return text
 
 
-def parse_value(field_name: str, raw: str) -> object:
+def parse_value(field_name: str, raw: str) -> str | None | list[str]:
     cleaned = strip_inline_comments(raw)
     if field_name == "aliases":
         # Aliases are always backtick-wrapped JSON arrays per §4 convention.
@@ -148,7 +148,7 @@ def extract_frequency(heading_rest: str) -> int:
 
 def parse_worksheet(path: Path) -> list[Entry]:
     entries: list[Entry] = []
-    lines = path.read_text().splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
 
     current: Entry | None = None
     for lineno, line in enumerate(lines, start=1):
@@ -272,14 +272,25 @@ def render_table(entries: list[Entry]) -> str:
 
 
 def verify_invariants(entries: list[Entry]) -> list[str]:
-    """Return a list of human-readable invariant-violation messages (empty if clean)."""
+    """Return a list of human-readable invariant-violation messages (empty if clean).
+
+    Expected per-cluster, tier, and verdict distributions are calibrated to the
+    Session 75 / PR #491 curriculum-team-fill state of the worksheet (88 rows).
+    Update the expected_* dicts here when the worksheet evolves (new entries,
+    verdict reclassifications, tier promotions).
+    """
     problems: list[str] = []
+
+    expected_counts = {"11": 18, "12": 22, "13": 10, "14": 14, "15": 11, "9.1": 13}
+    expected_tier_distribution = {"top": 12, "sub": 19, "internal": 57}
+    expected_verdict_distribution = {"keep": 51, "merge": 17, "new": 20}
+    allowed_tiers = set(expected_tier_distribution)
+    allowed_verdicts = set(expected_verdict_distribution) | {"<to_fill>"}
 
     by_cluster: dict[str, list[Entry]] = {}
     for entry in entries:
         by_cluster.setdefault(entry.cluster, []).append(entry)
 
-    expected_counts = {"11": 18, "12": 22, "13": 10, "14": 14, "15": 11, "9.1": 13}
     for cluster, expected in expected_counts.items():
         actual = len(by_cluster.get(cluster, []))
         if actual != expected:
@@ -290,14 +301,43 @@ def verify_invariants(entries: list[Entry]) -> list[str]:
     if len(entries) != 88:
         problems.append(f"total entries: expected 88, found {len(entries)}")
 
-    counts = {"keep": 0, "merge": 0, "new": 0, "drop": 0, "split": 0, "<to_fill>": 0}
+    tier_counts: dict[str, int] = {}
+    verdict_counts: dict[str, int] = {}
     for entry in entries:
-        v = entry.verdict or "<to_fill>"
-        counts[v] = counts.get(v, 0) + 1
-    if counts.get("<to_fill>", 0) != 0:
+        tier = entry.filter_ui_tier or "<to_fill>"
+        tier_counts[tier] = tier_counts.get(tier, 0) + 1
+        if tier not in allowed_tiers:
+            problems.append(
+                f"{entry.cluster}.{entry.idx}: unknown filter_ui_tier {tier!r}"
+                f" (allowed: {sorted(allowed_tiers)})"
+            )
+
+        verdict = entry.verdict or "<to_fill>"
+        verdict_counts[verdict] = verdict_counts.get(verdict, 0) + 1
+        if verdict not in allowed_verdicts:
+            problems.append(
+                f"{entry.cluster}.{entry.idx}: unknown verdict {verdict!r}"
+                f" (allowed: {sorted(allowed_verdicts)})"
+            )
+
+    if verdict_counts.get("<to_fill>", 0) != 0:
         problems.append(
-            f"verdict <to_fill>: expected 0 unfilled cells, found {counts['<to_fill>']}"
+            f"verdict <to_fill>: expected 0 unfilled cells, found {verdict_counts['<to_fill>']}"
         )
+
+    for tier, expected in expected_tier_distribution.items():
+        actual = tier_counts.get(tier, 0)
+        if actual != expected:
+            problems.append(
+                f"tier {tier!r}: expected {expected} entries, found {actual}"
+            )
+
+    for verdict, expected in expected_verdict_distribution.items():
+        actual = verdict_counts.get(verdict, 0)
+        if actual != expected:
+            problems.append(
+                f"verdict {verdict!r}: expected {expected} entries, found {actual}"
+            )
 
     # Drift-entry §7 alias_map identity invariant: a merge entry's canonical_key
     # equals its merge_into target's canonical_key (drift literals only).
@@ -366,7 +406,13 @@ def main() -> int:
     table = render_table(entries)
 
     if args.apply:
-        content = args.worksheet.read_text()
+        if problems:
+            print(
+                "error: refusing to apply with invariant failures (see above).",
+                file=sys.stderr,
+            )
+            return 1
+        content = args.worksheet.read_text(encoding="utf-8")
         # The §16 table block lives between the introductory ``` fence and the
         # closing ``` fence. Replace only the fenced block to preserve preamble
         # and trailing prose.
@@ -383,7 +429,7 @@ def main() -> int:
             return 2
         replacement = match.group(1) + table + match.group(3)
         new_content = content[: match.start()] + replacement + content[match.end():]
-        args.worksheet.write_text(new_content)
+        args.worksheet.write_text(new_content, encoding="utf-8")
         print(f"Replaced §16 table in {args.worksheet}", file=sys.stderr)
     else:
         print(table)

--- a/scripts/parse-heritage-worksheet.py
+++ b/scripts/parse-heritage-worksheet.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Parse the Stage 1 heritage worksheet's per-value entries and emit the §16
+end-summary canonical-vocabulary table.
+
+Input:  docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md
+Output: 88-row 7-column markdown table (stdout by default), or in-place
+        replacement of the §16 table block (with --apply).
+
+Section selection: §11.X (Asian), §12.X (Americas), §13.X (African),
+§14.X (European), §15.X (Middle Eastern), §9.1.X (Cross-cluster Diaspora &
+Indigenous). The §4 entry-shape template and §10 cluster template are skipped.
+
+Per-value entry shape: a `####`-heading section followed by labeled-line
+bullets `- **<field>:** <value>`. Inline HTML comments are tolerated and
+stripped per §7. Drift entries (verdict `merge`) carry a `canonical_key`
+identical to their `merge_into` target per the §7 alias_map identity-shaped-
+entries invariant.
+
+Frequency comes from the section header parenthetical; multiple shapes are
+supported:
+  - "Asian (63)"                                        → 63
+  - "`asian` (drift literal — 1 corpus appearance)"     → 1
+  - "Indigenous/Native American (1, v3 canonical ...)"  → 1
+  - "Diaspora & Indigenous (cluster root — NEW canonical, 57 distinct ...)"
+                                                        → 57
+
+Output column order: canonical_key | surface_label | parent | filter_ui_tier
+| frequency | aliases | verdict. The verdict cell encodes merge targets inline
+as `merge → <target_canonical_key>`; consumers MUST filter on
+`verdict in ('keep', 'new')` BEFORE keying canonical vocabulary by
+`canonical_key` to avoid drift/canonical collision (§7 parser invariant).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WORKSHEET = (
+    REPO_ROOT
+    / "docs"
+    / "plans"
+    / "2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md"
+)
+
+# Clusters whose per-value entries feed §16, in §16 emission order.
+TARGET_CLUSTERS = ("11", "12", "13", "14", "15", "9.1")
+
+HEADING_RE = re.compile(
+    r"^####\s+(?P<cluster>\d+(?:\.\d+)?)\.(?P<idx>\d+)\.\s+(?P<rest>.*?)\s*$"
+)
+FIELD_RE = re.compile(r"^-\s+\*\*(?P<field>[a-z_]+):\*\*\s*(?P<value>.*?)\s*$")
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+FIELD_NAMES = {
+    "canonical_key",
+    "surface_label",
+    "parent",
+    "filter_ui_tier",
+    "verdict",
+    "merge_into",
+    "split_into",
+    "drop_to",
+    "aliases",
+}
+
+
+@dataclass
+class Entry:
+    cluster: str
+    idx: int
+    raw_heading: str
+    frequency: int
+    canonical_key: str = ""
+    surface_label: str = ""
+    parent: str | None = None
+    filter_ui_tier: str = ""
+    verdict: str = ""
+    merge_into: str | None = None
+    split_into: str | None = None
+    drop_to: str | None = None
+    aliases: list[str] = field(default_factory=list)
+    source_lineno: int = 0
+
+
+def strip_inline_comments(text: str) -> str:
+    return HTML_COMMENT_RE.sub("", text).strip()
+
+
+def strip_backticks(text: str) -> str:
+    text = text.strip()
+    if text.startswith("`") and text.endswith("`") and len(text) >= 2:
+        return text[1:-1]
+    return text
+
+
+def parse_value(field_name: str, raw: str) -> object:
+    cleaned = strip_inline_comments(raw)
+    if field_name == "aliases":
+        # Aliases are always backtick-wrapped JSON arrays per §4 convention.
+        cleaned = strip_backticks(cleaned)
+        if not cleaned:
+            return []
+        try:
+            value = json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"aliases is not valid JSON: {raw!r}") from exc
+        if not isinstance(value, list):
+            raise ValueError(f"aliases is not a list: {raw!r}")
+        return value
+
+    cleaned = strip_backticks(cleaned)
+    if cleaned == "null":
+        return None
+    return cleaned
+
+
+def extract_frequency(heading_rest: str) -> int:
+    """Pull frequency from the section header parenthetical.
+
+    Supported shapes:
+      "Asian (63)"
+      "`asian` (drift literal — 1 corpus appearance)"
+      "`east-asian` (drift literal — 2 corpus appearances)"
+      "Indigenous/Native American (1, v3 canonical surface label)"
+      "Diaspora & Indigenous (cluster root — NEW canonical, 57 distinct ...)"
+    """
+    drift = re.search(r"drift literal\s*[—–-]\s*(\d+)\s+corpus appearance", heading_rest)
+    if drift:
+        return int(drift.group(1))
+
+    new_cluster = re.search(r"NEW canonical,\s*(\d+)\s+distinct", heading_rest)
+    if new_cluster:
+        return int(new_cluster.group(1))
+
+    paren = re.search(r"\((\d+)(?:[,\s)]|$)", heading_rest)
+    if paren:
+        return int(paren.group(1))
+
+    raise ValueError(f"could not extract frequency from heading: {heading_rest!r}")
+
+
+def parse_worksheet(path: Path) -> list[Entry]:
+    entries: list[Entry] = []
+    lines = path.read_text().splitlines()
+
+    current: Entry | None = None
+    for lineno, line in enumerate(lines, start=1):
+        heading_match = HEADING_RE.match(line)
+        if heading_match:
+            if current is not None:
+                entries.append(current)
+                current = None
+            cluster = heading_match.group("cluster")
+            idx_str = heading_match.group("idx")
+            rest = heading_match.group("rest")
+            if cluster not in TARGET_CLUSTERS:
+                continue
+            # Skip template placeholders that use literal "<cluster>" / "N" tokens.
+            if "<" in rest and "<cluster>" in line:
+                continue
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                continue
+            try:
+                freq = extract_frequency(rest)
+            except ValueError as exc:
+                print(
+                    f"warn: line {lineno}: {exc}", file=sys.stderr
+                )
+                continue
+            current = Entry(
+                cluster=cluster,
+                idx=idx,
+                raw_heading=rest,
+                frequency=freq,
+                source_lineno=lineno,
+            )
+            continue
+
+        if current is None:
+            continue
+
+        field_match = FIELD_RE.match(line)
+        if field_match:
+            field_name = field_match.group("field")
+            if field_name not in FIELD_NAMES:
+                continue
+            try:
+                value = parse_value(field_name, field_match.group("value"))
+            except ValueError as exc:
+                print(
+                    f"warn: line {lineno}: {field_name}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            setattr(current, field_name, value)
+            continue
+
+        if line.strip() == "":
+            continue
+
+        # First non-blank, non-bullet line after a heading closes the entry's
+        # labeled-line block (Notes paragraph, <details> tag, --- separator,
+        # next section heading, etc.). Commit and return to inter-entry mode.
+        entries.append(current)
+        current = None
+
+    if current is not None:
+        entries.append(current)
+
+    return entries
+
+
+def cluster_sort_key(entry: Entry) -> tuple:
+    """Order entries §11 → §12 → §13 → §14 → §15 → §9.1, then by idx."""
+    order = {c: i for i, c in enumerate(TARGET_CLUSTERS)}
+    return (order[entry.cluster], entry.idx)
+
+
+def render_aliases(aliases: list[str]) -> str:
+    if not aliases:
+        return "[]"
+    return json.dumps(aliases, ensure_ascii=False)
+
+
+def render_parent(parent: str | None) -> str:
+    return "null" if parent is None else parent
+
+
+def render_verdict(entry: Entry) -> str:
+    if entry.verdict == "merge":
+        target = entry.merge_into or "<to_fill>"
+        return f"merge → {target}"
+    if entry.verdict == "split":
+        target = entry.split_into or "<to_fill>"
+        return f"split → {target}"
+    if entry.verdict == "drop":
+        target = entry.drop_to or "<to_fill>"
+        return f"drop → {target}"
+    return entry.verdict or "<to_fill>"
+
+
+def render_table(entries: list[Entry]) -> str:
+    header = "| canonical_key | surface_label | parent | filter_ui_tier | frequency | aliases | verdict |"
+    sep = "|---|---|---|---|---|---|---|"
+    rows = [header, sep]
+    for entry in sorted(entries, key=cluster_sort_key):
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    entry.canonical_key or "<to_fill>",
+                    entry.surface_label or "<to_fill>",
+                    render_parent(entry.parent),
+                    entry.filter_ui_tier or "<to_fill>",
+                    str(entry.frequency),
+                    render_aliases(entry.aliases),
+                    render_verdict(entry),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(rows)
+
+
+def verify_invariants(entries: list[Entry]) -> list[str]:
+    """Return a list of human-readable invariant-violation messages (empty if clean)."""
+    problems: list[str] = []
+
+    by_cluster: dict[str, list[Entry]] = {}
+    for entry in entries:
+        by_cluster.setdefault(entry.cluster, []).append(entry)
+
+    expected_counts = {"11": 18, "12": 22, "13": 10, "14": 14, "15": 11, "9.1": 13}
+    for cluster, expected in expected_counts.items():
+        actual = len(by_cluster.get(cluster, []))
+        if actual != expected:
+            problems.append(
+                f"cluster {cluster}: expected {expected} entries, found {actual}"
+            )
+
+    if len(entries) != 88:
+        problems.append(f"total entries: expected 88, found {len(entries)}")
+
+    counts = {"keep": 0, "merge": 0, "new": 0, "drop": 0, "split": 0, "<to_fill>": 0}
+    for entry in entries:
+        v = entry.verdict or "<to_fill>"
+        counts[v] = counts.get(v, 0) + 1
+    if counts.get("<to_fill>", 0) != 0:
+        problems.append(
+            f"verdict <to_fill>: expected 0 unfilled cells, found {counts['<to_fill>']}"
+        )
+
+    # Drift-entry §7 alias_map identity invariant: a merge entry's canonical_key
+    # equals its merge_into target's canonical_key (drift literals only).
+    drift_candidates = [e for e in entries if e.verdict == "merge"]
+    for entry in drift_candidates:
+        if entry.merge_into is None:
+            problems.append(
+                f"{entry.cluster}.{entry.idx}: verdict merge missing merge_into"
+            )
+            continue
+        # Drift entries are surfaced when their surface_label equals the kebab-case
+        # slug (lowercase) — same surface text as the canonical_key. Skip the
+        # check for true merge entries that are NOT drift (e.g., AA-diaspora →
+        # African American), where the canonical_key differs from the merge target.
+        if entry.canonical_key == entry.surface_label and entry.canonical_key != entry.merge_into:
+            problems.append(
+                f"{entry.cluster}.{entry.idx} drift entry: canonical_key {entry.canonical_key!r}"
+                f" ≠ merge_into {entry.merge_into!r} (§7 identity invariant)"
+            )
+
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--worksheet",
+        type=Path,
+        default=DEFAULT_WORKSHEET,
+        help="Path to the heritage worksheet markdown file.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Replace the existing §16 table block in-place (default: print to stdout).",
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Run invariant checks and exit; do not emit a table.",
+    )
+    args = parser.parse_args()
+
+    entries = parse_worksheet(args.worksheet)
+
+    problems = verify_invariants(entries)
+    if problems:
+        for p in problems:
+            print(f"INVARIANT FAILURE: {p}", file=sys.stderr)
+        # Continue to emit the table even with failures so the diff is reviewable.
+
+    if args.verify_only:
+        # Summary distribution
+        dist: dict[str, int] = {}
+        for e in entries:
+            key = "merge" if e.verdict == "merge" else (e.verdict or "<to_fill>")
+            dist[key] = dist.get(key, 0) + 1
+        tiers: dict[str, int] = {}
+        for e in entries:
+            tiers[e.filter_ui_tier] = tiers.get(e.filter_ui_tier, 0) + 1
+        print(f"Total entries: {len(entries)}", file=sys.stderr)
+        print(f"Verdict distribution: {dist}", file=sys.stderr)
+        print(f"Tier distribution: {tiers}", file=sys.stderr)
+        return 1 if problems else 0
+
+    table = render_table(entries)
+
+    if args.apply:
+        content = args.worksheet.read_text()
+        # The §16 table block lives between the introductory ``` fence and the
+        # closing ``` fence. Replace only the fenced block to preserve preamble
+        # and trailing prose.
+        fence_pattern = re.compile(
+            r"(## 16\. End summary: canonical vocabulary table.*?```\n)(.*?)(\n```)",
+            re.DOTALL,
+        )
+        match = fence_pattern.search(content)
+        if not match:
+            print(
+                "error: could not locate the §16 fenced table block to replace.",
+                file=sys.stderr,
+            )
+            return 2
+        replacement = match.group(1) + table + match.group(3)
+        new_content = content[: match.start()] + replacement + content[match.end():]
+        args.worksheet.write_text(new_content)
+        print(f"Replaced §16 table in {args.worksheet}", file=sys.stderr)
+    else:
+        print(table)
+
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/parse-heritage-worksheet.py
+++ b/scripts/parse-heritage-worksheet.py
@@ -51,6 +51,7 @@ DEFAULT_WORKSHEET = (
 
 # Clusters whose per-value entries feed §16, in §16 emission order.
 TARGET_CLUSTERS = ("11", "12", "13", "14", "15", "9.1")
+_CLUSTER_ORDER = {c: i for i, c in enumerate(TARGET_CLUSTERS)}
 
 HEADING_RE = re.compile(
     r"^####\s+(?P<cluster>\d+(?:\.\d+)?)\.(?P<idx>\d+)\.\s+(?P<rest>.*?)\s*$"
@@ -221,8 +222,7 @@ def parse_worksheet(path: Path) -> list[Entry]:
 
 def cluster_sort_key(entry: Entry) -> tuple:
     """Order entries §11 → §12 → §13 → §14 → §15 → §9.1, then by idx."""
-    order = {c: i for i, c in enumerate(TARGET_CLUSTERS)}
-    return (order[entry.cluster], entry.idx)
+    return (_CLUSTER_ORDER[entry.cluster], entry.idx)
 
 
 def render_aliases(aliases: list[str]) -> str:


### PR DESCRIPTION
## Summary

Stage 1 Session 76. Mechanically regenerates the §16 end-summary canonical-vocabulary table in `docs/plans/2026-05-10-metadata-rebuild-stage1-heritage-worksheet.md` from the now-filled per-value entries in §11-§15 + §9.1 (curriculum-team verdicts landed via PR #491, squash `d8af791`).

- Adds `scripts/parse-heritage-worksheet.py` — a reusable Python parser that reads labeled-line per-value entries per §4/§7 conventions and emits the 88-row 7-column markdown table to stdout (or in-place with `--apply`).
- Replaces §16's table block in the worksheet with the parser's output. All 75 previously-`<to_fill>` cells are now filled with real verdicts and slugs from the curriculum-team fill.
- Adds `__pycache__/` and `*.pyc` to `.gitignore` (first Python utility in this repo).

## Verification (must-verify list from Session 76 contract)

| Invariant | Expected | Actual |
|---|---|---|
| Row count | 88 (§11×18 + §12×22 + §13×10 + §14×14 + §15×11 + §9.1×13) | **88** ✓ |
| Verdict distribution | 51 keep + 17 merge + 20 new = 88 | **51 / 17 / 20 = 88** ✓ |
| Tier distribution | 12 top + 19 sub + 57 internal = 88 | **12 / 19 / 57 = 88** ✓ |
| `<to_fill>` verdict cells | 0 | **0** ✓ |
| §7 alias_map drift-canonical identity | every drift entry's `canonical_key == merge_into` | **13/13 drift entries pass** ✓ |

Distribution counts are also reported by the parser via `python3 scripts/parse-heritage-worksheet.py --verify-only`.

## §9.1 decisions reflected (per PR #491 curriculum-team fill)

- **D1** cluster root: `indigenous-and-diaspora` / `Indigenous and Diaspora`
- **D2**: `african-american` keep; `african-american-diaspora` merge → `african-american`
- **D3**: `indigenous` keep with three aliases; `native-american` / `indigenous-native-american` / `indigenous-peoples` all merge → `indigenous`
- **D4**: `lenape` + `haudenosaunee` parented directly under `indigenous`
- **D5**: v3-corpus-absent values (`soul-food`, `three-sisters-traditions`, `black-culinary-history`, `cajun-creole`) kept as `internal`-tier placeholders. `cajun-creole` parents under `indigenous-and-diaspora` per the §9.1.13 inline-comment reconciliation; siblings `soul-food` + `black-culinary-history` parent under `african-american`; `three-sisters-traditions` parents under `indigenous`.

## Out of scope

- Curriculum-team verdict re-litigation. Verdicts are settled by PR #491.
- §16 preamble was lightly updated to drop the now-stale `<to_fill>` placeholder prose and reference the parser. Substantive content (column spec, drift-entry encoding, §7 alias_map invariant) unchanged.
- Status doc dashboard / Last-updated banner / Next session contract / session log updates — these land as a separate closeout-backfill commit direct-to-main post-merge per the established Stage 1 pattern (Sessions 67/68/69/71/73/74/75 precedent).

## Pre-push review

Pre-push Opus code-reviewer agent (feature-dev:code-reviewer) reviewed `git diff main...HEAD`. Verdict: **Round 0 clean** — 0 P1 / 0 P2 / 0 P3 substantive findings. Cross-checks performed: parser correctness (entry boundaries, frequency extraction across 4 header shapes, alias-list parsing, drift-vs-canonical distinction), §16 table accuracy (88 rows × 7 columns, sample rows verified against source per-value entries across all 6 cluster groups + all 13 §9.1 entries), and §7 alias_map drift-canonical identity invariant.

## Test plan

- [x] `python3 scripts/parse-heritage-worksheet.py --verify-only` reports 88 entries with 51 keep + 17 merge + 20 new and 12 top + 19 sub + 57 internal, and exits 0 (no invariant failures).
- [x] `python3 -m py_compile scripts/parse-heritage-worksheet.py` returns OK.
- [x] `git diff --name-only origin/main...HEAD | grep -Ev '^(docs/|scripts/parse-heritage-worksheet\.py|\.gitignore)$'` returns empty (no unexpected file changes).
- [x] Round 0 clean pre-push reviewer agent on the diff.
- [ ] CI checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)