### PR TITLE
Fold 'urban revitalization' concept into Advocacy (PR 5b follow-up)

### DIFF
--- a/data/vocab/academic-concepts.vocab.json
+++ b/data/vocab/academic-concepts.vocab.json
@@ -1,15 +1,18 @@
 {
   "provenance": {
     "source": "docs/plans/2026-06-11-metadata-rebuild-stage1-concepts-worksheet-returned.md",
-    "source_commit": "f3f050f0c1f1d12f2a9e1525957025481374261e",
+    "source_commit": "96df268ca33720d1d630a0bdceef3999f5b76b51",
     "verdict_counts": {
       "drop": 7,
       "keep": 119,
       "merge": 82
     },
-    "emitted": "2026-06-11",
+    "emitted": "2026-06-12",
     "renames": {
       "sorting": "sorting_and_categorization"
+    },
+    "addenda": {
+      "urban revitalization": "advocacy"
     }
   },
   "canonical": [
@@ -1046,6 +1049,7 @@
     "tool use": "tool_use",
     "trade routes": "trade_routes",
     "unit rates": "ratios",
+    "urban revitalization": "advocacy",
     "visual arts": "visual_arts",
     "vocabulary development": "vocabulary_development",
     "volume": "measurement",

--- a/scripts/emit-concepts-vocab.py
+++ b/scripts/emit-concepts-vocab.py
@@ -26,11 +26,17 @@ Mechanism notes (design doc 2026-06-11-…-pr5-canonicalization-design.md §4.1)
   in provenance.
 * alias_map keys are corpus literals, values are canonical keys (worksheet
   §10 contract). Drops are the 7 drop entries' corpus literals.
+* POST_WORKSHEET_ADDENDA: verdicts issued AFTER the worksheet round for
+  literals its census never saw (the census matched TEST; PROD carried rows
+  TEST lacked). Each addendum folds a literal into an existing keep key and
+  is recorded in provenance. The committed 5b migration predates the addenda
+  and is NOT regenerated (pushed history); each addendum ships in its own
+  follow-up migration.
 
 Self-checks (fail loudly, no silent emit): verdict counts 119/82/7; every
 merge_into resolves to a keep key after the rename; alias_map covers exactly
-the 201 non-drop literals; labels unique; appearance sum == 1912; subjects
-restricted to the 6 canonical subject keys.
+the 201 non-drop worksheet literals + the addenda; labels unique; appearance
+sum == 1912; subjects restricted to the 6 canonical subject keys.
 """
 
 from __future__ import annotations
@@ -69,6 +75,19 @@ EXPECTED_TOTAL_APPEARANCES = 1912
 # "Sorting and Categorization" in-file, the KEY rename was deferred to here).
 RENAMES = {"sorting": "sorting_and_categorization"}
 RENAME_EXPECTED_LABELS = {"sorting": "Sorting and Categorization"}
+
+# Post-worksheet verdict addenda: literal → existing keep key. The worksheet
+# census matched TEST, which lacks some PROD rows; literals discovered on
+# PROD afterward get individual verdicts from the verdict authority (the
+# user, acting as curriculum stakeholder) and land here, not in the
+# (read-only) returned worksheet.
+#   urban revitalization → advocacy: verdict 2026-06-12 at the PR 5b PROD
+#   before-census (1 appearance, PROD-only lesson "Seed Bursts"
+#   1NqjpqXV8soDQs2W9HonavtlxQT4MbFI0H7pUdnH-mEI). Precedent: the worksheet
+#   folded `community activism` → advocacy; this lesson is community-garden
+#   activism ("changemakers", "movements to revitalize urban communities").
+#   Applied by migration 20260613000000.
+POST_WORKSHEET_ADDENDA = {"urban revitalization": "advocacy"}
 
 # Appendix A per-subject sections: heading → canonical subject key.
 APPENDIX_SECTION_RE = re.compile(
@@ -291,11 +310,27 @@ def build_artifact(
     expected_alias_entries = EXPECTED_DISTINCT_LITERALS - EXPECTED_VERDICT_COUNTS["drop"]
     if len(alias_map) != expected_alias_entries:
         errors.append(
-            f"alias_map: expected {expected_alias_entries} entries,"
+            f"alias_map: expected {expected_alias_entries} worksheet entries,"
             f" found {len(alias_map)}"
         )
     if len(drops) != EXPECTED_VERDICT_COUNTS["drop"]:
         errors.append(f"drops: expected 7 literals, found {len(drops)}: {drops}")
+
+    # ---- post-worksheet addenda (validated against worksheet-derived state) ----
+    for lit, target in sorted(POST_WORKSHEET_ADDENDA.items()):
+        if lit in alias_map or lit in drops:
+            errors.append(
+                f"addendum {lit!r} collides with a worksheet literal — it"
+                f" belongs in the worksheet round, not the addenda"
+            )
+            continue
+        if target not in keep_keys:
+            errors.append(
+                f"addendum {lit!r}: target {target!r} is not a keep key"
+            )
+            continue
+        alias_map[lit] = target
+
     overlap = set(alias_map) & set(drops)
     if overlap:
         errors.append(f"literals in both alias_map and drops: {sorted(overlap)}")
@@ -312,6 +347,10 @@ def build_artifact(
             "verdict_counts": dict(sorted(verdict_counts.items())),
             "emitted": emit_date,
             "renames": dict(RENAMES),
+            "addenda": {
+                k: POST_WORKSHEET_ADDENDA[k]
+                for k in sorted(POST_WORKSHEET_ADDENDA)
+            },
         },
         "canonical": sorted(canonical, key=lambda c: c["key"]),
         "alias_map": {k: alias_map[k] for k in sorted(alias_map)},

--- a/scripts/generate-concepts-rewrite-migration.py
+++ b/scripts/generate-concepts-rewrite-migration.py
@@ -61,9 +61,18 @@ def sql_quote(value: str) -> str:
 
 
 def build_pairs(artifact: dict) -> tuple[list[tuple[str, str]], list[str], int]:
-    """Return (non-identity alias→label pairs, sorted drop literals, identity count)."""
+    """Return (non-identity alias→label pairs, sorted drop literals, identity count).
+
+    Post-worksheet addenda (artifact provenance.addenda) are EXCLUDED: each
+    addendum ships in its own follow-up migration (e.g. 20260613000000), and
+    excluding them keeps the regenerated SQL BODY identical to the committed
+    20260612000000 PR 5b migration, which predates the addenda. (Only the
+    artifact-provenance header comment lines — source_commit / emitted —
+    move with artifact re-emits.)
+    """
     errors: list[str] = []
     label_by_key = {c["key"]: c["label"] for c in artifact["canonical"]}
+    addenda = artifact.get("provenance", {}).get("addenda", {})
 
     labels = [c["label"] for c in artifact["canonical"]]
     if len(set(labels)) != len(labels):
@@ -84,6 +93,8 @@ def build_pairs(artifact: dict) -> tuple[list[tuple[str, str]], list[str], int]:
     pairs: list[tuple[str, str]] = []
     identity_count = 0
     for literal, target_key in sorted(artifact["alias_map"].items()):
+        if literal in addenda:
+            continue  # ships in its own follow-up migration (see docstring)
         label = label_by_key.get(target_key)
         if label is None:
             errors.append(
@@ -159,9 +170,11 @@ def main() -> int:
         print(f"GENERATOR SELF-CHECK FAILURE:\n{exc}", file=sys.stderr)
         return 1
 
+    addenda_count = len(artifact.get("provenance", {}).get("addenda", {}))
     print(
         f"self-check OK: {len(pairs)} non-identity pairs"
-        f" (identity filtered: {identity_count}); drops: {len(drops)}",
+        f" (identity filtered: {identity_count};"
+        f" addenda excluded: {addenda_count}); drops: {len(drops)}",
         file=sys.stderr,
     )
 

--- a/supabase/migrations/20260613000000_fold_urban_revitalization_concept.sql
+++ b/supabase/migrations/20260613000000_fold_urban_revitalization_concept.sql
@@ -1,0 +1,162 @@
+-- =====================================================
+-- Migration: fold_urban_revitalization_concept
+-- =====================================================
+-- Description: Fold the concept literal 'urban revitalization' into the
+-- canonical label 'Advocacy' (PR 5b follow-up).
+--
+-- Why a follow-up: the Stage 1 concepts worksheet census matched TEST,
+-- which lacks some PROD rows. The PR 5b PROD before-census (2026-06-12)
+-- found this one literal outside the worksheet's 208 — a single appearance
+-- on PROD-only lesson "Seed Bursts"
+-- (1NqjpqXV8soDQs2W9HonavtlxQT4MbFI0H7pUdnH-mEI, Social Studies array).
+-- Verdict issued 2026-06-12 by the verdict authority: fold into `advocacy`,
+-- per the worksheet precedent `community activism` → Advocacy (the lesson
+-- is community-garden activism). Recorded in the vocab artifact's
+-- provenance.addenda (data/vocab/academic-concepts.vocab.json, emitted by
+-- scripts/emit-concepts-vocab.py POST_WORKSHEET_ADDENDA).
+--
+-- Mechanism: same shape as 20260612000000_pr5b_concepts_canonicalization
+-- with a single-pair alias map and no drops. Live rows only
+-- (retired_at IS NULL); per-subject in-place rewrite with first-occurrence
+-- dedupe (if 'Advocacy' is already co-tagged in the same array, the fold
+-- collapses); subject keys otherwise untouched. No drops → no array can
+-- empty → no key/object removal branch needed, but the structure keeps the
+-- 5b NULL-handling for safety. FTS refreshes via
+-- update_lesson_search_vector_trigger (UPDATE OF metadata).
+--
+-- Idempotent: 'Advocacy' is not the alias literal, so re-running matches
+-- zero rows; the snapshot INSERT is ON CONFLICT DO NOTHING (the affected
+-- PROD row is already in pr5b_concepts_rollback with its pre-5b original,
+-- which is the correct restore point).
+--
+-- Expected impact: PROD 1 row / 1 appearance; TEST 0 rows (the lesson is
+-- PROD-only); local 0 rows (seed data carries no such literal).
+
+-- =====================================================
+-- (1) Rollback snapshot — reuses the PR 5b table; no-op for rows already
+--     snapshotted by 20260612000000
+-- =====================================================
+
+INSERT INTO public.pr5b_concepts_rollback (lesson_id, metadata_academicconcepts)
+SELECT l.lesson_id, l.metadata->'academicConcepts'
+FROM public.lessons l
+WHERE l.retired_at IS NULL
+  AND jsonb_typeof(l.metadata->'academicConcepts') = 'object'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_each(l.metadata->'academicConcepts') s(subj, arr)
+    CROSS JOIN LATERAL jsonb_array_elements_text(
+      CASE WHEN jsonb_typeof(s.arr) = 'array' THEN s.arr ELSE '[]'::jsonb END
+    ) v(val)
+    WHERE v.val = 'urban revitalization'
+  )
+ON CONFLICT (lesson_id) DO NOTHING;
+
+-- =====================================================
+-- (2) Rewrite: 'urban revitalization' → 'Advocacy', per-subject dedupe
+-- =====================================================
+
+WITH alias_map(alias, canonical) AS (
+  VALUES
+    ('urban revitalization', 'Advocacy')
+)
+UPDATE public.lessons l
+SET metadata = (
+  SELECT CASE
+           WHEN agg.new_obj IS NULL THEN l.metadata - 'academicConcepts'
+           ELSE jsonb_set(l.metadata, '{academicConcepts}', agg.new_obj)
+         END
+  FROM (
+    SELECT jsonb_object_agg(per_subject.subj, per_subject.new_arr) AS new_obj
+    FROM (
+      SELECT s.subj,
+             CASE
+               WHEN jsonb_typeof(s.arr) <> 'array' THEN s.arr  -- passthrough (none in corpus)
+               ELSE (
+                 SELECT jsonb_agg(mapped.val ORDER BY mapped.first_ord)
+                 FROM (
+                   SELECT COALESCE(m.canonical, u.val) AS val, min(u.ord) AS first_ord
+                   FROM jsonb_array_elements_text(s.arr) WITH ORDINALITY u(val, ord)
+                   LEFT JOIN alias_map m ON m.alias = u.val
+                   GROUP BY COALESCE(m.canonical, u.val)
+                 ) mapped
+               )
+             END AS new_arr
+      FROM jsonb_each(l.metadata->'academicConcepts') s(subj, arr)
+    ) per_subject
+    WHERE per_subject.new_arr IS NOT NULL
+  ) agg
+)
+WHERE l.retired_at IS NULL
+  AND jsonb_typeof(l.metadata->'academicConcepts') = 'object'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_each(l.metadata->'academicConcepts') s(subj, arr)
+    CROSS JOIN LATERAL jsonb_array_elements_text(
+      CASE WHEN jsonb_typeof(s.arr) = 'array' THEN s.arr ELSE '[]'::jsonb END
+    ) v(val)
+    WHERE v.val IN (SELECT alias FROM alias_map)
+  );
+
+-- =====================================================
+-- (3) Post-verify: the literal is gone from live rows; no empty subject
+--     array or empty academicConcepts object was produced
+-- =====================================================
+
+DO $$
+DECLARE
+  v_literal_rows integer;
+  v_empty_array_rows integer;
+  v_empty_object_rows integer;
+BEGIN
+  SELECT count(*) INTO v_literal_rows
+  FROM public.lessons l
+  WHERE l.retired_at IS NULL
+    AND jsonb_typeof(l.metadata->'academicConcepts') = 'object'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_each(l.metadata->'academicConcepts') s(subj, arr)
+      CROSS JOIN LATERAL jsonb_array_elements_text(
+        CASE WHEN jsonb_typeof(s.arr) = 'array' THEN s.arr ELSE '[]'::jsonb END
+      ) v(val)
+      WHERE v.val = 'urban revitalization'
+    );
+
+  SELECT count(*) INTO v_empty_array_rows
+  FROM public.lessons l
+  WHERE l.retired_at IS NULL
+    AND jsonb_typeof(l.metadata->'academicConcepts') = 'object'
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_each(l.metadata->'academicConcepts') s(subj, arr)
+      WHERE s.arr = '[]'::jsonb
+    );
+
+  SELECT count(*) INTO v_empty_object_rows
+  FROM public.lessons l
+  WHERE l.retired_at IS NULL
+    AND l.metadata->'academicConcepts' = '{}'::jsonb;
+
+  IF v_literal_rows > 0 OR v_empty_array_rows > 0 OR v_empty_object_rows > 0 THEN
+    RAISE EXCEPTION
+      'urban revitalization fold failed post-verify: % live rows with the literal, % with empty subject array, % with empty academicConcepts object',
+      v_literal_rows, v_empty_array_rows, v_empty_object_rows;
+  END IF;
+END $$;
+
+-- =====================================================
+-- ROLLBACK (keep as comments)
+-- =====================================================
+-- The affected row's pre-PR-5b original is in pr5b_concepts_rollback
+-- (snapshotted by 20260612000000 on PROD; the INSERT above is a no-op
+-- there). Restoring from it would revert BOTH PR 5b's canonicalization and
+-- this fold for that row:
+--
+-- UPDATE public.lessons l
+-- SET metadata = jsonb_set(l.metadata, '{academicConcepts}', r.metadata_academicconcepts)
+-- FROM public.pr5b_concepts_rollback r
+-- WHERE l.lesson_id = r.lesson_id
+--   AND l.lesson_id = '1NqjpqXV8soDQs2W9HonavtlxQT4MbFI0H7pUdnH-mEI';
+--
+-- To revert ONLY this fold: replace 'Advocacy' with 'urban revitalization'
+-- in the row's Social Studies array (forward migration, hand-written).


### PR DESCRIPTION
## Summary

Settles the one leftover from PR 5b (#505): `urban revitalization`, the single concept literal the Stage 1 worksheet never reviewed (its census matched TEST, which lacks the PROD-only lesson carrying it). Verdict issued 2026-06-12 by the verdict authority: **fold into Advocacy**, per the worksheet's `community activism` → Advocacy precedent (the lesson, "Seed Bursts," is community-garden activism).

- **Emitter** `scripts/emit-concepts-vocab.py` gains `POST_WORKSHEET_ADDENDA` — post-worksheet verdicts validated against worksheet state (target must be a keep key; literal must not collide with worksheet literals/drops) and recorded in `provenance.addenda`. The 5b generator excludes addenda (each ships in its own migration), so the committed 5b migration still regenerates body-identically.
- **Artifact** `data/vocab/academic-concepts.vocab.json` regenerated: 202 aliases (201 worksheet + 1 addendum), byte-stable.
- **Migration** `20260613000000_fold_urban_revitalization_concept.sql` — reuses `pr5b_concepts_rollback` (ON CONFLICT no-op for the already-snapshotted PROD row), single-pair rewrite using the proven 5b jsonb shape (per-subject map + first-occurrence dedup), post-verify DO block. Idempotent.

## Expected impact

- **PROD: 1 row** — Seed Bursts' Social Studies array `["Community Systems", "urban revitalization"]` → `["Community Systems", "Advocacy"]`. Post-apply census: 119 distinct (all canonical), closing the 120th-value gap from #505.
- **TEST: 0 rows** (the lesson is PROD-only) — the migration applies as a structural no-op.
- Zero `src/` changes.

## Verification

Local rehearsal green: plain fold + Advocacy-collision dedup both verified, snapshot preserved, FTS regenerated (`Advocacy` matches, `urban revitalization` doesn't), re-run matches 0 rows, `test:rls` unchanged (2 known pre-existing local failures only). Post-merge: PROD before/after probes via MCP per the PR 5 ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)